### PR TITLE
Add approval-aware managed plugin settings workflow

### DIFF
--- a/src/__tests__/plugin-settings.test.ts
+++ b/src/__tests__/plugin-settings.test.ts
@@ -5,8 +5,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
   classifyPluginSettingsChange,
+  diffManagedPluginData,
   readManagedPluginData,
   resolveManagedPluginDataPath,
+  syncManagedPluginData,
   writeManagedPluginData,
 } from "../obsidian/plugin-settings.js";
 
@@ -71,5 +73,76 @@ describe("plugin settings helpers", () => {
       classifyPluginSettingsChange({ guidelineExplicit: false }),
       "approval-required",
     );
+  });
+
+  it("diffs changed plugin setting keys", () => {
+    const changed = diffManagedPluginData(
+      { enabled: true, nested: { theme: "light" } },
+      { enabled: false, nested: { theme: "light" }, extra: 1 },
+    );
+    assert.deepEqual(changed, ["enabled", "extra"]);
+  });
+
+  it("auto-applies guideline-explicit plugin changes", () => {
+    const plugin = { id: "calendar" };
+    writeManagedPluginData(tmpDir, plugin, { enabled: false, view: "month" });
+
+    const result = syncManagedPluginData(
+      tmpDir,
+      plugin,
+      { enabled: true, view: "month" },
+      { guidelineExplicit: true },
+    );
+
+    assert.equal(result.mode, "auto-apply");
+    assert.deepEqual(result.changedKeys, ["enabled"]);
+    assert.equal(result.proposalPath, undefined);
+    assert.deepEqual(readManagedPluginData(tmpDir, plugin), {
+      enabled: true,
+      view: "month",
+    });
+  });
+
+  it("creates a proposal instead of writing optimization-only changes", () => {
+    const plugin = { id: "calendar" };
+    writeManagedPluginData(tmpDir, plugin, { enabled: false, view: "month" });
+
+    const result = syncManagedPluginData(
+      tmpDir,
+      plugin,
+      { enabled: false, view: "week" },
+      { guidelineExplicit: false },
+      "calendar-optimization",
+    );
+
+    assert.equal(result.mode, "approval-required");
+    assert.deepEqual(result.changedKeys, ["view"]);
+    assert.ok(result.proposalPath);
+    assert.ok(fs.existsSync(result.proposalPath!));
+    assert.deepEqual(readManagedPluginData(tmpDir, plugin), {
+      enabled: false,
+      view: "month",
+    });
+
+    const proposal = fs.readFileSync(result.proposalPath!, "utf-8");
+    assert.match(proposal, /Plugin Settings Proposal: calendar/);
+    assert.match(proposal, /Changed keys: view/);
+    assert.match(proposal, /"view": "week"/);
+  });
+
+  it("returns no-op when desired settings already match current data", () => {
+    const plugin = { id: "calendar" };
+    writeManagedPluginData(tmpDir, plugin, { enabled: true });
+
+    const result = syncManagedPluginData(
+      tmpDir,
+      plugin,
+      { enabled: true },
+      { guidelineExplicit: true },
+    );
+
+    assert.equal(result.mode, "no-op");
+    assert.deepEqual(result.changedKeys, []);
+    assert.equal(result.proposalPath, undefined);
   });
 });

--- a/src/obsidian/plugin-settings.ts
+++ b/src/obsidian/plugin-settings.ts
@@ -1,9 +1,18 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ManagedPluginConfig } from "../rules/types.js";
+import { writeProposal } from "../proposals/writer.js";
 
 export interface PluginSettingsChangePolicy {
   guidelineExplicit: boolean;
+}
+
+export interface ManagedPluginSettingsResult {
+  mode: "auto-apply" | "approval-required" | "no-op";
+  pluginId: string;
+  dataPath: string;
+  changedKeys: string[];
+  proposalPath?: string;
 }
 
 export function resolveManagedPluginDataPath(
@@ -59,4 +68,90 @@ export function classifyPluginSettingsChange(
   policy: PluginSettingsChangePolicy,
 ): "auto-apply" | "approval-required" {
   return policy.guidelineExplicit ? "auto-apply" : "approval-required";
+}
+
+export function diffManagedPluginData(
+  current: Record<string, unknown>,
+  desired: Record<string, unknown>,
+): string[] {
+  const keys = new Set<string>([
+    ...Object.keys(current),
+    ...Object.keys(desired),
+  ]);
+
+  return [...keys]
+    .filter((key) => JSON.stringify(current[key]) !== JSON.stringify(desired[key]))
+    .sort();
+}
+
+function buildPluginSettingsProposal(
+  plugin: ManagedPluginConfig,
+  changedKeys: string[],
+  current: Record<string, unknown>,
+  desired: Record<string, unknown>,
+): string {
+  return [
+    `# Plugin Settings Proposal: ${plugin.id}`,
+    "",
+    "These setting changes require approval before OMSB updates the plugin-owned `data.json`.",
+    "",
+    `Changed keys: ${changedKeys.join(", ") || "none"}`,
+    "",
+    "## Current",
+    "```json",
+    JSON.stringify(current, null, 2),
+    "```",
+    "",
+    "## Desired",
+    "```json",
+    JSON.stringify(desired, null, 2),
+    "```",
+    "",
+  ].join("\n");
+}
+
+export function syncManagedPluginData(
+  vaultPath: string,
+  plugin: ManagedPluginConfig,
+  desired: Record<string, unknown>,
+  policy: PluginSettingsChangePolicy,
+  slug = plugin.id,
+): ManagedPluginSettingsResult {
+  const dataPath = resolveManagedPluginDataPath(vaultPath, plugin);
+  const current = readManagedPluginData(vaultPath, plugin);
+  const changedKeys = diffManagedPluginData(current, desired);
+
+  if (changedKeys.length === 0) {
+    return {
+      mode: "no-op",
+      pluginId: plugin.id,
+      dataPath,
+      changedKeys: [],
+    };
+  }
+
+  const mode = classifyPluginSettingsChange(policy);
+  if (mode === "auto-apply") {
+    writeManagedPluginData(vaultPath, plugin, desired);
+    return {
+      mode,
+      pluginId: plugin.id,
+      dataPath,
+      changedKeys,
+    };
+  }
+
+  const proposalPath = writeProposal(
+    vaultPath,
+    `${slug}-plugin-settings`,
+    buildPluginSettingsProposal(plugin, changedKeys, current, desired),
+  );
+
+  return {
+    mode,
+    pluginId: plugin.id,
+    dataPath,
+    changedKeys,
+    proposalPath,
+  };
 }


### PR DESCRIPTION
## Summary
- add a higher-level managed plugin settings workflow that diffs current vs desired plugin-owned settings
- auto-apply guideline-explicit changes to plugin `data.json`
- generate proposal artifacts for optimization-only changes instead of mutating settings immediately
- add regression tests for diffing, auto-apply, proposal generation, and no-op behavior

## Verification
- `npm run build`
- `npm test` (105 passing, 0 failing)

## Notes
- This PR stays within the plugin-settings contract: data.json only, no source/CSS/JS mutation.
- Optimization-only changes remain approval-required and now leave an auditable proposal artifact.
