### PR TITLE
Add proposal-aware planning for user-visible note operations

### DIFF
--- a/src/__tests__/obsidian-operations.test.ts
+++ b/src/__tests__/obsidian-operations.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
-import { resolveVaultOperationMode } from "../obsidian/operations.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  planUserVisibleVaultOperation,
+  resolveVaultOperationMode,
+} from "../obsidian/operations.js";
 
 describe("resolveVaultOperationMode", () => {
   it("prefers obsidian-native mode for user-visible note mutations", () => {
@@ -16,5 +22,49 @@ describe("resolveVaultOperationMode", () => {
   it("keeps non-user-visible artifact writes on filesystem mode", () => {
     assert.equal(resolveVaultOperationMode("config-write", false), "filesystem");
     assert.equal(resolveVaultOperationMode("plugin-data-write", true), "filesystem");
+  });
+
+  it("creates a proposal artifact when native support is unavailable for an explicit route", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omsb-op-plan-"));
+    try {
+      const result = planUserVisibleVaultOperation(
+        tmpDir,
+        "term",
+        "note-route",
+        "terminology",
+        { kind: "explicit", destination: "20. Terminology" },
+        false,
+      );
+
+      assert.equal(result.mode, "proposal-only");
+      assert.equal(result.destination, "20. Terminology");
+      assert.equal(result.reason, "native-unavailable");
+      assert.ok(result.proposalPath);
+      assert.ok(fs.existsSync(result.proposalPath!));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes through routing proposals when the route itself is ambiguous", () => {
+    const result = planUserVisibleVaultOperation(
+      "/vault",
+      "term",
+      "note-route",
+      "terminology",
+      {
+        kind: "propose",
+        candidates: ["A", "B"],
+        reason: "ambiguous",
+        proposalPath: "/vault/.omsb/proposals/example.md",
+      },
+      true,
+    );
+
+    assert.deepEqual(result, {
+      mode: "proposal-only",
+      proposalPath: "/vault/.omsb/proposals/example.md",
+      reason: "ambiguous",
+    });
   });
 });

--- a/src/__tests__/terminology-service.test.ts
+++ b/src/__tests__/terminology-service.test.ts
@@ -45,7 +45,8 @@ describe("planTerminologyPlacement", () => {
   it("uses obsidian-native mode when routing is explicit and native support is available", () => {
     const result = planTerminologyPlacement(tmpDir, "term", makeConfig(), true);
     assert.equal(result.routing.kind, "explicit");
-    assert.equal(result.operationMode, "obsidian-native");
+    assert.equal(result.operation.mode, "obsidian-native");
+    assert.equal(result.operation.destination, "20. Terminology");
   });
 
   it("falls back to proposal-only mode for ambiguous routing", () => {
@@ -59,7 +60,17 @@ describe("planTerminologyPlacement", () => {
 
     const result = planTerminologyPlacement(tmpDir, "term", config, true);
     assert.equal(result.routing.kind, "propose");
-    assert.equal(result.operationMode, "proposal-only");
+    assert.equal(result.operation.mode, "proposal-only");
     assert.ok(result.routing.proposalPath);
+    assert.equal(result.operation.proposalPath, result.routing.proposalPath);
+  });
+
+  it("creates an operation proposal when native support is unavailable for an explicit route", () => {
+    const result = planTerminologyPlacement(tmpDir, "term", makeConfig(), false);
+    assert.equal(result.routing.kind, "explicit");
+    assert.equal(result.operation.mode, "proposal-only");
+    assert.equal(result.operation.reason, "native-unavailable");
+    assert.ok(result.operation.proposalPath);
+    assert.ok(fs.existsSync(result.operation.proposalPath!));
   });
 });

--- a/src/obsidian/operations.ts
+++ b/src/obsidian/operations.ts
@@ -1,3 +1,6 @@
+import type { RoutingDecision } from "../routing/resolver.js";
+import { writeProposal } from "../proposals/writer.js";
+
 export type VaultOperationKind =
   | "note-create"
   | "note-move"
@@ -13,6 +16,13 @@ export type VaultOperationMode =
   | "obsidian-native"
   | "proposal-only"
   | "filesystem";
+
+export interface UserVisibleVaultOperationPlan {
+  mode: "obsidian-native" | "proposal-only";
+  destination?: string;
+  proposalPath?: string;
+  reason?: "native-unavailable" | "ambiguous" | "missing-target" | "missing-config";
+}
 
 const USER_VISIBLE_MUTATIONS = new Set<VaultOperationKind>([
   "note-create",
@@ -30,4 +40,60 @@ export function resolveVaultOperationMode(
   }
 
   return "filesystem";
+}
+
+function buildNativeUnavailableProposal(
+  kind: VaultOperationKind,
+  noteKind: string,
+  destination: string,
+): string {
+  return [
+    `# Vault Operation Proposal: ${noteKind}`,
+    "",
+    `Operation: ${kind}`,
+    "Reason: native-unavailable",
+    `Intended destination: ${destination}`,
+    "",
+    "OMSB resolved a deterministic destination, but Obsidian-native support is unavailable.",
+    "User confirmation is required before proceeding with a user-visible vault mutation.",
+    "",
+  ].join("\n");
+}
+
+export function planUserVisibleVaultOperation(
+  vaultPath: string,
+  slug: string,
+  kind: Extract<VaultOperationKind, "note-create" | "note-move" | "note-rename" | "note-route">,
+  noteKind: string,
+  routing: RoutingDecision & { proposalPath?: string },
+  nativeAvailable: boolean,
+): UserVisibleVaultOperationPlan {
+  if (routing.kind === "propose") {
+    return {
+      mode: "proposal-only",
+      proposalPath: routing.proposalPath,
+      reason: routing.reason,
+    };
+  }
+
+  const mode = resolveVaultOperationMode(kind, nativeAvailable);
+  if (mode === "obsidian-native") {
+    return {
+      mode,
+      destination: routing.destination,
+    };
+  }
+
+  const proposalPath = writeProposal(
+    vaultPath,
+    `${slug}-${noteKind}-${kind}`,
+    buildNativeUnavailableProposal(kind, noteKind, routing.destination),
+  );
+
+  return {
+    mode: "proposal-only",
+    destination: routing.destination,
+    proposalPath,
+    reason: "native-unavailable",
+  };
 }

--- a/src/terminology/service.ts
+++ b/src/terminology/service.ts
@@ -4,13 +4,13 @@ import {
   type RoutingDecision,
 } from "../routing/resolver.js";
 import {
-  resolveVaultOperationMode,
-  type VaultOperationMode,
+  planUserVisibleVaultOperation,
+  type UserVisibleVaultOperationPlan,
 } from "../obsidian/operations.js";
 
 export interface TerminologyPlacementPlan {
   routing: RoutingDecision & { proposalPath?: string };
-  operationMode: VaultOperationMode;
+  operation: UserVisibleVaultOperationPlan;
 }
 
 export function planTerminologyPlacement(
@@ -26,13 +26,17 @@ export function planTerminologyPlacement(
     config.routing,
   );
 
-  const operationMode =
-    routing.kind === "propose"
-      ? "proposal-only"
-      : resolveVaultOperationMode("note-route", nativeAvailable);
+  const operation = planUserVisibleVaultOperation(
+    vaultPath,
+    slug,
+    "note-route",
+    "terminology",
+    routing,
+    nativeAvailable,
+  );
 
   return {
     routing,
-    operationMode,
+    operation,
   };
 }


### PR DESCRIPTION
## Summary
- add a reusable user-visible vault operation planner for note actions
- generate explicit proposal artifacts when routing is deterministic but Obsidian-native support is unavailable
- preserve routing-originated proposal artifacts for ambiguous cases
- update terminology placement to return the richer operation plan
- add regression tests for native-unavailable explicit routes and proposal pass-through behavior

## Verification
- `npm run build`
- `npm test` (108 passing, 0 failing)

## Notes
- This PR keeps the user-visible mutation boundary intact: explicit routes still avoid silent filesystem fallbacks when native support is unavailable.
- Routing ambiguity proposals and native-unavailable operation proposals are intentionally distinct.
