### PR TITLE
Clarify OMSB planning/runtime contract and recovery policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation-slice.md
+++ b/.github/ISSUE_TEMPLATE/implementation-slice.md
@@ -1,0 +1,22 @@
+---
+name: Implementation slice
+about: Plan one focused OMSB implementation issue
+---
+
+## Goal
+<!-- What should this issue accomplish? -->
+
+## Scope
+<!-- What is included? What is explicitly out of scope? -->
+
+## SSOT impact
+- Docs/process SSOT impact:
+- Runtime enforcement SSOT impact:
+
+## Verification plan
+- [ ] npm run build
+- [ ] npm test
+- [ ] Focused contract checks (describe)
+
+## Reference notes
+<!-- If this slice references OMC, explain the inspiration boundary clearly. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+## Linked issue / scope
+
+## SSOT check
+- Docs/process SSOT changes:
+- Runtime enforcement SSOT changes:
+
+## Verification evidence
+- [ ] npm run build
+- [ ] npm test
+- [ ] Additional focused checks documented below
+
+## Risks / follow-ups
+
+## Reference policy check
+- [ ] If OMC was referenced, the PR keeps the attribution explicit and does not broaden OMSB scope wholesale.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to OMSB
+
+OMSB uses a deliberate split between planning/process truth and runtime enforcement truth.
+
+## Source-of-truth split
+- **Docs/process SSOT:** `docs/` (Ataraxia-linked project folder)
+- **Runtime enforcement SSOT:** `guideline folder -> omsb.config.json -> .omsb/rules.json`
+
+Do not collapse these two layers. Documentation drives planning and workflow. Hook/runtime behavior still derives from the configured guideline sources and generated artifacts.
+
+## Default delivery flow
+1. Create or refine an issue.
+2. Create a focused branch.
+3. Implement one scoped slice.
+4. Open a PR with verification evidence.
+5. Merge only after review + checks pass.
+
+## Branch naming
+Use short, intent-first branch names such as:
+- `feat/docs-governance-reference-license`
+- `feat/source-hierarchy-lifecycle`
+- `feat/freshness-recovery-contract`
+- `feat/routing-obsidian-boundary`
+- `feat/managed-plugin-settings`
+- `chore/verification-alignment`
+
+## Pull request expectations
+Every PR should include:
+- linked issue or explicit scope statement
+- summary of the behavioral change
+- impact on docs/process SSOT vs runtime SSOT
+- verification evidence (`npm run build`, `npm test`, focused checks, or artifact proof)
+- remaining risks / known gaps
+
+## Reference policy
+`oh-my-claudecode/` is a local read-only reference for learning from skills, hooks, agents, and documentation patterns.
+
+Use it as inspiration and attribution context, not as a reason to broaden OMSB into a general orchestration framework or to copy code/scope wholesale.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 GoBeromsu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ In short:
 
 Generated files help enforcement. They do **not** outrank the guideline docs.
 
+### Planning/process SSOT vs runtime enforcement SSOT
+
+OMSB now uses an explicit split:
+
+- **`docs/`** is the product, planning, and development-process SSOT
+- **`guideline folder -> omsb.config.json -> .omsb/rules.json`** is the runtime enforcement SSOT
+
+That means roadmap, implementation sequencing, and contributor workflow belong in docs/process material, while hook enforcement still derives from the configured guideline sources and generated operational artifacts.
+
 ---
 
 ## How OMSB works
@@ -377,14 +386,11 @@ oh-my-second-brain/
 
 ## Documentation
 
