### PR TITLE
Add config-managed plugin registry sync helpers

### DIFF
--- a/src/__tests__/plugin-settings.test.ts
+++ b/src/__tests__/plugin-settings.test.ts
@@ -6,11 +6,15 @@ import * as path from "node:path";
 import {
   classifyPluginSettingsChange,
   diffManagedPluginData,
+  getManagedPlugin,
+  listManagedPlugins,
   readManagedPluginData,
   resolveManagedPluginDataPath,
   syncManagedPluginData,
+  syncManagedPluginDataFromConfig,
   writeManagedPluginData,
 } from "../obsidian/plugin-settings.js";
+import type { OmsbConfig } from "../rules/types.js";
 
 let tmpDir: string;
 
@@ -21,6 +25,37 @@ before(() => {
 after(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
+
+function makeConfig(): OmsbConfig {
+  return {
+    version: 1,
+    vault_path: tmpDir,
+    vault_name: "Vault",
+    governance: {
+      runtime_enforcement: {
+        docs_are_runtime_authority: false,
+        human_guidelines: "authoritative",
+        config_rules: "tier1-operational-input",
+      },
+    },
+    guidelines: {
+      root: "Guidelines",
+      files: ["Folder Guideline.md"],
+    },
+    rules: {
+      raw_paths: ["References/**"],
+    },
+    enforcement: {
+      raw_boundary: "deny",
+      frontmatter: "advisory",
+      naming: "advisory",
+    },
+    managed_plugins: [
+      { id: "calendar" },
+      { id: "tasks", data_json_path: ".obsidian/plugins/tasks/data.json" },
+    ],
+  };
+}
 
 describe("plugin settings helpers", () => {
   it("resolves default data.json path inside .obsidian/plugins", () => {
@@ -144,5 +179,46 @@ describe("plugin settings helpers", () => {
     assert.equal(result.mode, "no-op");
     assert.deepEqual(result.changedKeys, []);
     assert.equal(result.proposalPath, undefined);
+  });
+
+  it("lists and resolves managed plugins from config", () => {
+    const config = makeConfig();
+    assert.deepEqual(
+      listManagedPlugins(config).map((plugin) => plugin.id),
+      ["calendar", "tasks"],
+    );
+    assert.equal(getManagedPlugin(config, "tasks").id, "tasks");
+  });
+
+  it("throws when syncing an unregistered managed plugin", () => {
+    const config = makeConfig();
+    assert.throws(
+      () =>
+        syncManagedPluginDataFromConfig(
+          tmpDir,
+          config,
+          "missing-plugin",
+          { enabled: true },
+          { guidelineExplicit: true },
+        ),
+      /not registered in managed_plugins/,
+    );
+  });
+
+  it("syncs plugin settings through config-managed plugin lookup", () => {
+    const config = makeConfig();
+    const plugin = getManagedPlugin(config, "calendar");
+    writeManagedPluginData(tmpDir, plugin, { enabled: false });
+
+    const result = syncManagedPluginDataFromConfig(
+      tmpDir,
+      config,
+      "calendar",
+      { enabled: true },
+      { guidelineExplicit: true },
+    );
+
+    assert.equal(result.mode, "auto-apply");
+    assert.deepEqual(readManagedPluginData(tmpDir, plugin), { enabled: true });
   });
 });

--- a/src/obsidian/plugin-settings.ts
+++ b/src/obsidian/plugin-settings.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ManagedPluginConfig } from "../rules/types.js";
+import type { ManagedPluginConfig, OmsbConfig } from "../rules/types.js";
 import { writeProposal } from "../proposals/writer.js";
 
 export interface PluginSettingsChangePolicy {
@@ -13,6 +13,23 @@ export interface ManagedPluginSettingsResult {
   dataPath: string;
   changedKeys: string[];
   proposalPath?: string;
+}
+
+export function listManagedPlugins(config: OmsbConfig): ManagedPluginConfig[] {
+  return config.managed_plugins ?? [];
+}
+
+export function getManagedPlugin(
+  config: OmsbConfig,
+  pluginId: string,
+): ManagedPluginConfig {
+  const plugin = listManagedPlugins(config).find((entry) => entry.id === pluginId);
+  if (!plugin) {
+    throw new Error(
+      `omsb plugin-settings: plugin "${pluginId}" is not registered in managed_plugins`,
+    );
+  }
+  return plugin;
 }
 
 export function resolveManagedPluginDataPath(
@@ -154,4 +171,16 @@ export function syncManagedPluginData(
     changedKeys,
     proposalPath,
   };
+}
+
+export function syncManagedPluginDataFromConfig(
+  vaultPath: string,
+  config: OmsbConfig,
+  pluginId: string,
+  desired: Record<string, unknown>,
+  policy: PluginSettingsChangePolicy,
+  slug = pluginId,
+): ManagedPluginSettingsResult {
+  const plugin = getManagedPlugin(config, pluginId);
+  return syncManagedPluginData(vaultPath, plugin, desired, policy, slug);
 }


### PR DESCRIPTION
## Summary
- add helpers to list and resolve managed plugins from `OmsbConfig`
- allow plugin settings sync to start from the vault-local `managed_plugins` registry instead of raw plugin descriptors
- fail clearly when callers request an unregistered plugin id
- add regression tests for registry listing, missing-plugin errors, and config-driven sync behavior

## Verification
- `npm run build`
- `npm test` (111 passing, 0 failing)

## Notes
- This keeps the plugin settings workflow vault-scoped by honoring `managed_plugins` as the registry of record.
- Unregistered plugins now fail explicitly instead of silently bypassing the registry contract.
