### PR TITLE
Fix OMSB command registration for live Claude runtime

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,6 +15,5 @@
     "knowledge-management",
     "ai-harness"
   ],
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }

--- a/scripts/guideline-enforcer.mjs
+++ b/scripts/guideline-enforcer.mjs
@@ -230,6 +230,7 @@ function buildRecoveryOutput(message) {
   return JSON.stringify({
     continue: true,
     hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
       additionalContext: `[OMSB] ${message}`,
     },
   });
@@ -446,6 +447,7 @@ function buildBlockOutput(rule, filePath) {
 
   return JSON.stringify({
     hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
       permissionDecision: 'deny',
       permissionDecisionReason: reason,
     },
@@ -463,6 +465,7 @@ function buildDenyOutput(rule, description, details) {
 
   return JSON.stringify({
     hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
       permissionDecision: 'deny',
       permissionDecisionReason: lines.join('\n'),
     },
@@ -474,6 +477,7 @@ function buildAdvisoryOutput(rule, message) {
   return JSON.stringify({
     continue: true,
     hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
       additionalContext: `[OMSB] ${message}\n\nRule: ${rule.id}`,
     },
   });

--- a/scripts/session-init.mjs
+++ b/scripts/session-init.mjs
@@ -49,6 +49,7 @@ function advisory(message) {
   return JSON.stringify({
     continue: true,
     hookSpecificOutput: {
+      hookEventName: 'SessionStart',
       additionalContext: `[OMSB] ${message}`,
     },
   });

--- a/skills/compile/SKILL.md
+++ b/skills/compile/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: omsb compile
+name: compile
+level: 2
 description: Compile raw vault sources into structured knowledge
 ---
 

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: omsb init
+name: init
+level: 2
 description: Initialize oh-my-second-brain vault enforcement
 ---
 

--- a/skills/plugin-settings/SKILL.md
+++ b/skills/plugin-settings/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: omsb plugin-settings
+name: plugin-settings
+level: 2
 description: Inspect and adjust managed Obsidian plugin settings using guideline-aware recommendations
 ---
 

--- a/skills/terminology/SKILL.md
+++ b/skills/terminology/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: omsb terminology
+name: terminology
+level: 2
 description: Create or route terminology notes with guideline-derived destinations
 ---
 

--- a/src/__tests__/hook-smoke.test.ts
+++ b/src/__tests__/hook-smoke.test.ts
@@ -82,10 +82,15 @@ describe("hook smoke flows", () => {
         content: "# source note\n",
       },
     }) as {
-      hookSpecificOutput: { permissionDecision: string; permissionDecisionReason: string };
+      hookSpecificOutput: {
+        hookEventName: string;
+        permissionDecision: string;
+        permissionDecisionReason: string;
+      };
       systemMessage: string;
     };
 
+    assert.equal(output.hookSpecificOutput.hookEventName, "PreToolUse");
     assert.equal(output.hookSpecificOutput.permissionDecision, "deny");
     assert.match(output.hookSpecificOutput.permissionDecisionReason, /write to protected path/i);
     assert.match(output.hookSpecificOutput.permissionDecisionReason, /raw boundary pattern/i);
@@ -109,10 +114,11 @@ describe("hook smoke flows", () => {
       },
     }) as {
       continue: boolean;
-      hookSpecificOutput: { additionalContext: string };
+      hookSpecificOutput: { hookEventName: string; additionalContext: string };
     };
 
     assert.equal(output.continue, true);
+    assert.equal(output.hookSpecificOutput.hookEventName, "PreToolUse");
     assert.match(output.hookSpecificOutput.additionalContext, /enforcement is inactive/i);
     assert.match(output.hookSpecificOutput.additionalContext, /\/omsb init/i);
   });

--- a/src/__tests__/plugin-runtime-contract.test.ts
+++ b/src/__tests__/plugin-runtime-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf-8");
+}
+
+describe("OMSB plugin runtime contract", () => {
+  it("does not redeclare the standard hooks manifest in plugin.json", () => {
+    const manifest = JSON.parse(readRepoFile(".claude-plugin/plugin.json")) as Record<string, unknown>;
+    assert.equal(manifest["hooks"], undefined);
+    assert.equal(manifest["skills"], "./skills/");
+  });
+
+  it("uses bare skill names so the plugin namespace can expose slash commands", () => {
+    const expected = new Map([
+      ["skills/init/SKILL.md", "init"],
+      ["skills/compile/SKILL.md", "compile"],
+      ["skills/terminology/SKILL.md", "terminology"],
+      ["skills/plugin-settings/SKILL.md", "plugin-settings"],
+    ]);
+
+    for (const [file, skillName] of expected.entries()) {
+      const text = readRepoFile(file);
+      assert.match(text, new RegExp(`^name:\\s*${skillName}$`, "m"));
+      assert.match(text, /^level:\s*2$/m);
+    }
+  });
+});

--- a/src/__tests__/session-init.test.ts
+++ b/src/__tests__/session-init.test.ts
@@ -108,9 +108,10 @@ describe("session-init hook", () => {
     );
 
     const output = runSessionInit(vaultPath) as {
-      hookSpecificOutput: { additionalContext: string };
+      hookSpecificOutput: { hookEventName: string; additionalContext: string };
     };
 
+    assert.equal(output.hookSpecificOutput.hookEventName, "SessionStart");
     assert.match(output.hookSpecificOutput.additionalContext, /added guideline files/i);
     assert.match(
       output.hookSpecificOutput.additionalContext,
@@ -129,9 +130,10 @@ describe("session-init hook", () => {
     );
 
     const output = runSessionInit(vaultPath) as {
-      hookSpecificOutput: { additionalContext: string };
+      hookSpecificOutput: { hookEventName: string; additionalContext: string };
     };
 
+    assert.equal(output.hookSpecificOutput.hookEventName, "SessionStart");
     assert.match(output.hookSpecificOutput.additionalContext, /missing tracked sources/i);
     assert.match(output.hookSpecificOutput.additionalContext, /removed or renamed guideline files/i);
     assert.match(output.hookSpecificOutput.additionalContext, /Folder Guideline\.md/);
@@ -148,9 +150,10 @@ describe("session-init hook", () => {
     );
 
     const output = runSessionInit(vaultPath) as {
-      hookSpecificOutput: { additionalContext: string };
+      hookSpecificOutput: { hookEventName: string; additionalContext: string };
     };
 
+    assert.equal(output.hookSpecificOutput.hookEventName, "SessionStart");
     assert.match(
       output.hookSpecificOutput.additionalContext,
       /Configured guideline folder is missing or unreadable/i,


### PR DESCRIPTION
## Summary
- remove the duplicate `hooks` manifest entry so the plugin no longer conflicts with the standard auto-loaded hooks file
- normalize OMSB skill names to bare names (`init`, `compile`, `terminology`, `plugin-settings`) and mark them as level 2 plugin skills
- add the required `hookEventName` field to SessionStart and PreToolUse hook outputs
- add regression coverage for the plugin runtime contract and updated hook output schema

## Verification
- `npm run build`
- `npm test` (122 passing, 0 failing)
- real interactive Claude probe on a sanitized vault:
  - `/oh-my-second-brain:init` is recognized and begins OMSB initialization

## Notes
- This PR intentionally targets `feat/runtime-verification-bundle` so the execution-first path for issues #8/#9 can be unblocked without waiting for all prep PRs to merge into `main`.
- The live probe was sufficient to show the command surface appears; it did not yet complete the entire init wizard flow.