-- [docs/philosophy.md](docs/philosophy.md)
-- [docs/architecture.md](docs/architecture.md)
-- [docs/managed-plugins.md](docs/managed-plugins.md)
-- [docs/demo-guide.md](docs/demo-guide.md)
-- [docs/shot-list.md](docs/shot-list.md)
-- [docs/releasing.md](docs/releasing.md)
-- [docs/demo-vault-template/README.md](docs/demo-vault-template/README.md)
-- [docs/smoke-test.md](docs/smoke-test.md)
+`docs/` in this repository points to the Ataraxia project folder and is treated as the product / planning / development-process SSOT.
+
+- [docs/Oh my second brain.md](docs/Oh%20my%20second%20brain.md)
+- [docs/learn-from-omc.md](docs/learn-from-omc.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ---
 
@@ -394,6 +400,17 @@ oh-my-second-brain/
 npm run build
 npm test
 ```
+
+## Development workflow
+
+The default implementation flow is:
+
+1. create or refine an issue
+2. create a focused branch
+3. open a PR with verification evidence
+4. merge only after build/test checks pass
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the working agreement and PR checklist.
 
 ---
 
@@ -423,6 +440,19 @@ If that matches how you want to run a second-brain vault, OMSB is for you.
 
 ---
 
+## Reference
+
+OMSB is developed with explicit reference to [yeachan-heo/oh-my-claudecode](https://github.com/yeachan-heo/oh-my-claudecode).
+
+We specifically reference OMC for ideas around:
+- Claude Code skill / agent surface design
+- hook lifecycle organization
+- operating-contract style documentation
+
+OMSB remains a narrower, Obsidian-focused harness and does **not** aim to copy OMC's orchestration scope wholesale.
+
+The reference repository is MIT-licensed, and OMSB keeps that attribution explicit in project docs.
+
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/scripts/session-init.mjs
+++ b/scripts/session-init.mjs
@@ -54,30 +54,28 @@ function advisory(message) {
   });
 }
 
-/**
- * Check whether any source file tracked in the manifest is newer than its
- * recorded mtime.
- *
- * @param {{ source_mtimes: Record<string, number> }} manifest
- * @returns {boolean} true if any source is stale
- */
-function hasStaleSource(manifest) {
+function collectStaleSourceDetails(manifest) {
   const mtimes = manifest.source_mtimes;
-  if (!mtimes || typeof mtimes !== 'object') return false;
+  const details = {
+    modified: [],
+    missing: [],
+  };
+
+  if (!mtimes || typeof mtimes !== 'object') return details;
 
   for (const [filePath, recordedMtime] of Object.entries(mtimes)) {
     try {
       const stat = fs.statSync(filePath);
       if (stat.mtimeMs > recordedMtime) {
-        return true;
+        details.modified.push(filePath);
       }
     } catch {
       // File missing — treat as stale
-      if (recordedMtime > 0) return true;
+      if (recordedMtime > 0) details.missing.push(filePath);
     }
   }
 
-  return false;
+  return details;
 }
 
 function collectGuidelineMarkdownFiles(rootDir) {
@@ -143,42 +141,98 @@ function findLikelyGuidelineDirs(startDir) {
   return [...new Set(results)].sort();
 }
 
-function hasGuidelineSnapshotDrift(manifest) {
+function collectGuidelineSnapshotDrift(manifest) {
   const snapshot = manifest?.source_snapshot;
-  if (!snapshot || typeof snapshot !== 'object') return false;
+  if (!snapshot || typeof snapshot !== 'object') {
+    return {
+      missingRoot: false,
+      added: [],
+      removed: [],
+    };
+  }
 
   const rootDir = snapshot.guidelines_root;
-  if (typeof rootDir !== 'string' || rootDir.length === 0) return false;
+  if (typeof rootDir !== 'string' || rootDir.length === 0) {
+    return {
+      missingRoot: false,
+      added: [],
+      removed: [],
+    };
+  }
 
   const currentFiles = collectGuidelineMarkdownFiles(rootDir);
-  if (currentFiles === null) return true;
+  if (currentFiles === null) {
+    return {
+      missingRoot: true,
+      added: [],
+      removed: [],
+    };
+  }
 
   const recorded = Array.isArray(snapshot.discovered_guideline_files)
     ? [...snapshot.discovered_guideline_files].sort()
     : [];
 
-  if (recorded.length !== currentFiles.length) return true;
-  return recorded.some((file, index) => file !== currentFiles[index]);
+  const recordedSet = new Set(recorded);
+  const currentSet = new Set(currentFiles);
+
+  return {
+    missingRoot: false,
+    added: currentFiles.filter((file) => !recordedSet.has(file)),
+    removed: recorded.filter((file) => !currentSet.has(file)),
+  };
 }
 
-function buildRecoveryMessage(manifest, cwd) {
-  const rootDir = manifest?.source_snapshot?.guidelines_root;
-  const missingRoot =
-    typeof rootDir === 'string' &&
-    rootDir.length > 0 &&
-    collectGuidelineMarkdownFiles(rootDir) === null;
+function hasStaleSource(details) {
+  return details.modified.length > 0 || details.missing.length > 0;
+}
 
+function hasGuidelineSnapshotDrift(details) {
+  return details.missingRoot || details.added.length > 0 || details.removed.length > 0;
+}
+
+function summarizePaths(filePaths, cwd, maxItems = 3) {
+  const pretty = filePaths
+    .map((filePath) => path.relative(cwd, filePath) || filePath)
+    .slice(0, maxItems);
+  const suffix = filePaths.length > maxItems ? ` (+${filePaths.length - maxItems} more)` : '';
+  return pretty.join(', ') + suffix;
+}
+
+function buildRecoveryMessage(manifest, cwd, staleDetails, snapshotDrift) {
   const candidates = findLikelyGuidelineDirs(cwd);
   const candidateText =
     candidates.length > 0
       ? ` Likely guideline folders: ${candidates.join(', ')}.`
       : '';
 
-  if (missingRoot) {
+  if (snapshotDrift.missingRoot) {
     return `Configured guideline folder is missing or unreadable.${candidateText} Run /omsb init to confirm or recreate it.`;
   }
 
-  return `OMSB rules may be outdated. Guideline files changed since last init.${candidateText} Run /omsb init to refresh.`;
+  const reasons = [];
+  if (staleDetails.modified.length > 0) {
+    reasons.push(
+      `modified tracked sources: ${summarizePaths(staleDetails.modified, cwd)}`,
+    );
+  }
+  if (staleDetails.missing.length > 0) {
+    reasons.push(
+      `missing tracked sources: ${summarizePaths(staleDetails.missing, cwd)}`,
+    );
+  }
+  if (snapshotDrift.added.length > 0) {
+    reasons.push(`added guideline files: ${snapshotDrift.added.slice(0, 3).join(', ')}`);
+  }
+  if (snapshotDrift.removed.length > 0) {
+    reasons.push(`removed or renamed guideline files: ${snapshotDrift.removed.slice(0, 3).join(', ')}`);
+  }
+
+  const reasonText = reasons.length > 0
+    ? ` Detected ${reasons.join('; ')}.`
+    : ' Guideline files changed since last init.';
+
+  return `OMSB rules may be outdated.${reasonText}${candidateText} Run /omsb init to refresh.`;
 }
 
 async function main() {
@@ -208,9 +262,12 @@ async function main() {
       return;
     }
 
-    if (hasStaleSource(manifest) || hasGuidelineSnapshotDrift(manifest)) {
+    const staleDetails = collectStaleSourceDetails(manifest);
+    const snapshotDrift = collectGuidelineSnapshotDrift(manifest);
+
+    if (hasStaleSource(staleDetails) || hasGuidelineSnapshotDrift(snapshotDrift)) {
       process.stdout.write(
-        advisory(buildRecoveryMessage(manifest, process.cwd()))
+        advisory(buildRecoveryMessage(manifest, process.cwd(), staleDetails, snapshotDrift))
       );
       return;
     }

--- a/src/__tests__/compiler.test.ts
+++ b/src/__tests__/compiler.test.ts
@@ -75,6 +75,14 @@ describe("compileRules", () => {
     assert.equal(manifest.version, 1);
     assert.ok(typeof manifest.generated_at === "string");
     assert.ok(manifest.generated_at.length > 0);
+    assert.deepEqual(manifest.governance, {
+      runtime_enforcement: {
+        docs_are_runtime_authority: false,
+        human_guidelines: "authoritative",
+        config_rules: "tier1-operational-input",
+        rules_manifest: "generated-runtime-artifact",
+      },
+    });
     // generated_at should parse as a valid ISO date
     assert.ok(!isNaN(Date.parse(manifest.generated_at)));
   });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -17,6 +17,11 @@ describe("validateConfig", () => {
     assert.equal(result.version, 1);
     assert.equal(result.vault_path, "/vault");
     assert.equal(result.vault_name, "MyVault");
+    assert.equal(result.governance?.runtime_enforcement.docs_are_runtime_authority, false);
+    assert.equal(
+      result.governance?.runtime_enforcement.human_guidelines,
+      "authoritative",
+    );
     assert.deepEqual(result.rules.raw_paths, ["raw/**"]);
   });
 
@@ -151,6 +156,23 @@ describe("validateConfig", () => {
       },
     };
     assert.throws(() => validateConfig(data), /guidelines\.domains\.terminology/);
+  });
+
+  it("rejects governance that treats docs as runtime authority", () => {
+    const data = {
+      ...MINIMAL_VALID as Record<string, unknown>,
+      governance: {
+        runtime_enforcement: {
+          docs_are_runtime_authority: true,
+          human_guidelines: "authoritative",
+          config_rules: "tier1-operational-input",
+        },
+      },
+    };
+    assert.throws(
+      () => validateConfig(data),
+      /docs_are_runtime_authority/,
+    );
   });
 
   it("throws when root value is not an object", () => {

--- a/src/__tests__/docs-governance.test.ts
+++ b/src/__tests__/docs-governance.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf-8");
+}
+
+describe("docs governance surfaces", () => {
+  it("documents the docs/process SSOT split and OMC reference policy in README", () => {
+    const readme = readRepoFile("README.md");
+
+    assert.match(readme, /Planning\/process SSOT vs runtime enforcement SSOT/);
+    assert.match(readme, /docs\/`.*product, planning, and development-process SSOT/s);
+    assert.match(readme, /guideline folder -> omsb\.config\.json -> \.omsb\/rules\.json/);
+    assert.match(readme, /## Reference/);
+    assert.match(readme, /yeachan-heo\/oh-my-claudecode/);
+  });
+
+  it("captures the issue -> branch -> PR workflow in CONTRIBUTING", () => {
+    const contributing = readRepoFile("CONTRIBUTING.md");
+
+    assert.match(contributing, /## Default delivery flow/);
+    assert.match(contributing, /Create or refine an issue\./);
+    assert.match(contributing, /Create a focused branch\./);
+    assert.match(contributing, /Open a PR with verification evidence\./);
+    assert.match(contributing, /Docs\/process SSOT/);
+    assert.match(contributing, /Runtime enforcement SSOT/);
+  });
+
+  it("ships issue and pull request templates that enforce SSOT and verification checks", () => {
+    const issueTemplate = readRepoFile(".github/ISSUE_TEMPLATE/implementation-slice.md");
+    const prTemplate = readRepoFile(".github/pull_request_template.md");
+
+    assert.match(issueTemplate, /## SSOT impact/);
+    assert.match(issueTemplate, /## Verification plan/);
+    assert.match(prTemplate, /## SSOT check/);
+    assert.match(prTemplate, /## Verification evidence/);
+    assert.match(prTemplate, /Reference policy check/);
+  });
+
+  it("ships an explicit MIT license file", () => {
+    const license = readRepoFile("LICENSE");
+
+    assert.match(license, /^MIT License/m);
+    assert.match(license, /Permission is hereby granted, free of charge/m);
+  });
+});

--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -158,5 +158,12 @@ describe("generateConfig", () => {
       folder: "Folder Guideline.md",
       frontmatter: "Frontmatter Guide.md",
     });
+    assert.deepEqual(written.governance, {
+      runtime_enforcement: {
+        docs_are_runtime_authority: false,
+        human_guidelines: "authoritative",
+        config_rules: "tier1-operational-input",
+      },
+    });
   });
 });

--- a/src/__tests__/session-init.test.ts
+++ b/src/__tests__/session-init.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { compileRules, writeRuleManifest } from "../rules/compiler.js";
+import type { OmsbConfig } from "../rules/types.js";
+
+const createdDirs: string[] = [];
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    const dir = createdDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeVault(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omsb-session-init-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+function makeConfig(vaultPath: string, guidelineRoot = "90. Guidelines"): OmsbConfig {
+  return {
+    version: 1,
+    vault_path: vaultPath,
+    vault_name: "Vault",
+    guidelines: {
+      root: guidelineRoot,
+      files: ["Folder Guideline.md"],
+      required: ["folder"],
+      domains: {
+        folder: "Folder Guideline.md",
+      },
+    },
+    rules: {
+      raw_paths: ["80. References/**"],
+    },
+    enforcement: {
+      raw_boundary: "deny",
+      frontmatter: "advisory",
+      naming: "advisory",
+    },
+    routing: {
+      inbox_fallback: "Inbox",
+    },
+  };
+}
+
+function writeInitializedVault(vaultPath: string, config: OmsbConfig): void {
+  const guidelineDir = path.join(vaultPath, config.guidelines.root);
+  fs.mkdirSync(guidelineDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(guidelineDir, "Folder Guideline.md"),
+    "# Folder Guideline\n",
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(vaultPath, "omsb.config.json"),
+    JSON.stringify(config, null, 2) + "\n",
+    "utf-8",
+  );
+
+  const manifest = compileRules(config, vaultPath);
+  writeRuleManifest(manifest, vaultPath);
+}
+
+function runSessionInit(cwd: string): unknown {
+  const scriptPath = path.resolve(process.cwd(), "scripts/session-init.mjs");
+  const result = spawnSync(process.execPath, [scriptPath], {
+    cwd,
+    input: "",
+    encoding: "utf-8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(result.stdout.length > 0, "expected session-init to emit JSON output");
+  return JSON.parse(result.stdout);
+}
+
+describe("session-init hook", () => {
+  it("stays silent when the initialized vault is fresh", () => {
+    const vaultPath = makeVault();
+    writeInitializedVault(vaultPath, makeConfig(vaultPath));
+
+    const output = runSessionInit(vaultPath) as {
+      continue: boolean;
+      suppressOutput?: boolean;
+    };
+
+    assert.equal(output.continue, true);
+    assert.equal(output.suppressOutput, true);
+  });
+
+  it("reports added guideline files in the recovery message", () => {
+    const vaultPath = makeVault();
+    const config = makeConfig(vaultPath);
+    writeInitializedVault(vaultPath, config);
+
+    fs.writeFileSync(
+      path.join(vaultPath, config.guidelines.root, "Frontmatter Guideline.md"),
+      "# Frontmatter Guideline\n",
+      "utf-8",
+    );
+
+    const output = runSessionInit(vaultPath) as {
+      hookSpecificOutput: { additionalContext: string };
+    };
+
+    assert.match(output.hookSpecificOutput.additionalContext, /added guideline files/i);
+    assert.match(
+      output.hookSpecificOutput.additionalContext,
+      /Frontmatter Guideline\.md/,
+    );
+  });
+
+  it("reports renamed guideline files as removed or missing tracked sources", () => {
+    const vaultPath = makeVault();
+    const config = makeConfig(vaultPath);
+    writeInitializedVault(vaultPath, config);
+
+    fs.renameSync(
+      path.join(vaultPath, config.guidelines.root, "Folder Guideline.md"),
+      path.join(vaultPath, config.guidelines.root, "Folder Rules.md"),
+    );
+
+    const output = runSessionInit(vaultPath) as {
+      hookSpecificOutput: { additionalContext: string };
+    };
+
+    assert.match(output.hookSpecificOutput.additionalContext, /missing tracked sources/i);
+    assert.match(output.hookSpecificOutput.additionalContext, /removed or renamed guideline files/i);
+    assert.match(output.hookSpecificOutput.additionalContext, /Folder Guideline\.md/);
+  });
+
+  it("reports a missing guideline folder and suggests likely candidates", () => {
+    const vaultPath = makeVault();
+    const config = makeConfig(vaultPath, "90. Guidelines");
+    writeInitializedVault(vaultPath, config);
+
+    fs.renameSync(
+      path.join(vaultPath, "90. Guidelines"),
+      path.join(vaultPath, "91. Guidelines"),
+    );
+
+    const output = runSessionInit(vaultPath) as {
+      hookSpecificOutput: { additionalContext: string };
+    };
+
+    assert.match(
+      output.hookSpecificOutput.additionalContext,
+      /Configured guideline folder is missing or unreadable/i,
+    );
+    assert.match(output.hookSpecificOutput.additionalContext, /Likely guideline folders: 91\. Guidelines/i);
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,11 +1,13 @@
 import * as path from "node:path";
 import type {
+  GovernanceConfig,
   GuidelineDomainMap,
   GuidelineRequirement,
   ManagedPluginConfig,
   OmsbConfig,
   RoutingConfig,
 } from "../rules/types.js";
+import { defaultRuntimeEnforcementConfigGovernance } from "../rules/types.js";
 
 const VALID_SEVERITIES = ["block", "deny", "advisory"] as const;
 const VALID_GUIDELINE_REQUIREMENTS = ["folder", "frontmatter"] as const;
@@ -232,6 +234,47 @@ function validateRouting(raw: unknown): RoutingConfig {
   return routing;
 }
 
+function validateGovernance(raw: unknown): GovernanceConfig {
+  const defaults = defaultRuntimeEnforcementConfigGovernance();
+
+  if (raw === undefined) {
+    return {
+      runtime_enforcement: defaults,
+    };
+  }
+
+  if (!isObject(raw)) {
+    throw new Error(`omsb config: "governance" must be an object`);
+  }
+
+  const runtimeEnforcement = raw["runtime_enforcement"];
+  if (!isObject(runtimeEnforcement)) {
+    throw new Error(`omsb config: "governance.runtime_enforcement" must be an object`);
+  }
+
+  if (runtimeEnforcement["docs_are_runtime_authority"] !== false) {
+    throw new Error(
+      `omsb config: "governance.runtime_enforcement.docs_are_runtime_authority" must be false`,
+    );
+  }
+
+  if (runtimeEnforcement["human_guidelines"] !== defaults.human_guidelines) {
+    throw new Error(
+      `omsb config: "governance.runtime_enforcement.human_guidelines" must be "${defaults.human_guidelines}"`,
+    );
+  }
+
+  if (runtimeEnforcement["config_rules"] !== defaults.config_rules) {
+    throw new Error(
+      `omsb config: "governance.runtime_enforcement.config_rules" must be "${defaults.config_rules}"`,
+    );
+  }
+
+  return {
+    runtime_enforcement: defaults,
+  };
+}
+
 function validateManagedPlugins(raw: unknown): ManagedPluginConfig[] {
   if (!Array.isArray(raw)) {
     throw new Error(`omsb config: "managed_plugins" must be an array`);
@@ -317,6 +360,7 @@ export function validateConfig(data: unknown): OmsbConfig {
     version: 1,
     vault_path: assertString(data["vault_path"], "vault_path"),
     vault_name: assertString(data["vault_name"], "vault_name"),
+    governance: validateGovernance(data["governance"]),
     guidelines: validateGuidelines(data["guidelines"]),
     rules: validateRules(data["rules"]),
     enforcement: validateEnforcement(data["enforcement"]),

--- a/src/init/generator.ts
+++ b/src/init/generator.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { OmsbConfig, EnforcementRule, RuleManifest } from "../rules/types.js";
+import { defaultRuntimeEnforcementConfigGovernance } from "../rules/types.js";
 import { validateConfig } from "../config/schema.js";
 import { compileRules, writeRuleManifest, readRuleManifest } from "../rules/compiler.js";
 
@@ -43,6 +44,9 @@ export async function generateConfig(opts: InitOptions): Promise<void> {
     version: 1,
     vault_path: opts.vaultPath,
     vault_name: opts.vaultName,
+    governance: {
+      runtime_enforcement: defaultRuntimeEnforcementConfigGovernance(),
+    },
     guidelines: {
       root: opts.guidelineRoot,
       files: opts.guidelineFiles,
@@ -177,6 +181,12 @@ export async function generateClaudeMd(
       : null,
   ].filter(Boolean);
 
+  const hierarchySummary = [
+    "- Human guideline docs in the configured guideline folder are authoritative for runtime enforcement.",
+    "- `omsb.config.json` stores vault-scoped mappings and Tier 1 operational inputs.",
+    "- `.omsb/rules.json` is a generated runtime artifact and does not outrank the guidelines.",
+  ].join("\n");
+
   // Build rule summaries sorted by severity (block → deny → advisory)
   let ruleSummaries: string;
   if (rules && rules.rules.length > 0) {
@@ -209,6 +219,9 @@ export async function generateClaudeMd(
     "This vault is managed by oh-my-second-brain. AI operations are structurally enforced.",
     "",
     ...vaultContext,
+    "",
+    "## Runtime Source Hierarchy",
+    hierarchySummary,
     "",
     "## Enforcement Rules",
     ruleSummaries,

--- a/src/rules/compiler.ts
+++ b/src/rules/compiler.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { OmsbConfig, RuleManifest } from "./types.js";
+import { defaultRuntimeEnforcementManifestGovernance } from "./types.js";
 import { extractTier1Rules } from "./tier1-extractor.js";
 import { extractTier2Rules } from "./tier2-extractor.js";
 
@@ -123,6 +124,9 @@ export function compileRules(config: OmsbConfig, vaultPath: string): RuleManifes
   return {
     version: 1,
     generated_at: new Date().toISOString(),
+    governance: {
+      runtime_enforcement: defaultRuntimeEnforcementManifestGovernance(),
+    },
     source_mtimes,
     source_snapshot: {
       config_path: configPath,

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -12,6 +12,40 @@ export interface RoutingConfig {
 
 export type GuidelineDomainMap = Partial<Record<GuidelineRequirement, string>>;
 
+export interface RuntimeEnforcementConfigGovernance {
+  docs_are_runtime_authority: false;
+  human_guidelines: "authoritative";
+  config_rules: "tier1-operational-input";
+}
+
+export interface RuntimeEnforcementManifestGovernance
+  extends RuntimeEnforcementConfigGovernance {
+  rules_manifest: "generated-runtime-artifact";
+}
+
+export interface GovernanceConfig {
+  runtime_enforcement: RuntimeEnforcementConfigGovernance;
+}
+
+export interface GovernanceManifest {
+  runtime_enforcement: RuntimeEnforcementManifestGovernance;
+}
+
+export function defaultRuntimeEnforcementConfigGovernance(): RuntimeEnforcementConfigGovernance {
+  return {
+    docs_are_runtime_authority: false,
+    human_guidelines: "authoritative",
+    config_rules: "tier1-operational-input",
+  };
+}
+
+export function defaultRuntimeEnforcementManifestGovernance(): RuntimeEnforcementManifestGovernance {
+  return {
+    ...defaultRuntimeEnforcementConfigGovernance(),
+    rules_manifest: "generated-runtime-artifact",
+  };
+}
+
 export interface EnforcementRule {
   id: string;
   type: "path-boundary" | "path-boundary-exception" | "frontmatter-required" | "frontmatter-value" | "naming-convention";
@@ -27,6 +61,7 @@ export interface EnforcementRule {
 export interface RuleManifest {
   version: 1;
   generated_at: string;
+  governance?: GovernanceManifest;
   source_mtimes: Record<string, number>;
   source_snapshot: {
     config_path: string;
@@ -45,6 +80,7 @@ export interface OmsbConfig {
   version: 1;
   vault_path: string;
   vault_name: string;
+  governance?: GovernanceConfig;
   guidelines: {
     root: string;
     files: string[];


### PR DESCRIPTION
## Summary
- make the docs/process SSOT vs runtime enforcement SSOT split explicit in repo surfaces
- add contributor workflow, issue template, PR template, README reference section, and root MIT license
- encode runtime-governance metadata in config/rule artifacts and validate that docs cannot become runtime rule authority
- improve SessionStart freshness/recovery messaging with concrete added/removed/missing guideline evidence
- add automated tests for docs governance and session-init recovery behavior

## Verification
- `npm run build`
- `npm test` (101 passing, 0 failing)

## Notes
- OMC is referenced explicitly as inspiration only; this PR does not broaden OMSB into a general orchestration clone.
- This PR covers the docs governance / contract-hardening slice and leaves deeper vault UX work for follow-up slices.
