### PR TITLE
Make Lexa installable across Codex and Hermes

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -18,8 +18,8 @@ not a shared abstraction layer.
 | Host | Manifest | Convention file | Sigil | Status |
 |------|----------|----------------|-------|--------|
 | **claude-code** | `.claude-plugin/plugin.json` | `CLAUDE.md` | `/` | REAL installable v0 |
-| **codex** | `.codex-plugin/plugin.json` | `AGENTS.md` | `$` | Stub (v0) |
-| **hermes** | `manifest.json` | `SOUL.md` + context files | (built-in tools) | Stub (v0) |
+| **codex** | `.codex-plugin/plugin.json` | `AGENTS.md` | `$` | Native skills + MCP install (v0) |
+| **hermes** | `manifest.json` | `SOUL.md` + context files | (built-in tools) | Native skills + MCP install (v0) |
 
 ---
 
@@ -31,7 +31,7 @@ Each adapter lives at `adapters/<host>/` and contains:
 adapters/<host>/
   <manifest-dir>/
     plugin.json       # Host-specific manifest (schema varies per host — see below)
-  skills/             # Host-specific skill wrappers (claude-code only in v0)
+  skills/             # Host-specific skill wrappers/bundles
     <verb>/
       SKILL.md
   CLAUDE.md           # OR AGENTS.md OR SOUL.md — convention-file shim for this host
@@ -54,21 +54,21 @@ Release contract: the npm tarball must include `adapters/claude-code/` because `
 - **Hooks**: none in v0 (hook format is `hooks/hooks.json` multi-script array — roadmap).
 - **Install**: `claude plugin install path/to/adapters/claude-code` or point Claude Code at the adapter directory.
 
-### codex (stub)
+### codex (native skills + MCP install v0)
 
 - **Manifest**: `.codex-plugin/plugin.json`
   - Schema differs from claude-code: codex uses a unified `codex-native-hook.mjs` instead of `hooks.json`.
   - Skills are invoked with `$` sigil instead of `/`.
 - **Convention file**: `AGENTS.md` — append `adapters/codex/AGENTS.md` to your project's `AGENTS.md`.
-- **Status**: v0 stub. Skills not yet wired. MCP backbone (roadmap) will provide shared tool surface.
+- **Status**: v0 native install. `lexa install --runtime codex` installs `~/.codex/rules/lexa.md`, namespaced `~/.codex/skills/lexa-*`, a managed `[mcp_servers.lexa]` block in `~/.codex/config.toml`, and a copy of the adapter under `~/.codex/plugins/lexa`.
 
-### hermes (stub)
+### hermes (native skills + MCP install v0)
 
 - **Manifest**: `manifest.json` (Hermes/Nous Research format — schema TBD).
   - Hermes skills register on agentskills.io; no local manifest equivalent exists yet.
 - **Convention file**: `SOUL.md` + context files — append `adapters/hermes/SOUL.md` to your Hermes session context.
 - **Sigil**: N/A (Hermes uses built-in tools + MCP, not a `/`/`$` sigil system).
-- **Status**: v0 stub. MCP backbone (roadmap) will provide shared tool surface.
+- **Status**: v0 native install. `lexa install --runtime hermes` installs the skill bundle under `~/.hermes/skills/knowledge-management/lexa/`, registers `mcp_servers.lexa` in `~/.hermes/config.yaml`, and keeps an adapter copy under `~/.hermes/adapters/lexa`.
 
 ---
 
@@ -84,7 +84,7 @@ The MCP server currently exposes status/read/cache/capture tools:
 `lexa_graph_status`, `lexa_graph_build`, `lexa_list_concepts`,
 `lexa_retrieve_by_axis`, `lexa_lazy_load_note`, `lexa_validate_contract`,
 `lexa_capture_prepare`, and `lexa_capture_commit`.
-Capture commit is gated by path-safety, vault-confinement, and contract validation. The CLI (`npx @goberomsu/lexa setup`, `npx @goberomsu/lexa doctor`) remains the real surface for lifecycle commands.
+Capture commit is gated by path-safety, vault-confinement, and contract validation. The CLI (`npx @goberomsu/lexa setup`, `npx @goberomsu/lexa install`, `npx @goberomsu/lexa uninstall`, `npx @goberomsu/lexa doctor`) remains the real surface for lifecycle commands.
 
 ---
 

--- a/adapters/claude-code/.claude-plugin/plugin.json
+++ b/adapters/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lexa",
-  "version": "0.1.0",
-  "description": "Host-agnostic convention layer for Obsidian vaults \u2014 capture, retrieve, and validate knowledge under a declared semantic convention.",
+  "version": "0.1.1",
+  "description": "Host-agnostic convention layer for Obsidian vaults — capture, retrieve, and validate knowledge under a declared semantic convention.",
   "author": {
     "name": "gobeumsu"
   },
@@ -18,6 +18,7 @@
     "./skills/doctor/",
     "./skills/define/",
     "./skills/capture/",
-    "./skills/retrieve/"
+    "./skills/retrieve/",
+    "./skills/uninstall/"
   ]
 }

--- a/adapters/claude-code/skills/setup/SKILL.md
+++ b/adapters/claude-code/skills/setup/SKILL.md
@@ -20,6 +20,7 @@ Shells out to:
 
 ```bash
 npx @goberomsu/lexa setup [--vault <path>] [--yes] [--install-claude]
+npx @goberomsu/lexa install [--runtime <auto|all|claude|codex|hermes>] [--vault <path>] [--dry-run] [--execute] [--yes]
 ```
 
 The CLI will:
@@ -33,7 +34,10 @@ The CLI will:
 |------|-------------|
 | `--vault <path>` | Path to your Obsidian vault root (default: current directory) |
 | `--yes` | Non-interactive: accept all defaults, no prompts |
-| `--install-claude` | Print Claude Code plugin install and MCP registration commands. This is a dry-run; it does not mutate Claude config. Release smoke tests assert the printed plugin path exists inside the npm tarball. |
+| `--install-claude` | Legacy setup-only dry-run that prints Claude Code plugin install and MCP registration commands. |
+| `install --runtime <name>` | Install host adapter/MCP registration for `auto`, `all`, `claude`, `codex`, or `hermes`. |
+| `install --dry-run` | Preview host writes without mutating config. |
+| `install --execute` | Allow external host CLIs such as `claude plugin install` to run when available. |
 
 ## Example
 
@@ -44,8 +48,14 @@ npx @goberomsu/lexa setup --vault ~/Documents/MyVault
 # Non-interactive (CI / scripted):
 npx @goberomsu/lexa setup --vault ~/Documents/MyVault --yes
 
-# Also print Claude Code harness install commands (dry-run):
-npx @goberomsu/lexa setup --vault ~/Documents/MyVault --yes --install-claude
+# Preview all host adapter installs:
+npx @goberomsu/lexa install --runtime all --vault ~/Documents/MyVault --dry-run
+
+# Install all host adapter/MCP registrations:
+npx @goberomsu/lexa install --runtime all --vault ~/Documents/MyVault --yes
+
+# Also run external host CLIs where available:
+npx @goberomsu/lexa install --runtime claude --vault ~/Documents/MyVault --yes --execute
 ```
 
 ## After setup
@@ -54,7 +64,7 @@ Run `/lexa-doctor` to validate your existing notes against the convention.
 
 ## Roadmap
 
-Setup and the Claude Code dry-run install plan are real and release-gated by unpacked npm tarball smoke tests. The MCP command starts
+Setup plus `lexa install`/`lexa uninstall` host lifecycle commands are real and release-gated by unpacked npm tarball smoke tests. The MCP command starts
 the status/read/cache/capture runtime (`lexa_graph_status`, `lexa_graph_build`,
 `lexa_list_concepts`, `lexa_retrieve_by_axis`, `lexa_lazy_load_note`,
 `lexa_validate_contract`, `lexa_capture_prepare`, `lexa_capture_commit`).

--- a/adapters/claude-code/skills/uninstall/SKILL.md
+++ b/adapters/claude-code/skills/uninstall/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: lexa-uninstall
+description: Remove Lexa host adapter and MCP registrations by running npx @goberomsu/lexa uninstall.
+---
+
+# Skill: lexa-uninstall (Claude Code)
+
+Remove Lexa host registrations and adapter files. This does **not** delete vault notes or `vault/.lexa/` ontology data.
+
+## Invocation
+
+```
+/lexa-uninstall
+```
+
+## What this skill does
+
+Shells out to:
+
+```bash
+npx @goberomsu/lexa uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+```
+
+## Recommended flow
+
+```bash
+# Preview first:
+npx @goberomsu/lexa uninstall --runtime all --dry-run
+
+# Remove Lexa host registrations:
+npx @goberomsu/lexa uninstall --runtime all --yes
+```
+
+Use `--execute` only when you want Lexa to call external host CLIs such as `claude mcp remove lexa` or `claude plugin uninstall lexa`.

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,8 @@
 {
   "name": "lexa",
-  "version": "0.0.0",
-  "description": "Lexa convention layer for Obsidian vaults — Codex adapter stub.",
-  "_note": "v0 stub only. Codex adapter is not yet installable. See adapters/README.md for the adapter contract."
+  "version": "0.1.1",
+  "description": "Lexa convention layer for Obsidian vaults — Codex native rules, skills, and MCP adapter.",
+  "_note": "lexa install writes Codex MCP config, installs ~/.codex/rules/lexa.md, and installs ~/.codex/skills/lexa-*.",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
 }

--- a/adapters/codex/.mcp.json
+++ b/adapters/codex/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "lexa": {
+      "command": "npx",
+      "args": ["@goberomsu/lexa", "mcp", "--vault", "."]
+    }
+  }
+}

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -13,5 +13,4 @@ This vault is governed by Lexa conventions stored in `.lexa/`.
 **Capture:** Use `$lexa-capture` skill or follow the librarian persona.
 **Retrieve:** Use `$lexa-retrieve` skill or follow the retriever persona with declared lenses.
 
-> **v0 stub:** The Codex adapter plugin manifest is a stub. Skills are not yet wired into Codex.
-> Use the Lexa MCP server (roadmap) or agent-guided workflows until the Codex adapter ships.
+> **v0 native install:** `lexa install --runtime codex` installs Codex rules, `$lexa-*` skills, and a managed Codex MCP config. Use Lexa MCP tools for capture/retrieve and CLI commands for lifecycle.

--- a/adapters/codex/rules/lexa.md
+++ b/adapters/codex/rules/lexa.md
@@ -1,0 +1,25 @@
+# Lexa for Codex
+
+Use Lexa when the user asks to set up, validate, capture into, retrieve from, or inspect an Obsidian/Markdown vault governed by `vault/.lexa/`.
+
+## Core rule
+
+Lexa is a convention harness, not a content generator. The user owns the ontology in `vault/.lexa/`; agents must use the declared folder axis, frontmatter/property axes, wikilinks, and retrieval lenses before reading or writing notes.
+
+## Command mapping
+
+| User intent | Preferred Lexa surface |
+|---|---|
+| adopt a vault | `$lexa-setup` or `npx @goberomsu/lexa setup --vault <path>` |
+| install host integration | `$lexa-install` or `npx @goberomsu/lexa install --runtime codex --vault <path> --yes` |
+| uninstall host integration | `$lexa-uninstall` or `npx @goberomsu/lexa uninstall --runtime codex --yes` |
+| validate notes | `$lexa-doctor` or `npx @goberomsu/lexa doctor --vault <path>` |
+| capture knowledge | use MCP `lexa_capture_prepare` then `lexa_capture_commit` |
+| retrieve knowledge | use MCP `lexa_retrieve_by_axis`, then `lexa_lazy_load_note` only when needed |
+
+## Safety
+
+- Never delete vault notes or `vault/.lexa/` during uninstall.
+- Capture must stay inside the configured vault and target Markdown files only.
+- If required frontmatter is missing, ask for it; do not invent user-owned ontology values.
+- Route ambiguous captures to inbox when the ontology cannot decide.

--- a/adapters/codex/skills/lexa-capture/SKILL.md
+++ b/adapters/codex/skills/lexa-capture/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: lexa-capture
+description: Capture knowledge into the vault through Lexa's folder/frontmatter contract.
+---
+
+# lexa-capture
+
+Use MCP `lexa_capture_prepare` before writing. Commit only with `lexa_capture_commit` after the plan is `ready` or the user provides missing fields.
+
+Rules:
+
+1. Resolve concept from the user-owned ontology.
+2. Resolve folder from `vault/.lexa/taxonomy.yaml`.
+3. Fill required frontmatter; preserve additional properties.
+4. Route ambiguity to inbox.
+5. Keep writes inside the vault and Markdown-only.

--- a/adapters/codex/skills/lexa-doctor/SKILL.md
+++ b/adapters/codex/skills/lexa-doctor/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: lexa-doctor
+description: Validate vault notes against the active Lexa ontology.
+---
+
+# lexa-doctor
+
+Run:
+
+```bash
+npx @goberomsu/lexa doctor --vault <vault>
+```
+
+The command is advisory in v0 and exits 0 even when warnings are found.

--- a/adapters/codex/skills/lexa-install/SKILL.md
+++ b/adapters/codex/skills/lexa-install/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: lexa-install
+description: Install Lexa Codex/Hermes/Claude host adapters and MCP registration.
+---
+
+# lexa-install
+
+Use for host lifecycle installation.
+
+```bash
+npx @goberomsu/lexa install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
+```
+
+For Codex, this installs:
+
+- `~/.codex/rules/lexa.md`
+- `~/.codex/skills/lexa-*`
+- `~/.codex/plugins/lexa`
+- managed `[mcp_servers.lexa]` in `~/.codex/config.toml`

--- a/adapters/codex/skills/lexa-retrieve/SKILL.md
+++ b/adapters/codex/skills/lexa-retrieve/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: lexa-retrieve
+description: Retrieve vault knowledge axis-first using folders, frontmatter, wikilinks, and declared lenses.
+---
+
+# lexa-retrieve
+
+Use `lexa_retrieve_by_axis` first. Narrow by concept/folder/property/value/wikilink before lexical query. Use `lexa_lazy_load_note` only after selecting candidate notes.
+
+Return lens-shaped fields where possible; do not dump full note bodies unless the user asks or the retrieval task needs body evidence.

--- a/adapters/codex/skills/lexa-setup/SKILL.md
+++ b/adapters/codex/skills/lexa-setup/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: lexa-setup
+description: Adopt an Obsidian markdown vault into the Lexa convention and optionally install host MCP integration.
+---
+
+# lexa-setup
+
+Use when the user wants to initialize Lexa for a vault.
+
+Run:
+
+```bash
+npx @goberomsu/lexa setup --vault <vault> --yes
+```
+
+Then, when host registration is desired:
+
+```bash
+npx @goberomsu/lexa install --runtime codex --vault <vault> --yes
+```
+
+Do not modify vault notes during setup. Lexa writes only `vault/.lexa/taxonomy.yaml` and `vault/.lexa/concepts/`.

--- a/adapters/codex/skills/lexa-uninstall/SKILL.md
+++ b/adapters/codex/skills/lexa-uninstall/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: lexa-uninstall
+description: Remove Lexa host adapter files and MCP registration without deleting vault notes or vault ontology.
+---
+
+# lexa-uninstall
+
+Preview first:
+
+```bash
+npx @goberomsu/lexa uninstall --runtime all --dry-run
+```
+
+Remove host registrations:
+
+```bash
+npx @goberomsu/lexa uninstall --runtime all --yes
+```
+
+Never delete vault notes or `vault/.lexa/` as part of host uninstall.

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -1,0 +1,8 @@
+# Lexa Hermes Adapter
+
+Installed by `lexa install --runtime hermes` into:
+
+- `~/.hermes/skills/knowledge-management/lexa/`
+- `~/.hermes/config.yaml` as `mcp_servers.lexa`
+
+The skill bundle mirrors Lexa's capture/retrieve/setup/doctor lifecycle and uses the Lexa MCP server for runtime operations.

--- a/adapters/hermes/SOUL.md
+++ b/adapters/hermes/SOUL.md
@@ -16,5 +16,4 @@ construct required frontmatter, write note, then run `npx @goberomsu/lexa doctor
 
 **Retrieve:** Follow the retriever persona — identify purpose, match lens, project lens fields only.
 
-> **v0 stub:** The Hermes adapter manifest is a stub. Lexa skills are not yet registered on agentskills.io.
-> Use the Lexa MCP server (roadmap) or agent-guided workflows until the Hermes adapter ships.
+> **v0 native install:** `lexa install --runtime hermes` installs a Hermes skill bundle and registers Lexa MCP in `~/.hermes/config.yaml`. Use Lexa MCP tools for capture/retrieve and CLI commands for lifecycle.

--- a/adapters/hermes/manifest.json
+++ b/adapters/hermes/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "lexa",
-  "version": "0.0.0",
-  "description": "Lexa convention layer for Obsidian vaults — Hermes adapter stub.",
-  "_note": "v0 stub only. Hermes adapter is not yet installable. See adapters/README.md for the adapter contract."
+  "version": "0.1.1",
+  "description": "Lexa convention layer for Obsidian vaults — Hermes skill bundle and MCP adapter.",
+  "_note": "lexa install writes ~/.hermes/config.yaml mcp_servers.lexa and installs skills under ~/.hermes/skills/knowledge-management/lexa/.",
+  "skills": "./skills/"
 }

--- a/adapters/hermes/skills/capture/SKILL.md
+++ b/adapters/hermes/skills/capture/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: capture
+description: Capture knowledge into the vault through Lexa's folder/frontmatter contract.
+---
+
+# lexa-capture
+
+Use MCP `lexa_capture_prepare` before writing. Commit only with `lexa_capture_commit` after the plan is `ready` or the user provides missing fields.
+
+Rules:
+
+1. Resolve concept from the user-owned ontology.
+2. Resolve folder from `vault/.lexa/taxonomy.yaml`.
+3. Fill required frontmatter; preserve additional properties.
+4. Route ambiguity to inbox.
+5. Keep writes inside the vault and Markdown-only.

--- a/adapters/hermes/skills/doctor/SKILL.md
+++ b/adapters/hermes/skills/doctor/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: doctor
+description: Validate vault notes against the active Lexa ontology.
+---
+
+# lexa-doctor
+
+Run:
+
+```bash
+npx @goberomsu/lexa doctor --vault <vault>
+```
+
+The command is advisory in v0 and exits 0 even when warnings are found.

--- a/adapters/hermes/skills/install/SKILL.md
+++ b/adapters/hermes/skills/install/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: install
+description: Install Lexa Codex/Hermes/Claude host adapters and MCP registration.
+---
+
+# lexa-install
+
+Use for host lifecycle installation.
+
+```bash
+npx @goberomsu/lexa install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
+```
+
+For Codex, this installs:
+
+- `~/.codex/rules/lexa.md`
+- `~/.codex/skills/lexa-*`
+- `~/.codex/plugins/lexa`
+- managed `[mcp_servers.lexa]` in `~/.codex/config.toml`

--- a/adapters/hermes/skills/retrieve/SKILL.md
+++ b/adapters/hermes/skills/retrieve/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: retrieve
+description: Retrieve vault knowledge axis-first using folders, frontmatter, wikilinks, and declared lenses.
+---
+
+# lexa-retrieve
+
+Use `lexa_retrieve_by_axis` first. Narrow by concept/folder/property/value/wikilink before lexical query. Use `lexa_lazy_load_note` only after selecting candidate notes.
+
+Return lens-shaped fields where possible; do not dump full note bodies unless the user asks or the retrieval task needs body evidence.

--- a/adapters/hermes/skills/setup/SKILL.md
+++ b/adapters/hermes/skills/setup/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: setup
+description: Adopt an Obsidian markdown vault into the Lexa convention and optionally install host MCP integration.
+---
+
+# lexa-setup
+
+Use when the user wants to initialize Lexa for a vault.
+
+Run:
+
+```bash
+npx @goberomsu/lexa setup --vault <vault> --yes
+```
+
+Then, when host registration is desired:
+
+```bash
+npx @goberomsu/lexa install --runtime codex --vault <vault> --yes
+```
+
+Do not modify vault notes during setup. Lexa writes only `vault/.lexa/taxonomy.yaml` and `vault/.lexa/concepts/`.

--- a/adapters/hermes/skills/uninstall/SKILL.md
+++ b/adapters/hermes/skills/uninstall/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: uninstall
+description: Remove Lexa host adapter files and MCP registration without deleting vault notes or vault ontology.
+---
+
+# lexa-uninstall
+
+Preview first:
+
+```bash
+npx @goberomsu/lexa uninstall --runtime all --dry-run
+```
+
+Remove host registrations:
+
+```bash
+npx @goberomsu/lexa uninstall --runtime all --yes
+```
+
+Never delete vault notes or `vault/.lexa/` as part of host uninstall.

--- a/core/skills/uninstall/SKILL.md
+++ b/core/skills/uninstall/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: lexa-uninstall
+description: Remove Lexa host adapter and MCP registrations by running npx @goberomsu/lexa uninstall.
+---
+
+# Skill: lexa-uninstall (Claude Code)
+
+Remove Lexa host registrations and adapter files. This does **not** delete vault notes or `vault/.lexa/` ontology data.
+
+## Invocation
+
+```
+/lexa-uninstall
+```
+
+## What this skill does
+
+Shells out to:
+
+```bash
+npx @goberomsu/lexa uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+```
+
+## Recommended flow
+
+```bash
+# Preview first:
+npx @goberomsu/lexa uninstall --runtime all --dry-run
+
+# Remove Lexa host registrations:
+npx @goberomsu/lexa uninstall --runtime all --yes
+```
+
+Use `--execute` only when you want Lexa to call external host CLIs such as `claude mcp remove lexa` or `claude plugin uninstall lexa`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,9 +25,9 @@ Lexa's product posture is an **axis graph harness**:
 
 The full terminology lock is in the harness architecture doc. In short: Lexa helps the user operate their own knowledge system so notes can be retrieved and reused later; it does not fill the body content for them.
 
-## The 3-Host Handshake: Shared CORE + Thin ADAPTERS
+## The 3-Host Handshake: Shared CORE + Host ADAPTERS
 
-All knowledge logic (validation, ontology loading, folder resolution) is written **once** inside the shared CORE and exposed via the `lexa` CLI and — in a future version — via a shared MCP server. Host differences (manifest schema, hook format, invocation sigil, convention-file name) are absorbed by thin per-host ADAPTERS. Adding a fourth host means writing one more adapter, not touching the core.
+All knowledge logic (validation, ontology loading, folder resolution, graph/cache retrieval, and gated capture) is written **once** inside the shared CORE and exposed via the `lexa` CLI plus the shared MCP server. Host differences (manifest schema, skill layout, invocation sigil, convention-file name) are absorbed by per-host ADAPTERS. Adding a fourth host means writing one more adapter, not touching the core.
 
 | | Claude Code | Codex | Hermes |
 |---|---|---|---|
@@ -36,7 +36,7 @@ All knowledge logic (validation, ontology loading, folder resolution) is written
 | Convention file | `CLAUDE.md` / `AGENTS.md` | `AGENTS.md` | `SOUL.md` + context files |
 | Local vault access | yes | yes | yes |
 
-`adapters/claude-code/` is the only real installable adapter in v0. `adapters/codex/` and `adapters/hermes/` are manifest + convention-file stubs that document the contract without wiring up live installs.
+`adapters/claude-code/`, `adapters/codex/`, and `adapters/hermes/` all ship installable v0 host surfaces. `lexa install` copies host assets, installs Codex/Hermes skills or rules where the host expects them, and writes host MCP registration.
 
 ## Flow Diagram
 
@@ -45,8 +45,8 @@ All knowledge logic (validation, ontology loading, folder resolution) is written
 │  Host agent                                                      │
 │  (Claude Code | Codex | Hermes)                                  │
 │                                                                  │
-│  thin ADAPTER                                                    │
-│  ├─ plugin.json / plugin stub / SOUL.md fragment                 │
+│  host ADAPTER                                                    │
+│  ├─ plugin.json / rule+skill bundle / SOUL.md fragment              │
 │  └─ shells out to: npx @goberomsu/lexa setup | lexa doctor | lexa define    │
 └───────────────────────────┬──────────────────────────────────────┘
                             │ invokes

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,22 +1,79 @@
 # Install Lexa
 
-Lexa v0 is distributed as one npm package that contains the CLI/runtime, the default ontology, and the Claude Code adapter. Claude Code is the only real installable adapter in v0; Codex and Hermes remain documented stubs until their host-specific skills are wired.
+Lexa v0 is distributed as one npm/GitHub-release package that contains the CLI/runtime, the default ontology, host adapter assets, host-native skill/rule bundles, and shell installers. Claude Code, Codex, and Hermes all install a Lexa host surface backed by the same MCP capture/retrieve runtime.
 
 ## Prerequisites
 
 - Node.js 18 or newer.
+- `npm` on `PATH`.
 - An Obsidian vault, or any folder of Markdown notes.
-- Claude Code CLI for the Claude adapter/plugin flow.
+- Optional host CLIs: `claude`, `codex`, `hermes`.
 
-## Quick start from a checkout
+## One-line install
+
+Until npm publishing is unblocked, the installer installs the GitHub release tarball asset by default:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/install.sh | bash
+```
+
+Useful overrides:
+
+```bash
+# Pick one host instead of auto-detection.
+curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/install.sh | bash -s -- --runtime claude
+
+# Install every host adapter and point Lexa at a specific vault.
+curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/install.sh | bash -s -- --runtime all --vault /path/to/vault
+
+# Also execute external host CLIs where available, e.g. claude plugin/mcp commands.
+curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/install.sh | bash -s -- --runtime all --vault /path/to/vault --execute
+```
+
+Environment knobs:
+
+| Variable | Meaning |
+| --- | --- |
+| `LEXA_PACKAGE_SPEC` | npm package spec or tarball URL to install globally |
+| `LEXA_INSTALL_RUNTIME` | `auto`, `all`, `claude`, `codex`, or `hermes` |
+| `LEXA_VAULT` | vault path used for MCP registration |
+| `LEXA_EXECUTE_EXTERNAL=1` | allow host CLI commands such as `claude plugin install` |
+
+## CLI install
+
+From a checkout or installed package:
 
 ```bash
 npm ci
 npm run build
-npx @goberomsu/lexa setup --vault /path/to/vault --yes --install-claude
+npx @goberomsu/lexa install --runtime all --vault /path/to/vault --dry-run
+npx @goberomsu/lexa install --runtime all --vault /path/to/vault --yes
 ```
 
-The `--install-claude` flag is a dry-run. It prints the exact commands to install the Claude Code plugin adapter and register the MCP server; it does not mutate Claude configuration by itself.
+Runtime selection follows the Ouroboros pattern:
+
+1. Explicit `--runtime` wins.
+2. `auto` detects `claude`, `codex`, and `hermes` on `PATH`.
+3. If nothing is detected, `auto` defaults to Claude Code for conservative first-run behavior; use `--runtime all` to install every host surface.
+4. `all` installs every known adapter surface.
+
+## What install writes
+
+| Host | Install behavior |
+| --- | --- |
+| Claude Code | Upserts `~/.claude/mcp.json` entry for `lexa`; prints Claude plugin/MCP commands; with `--execute`, runs `claude plugin install` and `claude mcp add` when the CLI is available. |
+| Codex | Installs `~/.codex/rules/lexa.md`, `~/.codex/skills/lexa-*`, copies adapter files to `~/.codex/plugins/lexa`, and writes a managed `[mcp_servers.lexa]` block plus `LEXA_AGENT_RUNTIME=codex` env in `~/.codex/config.toml`. |
+| Hermes | Installs `~/.hermes/skills/knowledge-management/lexa/`, copies adapter files to `~/.hermes/adapters/lexa`, and writes `mcp_servers.lexa` in `~/.hermes/config.yaml`. |
+
+All host writes are namespaced under `lexa` and are reversible with `lexa uninstall`.
+
+## Legacy setup flow
+
+`setup` still adopts a vault into the Lexa ontology and can print the Claude Code plan:
+
+```bash
+npx @goberomsu/lexa setup --vault /path/to/vault --yes --install-claude
+```
 
 Typical printed commands look like:
 
@@ -25,49 +82,34 @@ claude plugin install /path/to/lexa/adapters/claude-code
 claude mcp add lexa -- npx @goberomsu/lexa mcp --vault /path/to/vault
 ```
 
-After running those commands, restart Claude Code and use the Lexa skills:
+## Uninstall
 
-- `/lexa-setup`
-- `/lexa-doctor`
-- `/lexa-define`
-- `/lexa-capture`
-- `/lexa-retrieve`
-
-## Quick start from npm
-
-After Lexa is published, the npm package is the install root for all runtime assets:
-
-- `dist/` — CLI and MCP runtime
-- `core/` — shipped default ontology and skills
-- `adapters/claude-code/` — Claude Code plugin adapter
-- `docs/install.md` and `docs/release.md` — release/install guidance
-
-Use either `npx` or a global install:
+Preview first:
 
 ```bash
-npx @goberomsu/lexa setup --vault /path/to/vault --yes --install-claude
-# or
-npm install -g @goberomsu/lexa
-lexa setup --vault /path/to/vault --yes --install-claude
+lexa uninstall --runtime all --dry-run
 ```
 
-Then run the printed Claude plugin and MCP registration commands.
+Remove host registrations and adapter files:
+
+```bash
+lexa uninstall --runtime all --yes
+```
+
+One-line uninstall:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/uninstall.sh | bash -s -- --yes
+```
+
+The uninstaller removes Lexa host registrations and adapter files. It does **not** remove vault notes or `vault/.lexa/` ontology data. Pass `--keep-package` to the shell uninstaller if you want to keep the globally installed package.
 
 ## Verify the install
 
 ```bash
 npx @goberomsu/lexa doctor --vault /path/to/vault
+lexa install --runtime all --vault /path/to/vault --dry-run
 claude plugin validate adapters/claude-code
 ```
 
-Inside Claude Code, verify the MCP server by listing MCP tools or asking for Lexa graph/status. The server exposes status, graph build, axis retrieval, lazy note loading, contract validation, and gated capture tools.
-
-## Host support boundary
-
-| Host | v0 status |
-| --- | --- |
-| Claude Code | Real installable adapter plus MCP registration |
-| Codex | Stub only; use the shared MCP server manually until adapter skills are wired |
-| Hermes | Stub only; use the shared MCP server manually until adapter registration is defined |
-
-Lexa intentionally does not ship an Ouroboros-style curl installer in v0. The release first proves npm package contents, unpacked-tarball setup/MCP smoke, and Claude plugin validation. A one-command installer can wrap those proven primitives later.
+Inside a host runtime, verify the MCP server by listing MCP tools or asking for Lexa graph/status. The server exposes status, graph build, axis retrieval, lazy note loading, contract validation, and gated capture tools.

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,8 +14,10 @@ The npm package root is the runtime asset root. A releasable tarball must includ
 - every Claude adapter `skills/*/SKILL.md`
 - `docs/install.md`
 - `docs/release.md`
+- `scripts/install.sh`
+- `scripts/uninstall.sh`
 
-Codex and Hermes adapter files may be packaged as stubs, but release notes must not claim they are installable v0 adapters.
+Codex and Hermes adapter files are packaged as host-native skill/rule bundles plus MCP registrations; release notes must describe the exact installed paths and avoid claiming behavior beyond the shipped skills and MCP tools.
 
 ## Local release gate
 
@@ -35,7 +37,7 @@ npm run release:check
 6. `npm run release:artifact-smoke`
 7. `npm run release:plugin`
 
-`release:pack` inspects `npm pack --dry-run --json` and fails if required runtime assets are missing. `release:artifact-smoke` creates a real tarball, unpacks it into a temp directory, installs production dependencies there, and runs setup plus MCP smoke from the extracted package root.
+`release:pack` inspects `npm pack --dry-run --json` and fails if required runtime assets are missing. `release:artifact-smoke` creates a real tarball, unpacks it into a temp directory, installs production dependencies there, and runs setup, host install dry-run, and MCP smoke from the extracted package root.
 
 ## Claude plugin validation
 
@@ -82,7 +84,7 @@ Before the first public release:
 1. Verify that the scoped `@goberomsu/lexa` npm package name is available to the publisher.
 2. Bump `package.json` to a real semver release.
 3. Keep `adapters/claude-code/.claude-plugin/plugin.json` version in sync with `package.json` unless a future ADR deliberately splits package/plugin versioning.
-4. Confirm release notes say Claude Code is real v0 support and Codex/Hermes are stubs.
+4. Confirm release notes list Codex rules/skills and Hermes skill-bundle install paths, plus the MCP registration files that make capture/retrieve tools available.
 
 ## Rollback posture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@goberomsu/lexa",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goberomsu/lexa",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goberomsu/lexa",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A host-agnostic, user-owned convention layer for Obsidian (plain-markdown) knowledge bases. Invoked from inside Claude Code, Codex, and Hermes to make knowledge capture and retrieval happen under a declared semantic convention.",
   "type": "module",
   "license": "MIT",
@@ -14,7 +14,9 @@
     "core",
     "adapters",
     "docs/install.md",
-    "docs/release.md"
+    "docs/release.md",
+    "scripts/install.sh",
+    "scripts/uninstall.sh"
   ],
   "engines": {
     "node": ">=18"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Lexa installer — installs the package and registers host adapters.
+# Usage: curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/install.sh | bash
+set -euo pipefail
+
+PACKAGE_SPEC="${LEXA_PACKAGE_SPEC:-https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.1/goberomsu-lexa-0.1.1.tgz}"
+RUNTIME="${LEXA_INSTALL_RUNTIME:-auto}"
+VAULT="${LEXA_VAULT:-$PWD}"
+EXECUTE="${LEXA_EXECUTE_EXTERNAL:-0}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --runtime) RUNTIME="${2:-}"; shift 2 ;;
+    --runtime=*) RUNTIME="${1#--runtime=}"; shift ;;
+    --vault) VAULT="${2:-}"; shift 2 ;;
+    --vault=*) VAULT="${1#--vault=}"; shift ;;
+    --package) PACKAGE_SPEC="${2:-}"; shift 2 ;;
+    --package=*) PACKAGE_SPEC="${1#--package=}"; shift ;;
+    --execute) EXECUTE=1; shift ;;
+    *) shift ;;
+  esac
+done
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Error: npm is required to install Lexa." >&2
+  exit 1
+fi
+
+echo "Lexa Installer"
+echo "  package: $PACKAGE_SPEC"
+echo "  runtime: $RUNTIME"
+echo "  vault:   $VAULT"
+echo
+
+npm install -g "$PACKAGE_SPEC"
+
+ARGS=(install --runtime "$RUNTIME" --vault "$VAULT" --yes)
+if [ "$EXECUTE" = "1" ]; then
+  ARGS+=(--execute)
+fi
+
+lexa "${ARGS[@]}"
+
+echo
+echo "Lexa install complete. Run: lexa doctor --vault \"$VAULT\""

--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -87,6 +87,18 @@ function setupSmoke(packageRoot, vault) {
   console.log("[release:artifact-smoke] ok: setup dry-run works from unpacked package.");
 }
 
+function hostInstallSmoke(packageRoot, vault) {
+  const cli = path.join(packageRoot, "dist/cli/lexa.js");
+  const result = run(process.execPath, [cli, "install", "--runtime", "all", "--vault", vault, "--dry-run"], {
+    cwd: packageRoot,
+  });
+  const output = `${result.stdout}\n${result.stderr}`;
+  for (const expected of ["claude install", "codex install", "hermes install", "rules/lexa.md", "skills/knowledge-management/lexa"]) {
+    if (!output.includes(expected)) fail(`host install dry-run did not include ${expected}`);
+  }
+  console.log("[release:artifact-smoke] ok: host install dry-run works from unpacked package.");
+}
+
 async function mcpSmoke(packageRoot, vault) {
   const cli = path.join(packageRoot, "dist/cli/lexa.js");
   const transport = new StdioClientTransport({
@@ -125,11 +137,19 @@ try {
   assertPath(path.join(packageRoot, "dist"), "dist directory");
   assertPath(path.join(packageRoot, "core"), "core directory");
   assertPath(path.join(packageRoot, "adapters/claude-code/.claude-plugin/plugin.json"), "Claude plugin manifest");
+  assertPath(path.join(packageRoot, "adapters/codex/rules/lexa.md"), "Codex Lexa rule");
+  assertPath(path.join(packageRoot, "adapters/codex/skills/lexa-capture/SKILL.md"), "Codex Lexa capture skill");
+  assertPath(path.join(packageRoot, "adapters/hermes/skills/capture/SKILL.md"), "Hermes Lexa capture skill");
   assertPath(path.join(packageRoot, "docs/install.md"), "install docs");
   assertPath(path.join(packageRoot, "docs/release.md"), "release docs");
+  assertPath(path.join(packageRoot, "scripts/install.sh"), "install shell script");
+  assertPath(path.join(packageRoot, "scripts/uninstall.sh"), "uninstall shell script");
   installRuntimeDependencies(packageRoot);
   const vault = makeVault(tempRoot);
-  if (runSetup) setupSmoke(packageRoot, vault);
+  if (runSetup) {
+    setupSmoke(packageRoot, vault);
+    hostInstallSmoke(packageRoot, vault);
+  }
   if (runMcp) await mcpSmoke(packageRoot, vault);
 } finally {
   if (tarball && existsSync(tarball)) rmSync(tarball, { force: true });

--- a/scripts/release-pack.mjs
+++ b/scripts/release-pack.mjs
@@ -47,10 +47,21 @@ const required = [
   "adapters/claude-code/skills/define/SKILL.md",
   "adapters/claude-code/skills/capture/SKILL.md",
   "adapters/claude-code/skills/retrieve/SKILL.md",
+  "adapters/claude-code/skills/uninstall/SKILL.md",
   "adapters/codex/.codex-plugin/plugin.json",
+  "adapters/codex/.mcp.json",
+  "adapters/codex/rules/lexa.md",
+  "adapters/codex/skills/lexa-setup/SKILL.md",
+  "adapters/codex/skills/lexa-capture/SKILL.md",
+  "adapters/codex/skills/lexa-retrieve/SKILL.md",
   "adapters/hermes/manifest.json",
+  "adapters/hermes/skills/setup/SKILL.md",
+  "adapters/hermes/skills/capture/SKILL.md",
+  "adapters/hermes/skills/retrieve/SKILL.md",
   "docs/install.md",
   "docs/release.md",
+  "scripts/install.sh",
+  "scripts/uninstall.sh",
 ];
 
 const missing = required.filter((requiredPath) => !hasPath(files, requiredPath));
@@ -62,6 +73,14 @@ const packageJson = JSON.parse(readFileSync("package.json", "utf-8"));
 const pluginJson = JSON.parse(readFileSync("adapters/claude-code/.claude-plugin/plugin.json", "utf-8"));
 if (packageJson.version !== pluginJson.version) {
   fail(`version mismatch: package.json=${packageJson.version}, Claude plugin=${pluginJson.version}`);
+}
+const codexPluginJson = JSON.parse(readFileSync("adapters/codex/.codex-plugin/plugin.json", "utf-8"));
+if (packageJson.version !== codexPluginJson.version) {
+  fail(`version mismatch: package.json=${packageJson.version}, Codex plugin=${codexPluginJson.version}`);
+}
+const hermesManifestJson = JSON.parse(readFileSync("adapters/hermes/manifest.json", "utf-8"));
+if (packageJson.version !== hermesManifestJson.version) {
+  fail(`version mismatch: package.json=${packageJson.version}, Hermes manifest=${hermesManifestJson.version}`);
 }
 
 console.log(`[release:pack] ok: ${pack.filename} includes ${files.length} files and required release assets.`);

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Lexa uninstaller — removes host adapter registrations and optionally the package.
+# Usage: curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/uninstall.sh | bash
+set -euo pipefail
+
+RUNTIME="${LEXA_UNINSTALL_RUNTIME:-all}"
+VAULT="${LEXA_VAULT:-$PWD}"
+REMOVE_PACKAGE="${LEXA_REMOVE_PACKAGE:-1}"
+EXECUTE="${LEXA_EXECUTE_EXTERNAL:-0}"
+YES="${LEXA_UNINSTALL_CONFIRM:-0}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --runtime) RUNTIME="${2:-}"; shift 2 ;;
+    --runtime=*) RUNTIME="${1#--runtime=}"; shift ;;
+    --vault) VAULT="${2:-}"; shift 2 ;;
+    --vault=*) VAULT="${1#--vault=}"; shift ;;
+    --keep-package) REMOVE_PACKAGE=0; shift ;;
+    --execute) EXECUTE=1; shift ;;
+    -y|--yes) YES=1; shift ;;
+    *) shift ;;
+  esac
+done
+
+if [ "$YES" != "1" ]; then
+  if [ -t 0 ]; then
+    printf 'Remove Lexa host registrations for runtime=%s? (y/N) ' "$RUNTIME"
+    read -r REPLY
+  elif [ -c /dev/tty ]; then
+    printf 'Remove Lexa host registrations for runtime=%s? (y/N) ' "$RUNTIME" >&2
+    read -r REPLY < /dev/tty
+  else
+    echo "Non-interactive uninstall requires --yes or LEXA_UNINSTALL_CONFIRM=1." >&2
+    exit 1
+  fi
+  case "$REPLY" in
+    y|Y|yes|YES) ;;
+    *) echo "Cancelled."; exit 0 ;;
+  esac
+fi
+
+ARGS=(uninstall --runtime "$RUNTIME" --vault "$VAULT" --yes)
+if [ "$EXECUTE" = "1" ]; then
+  ARGS+=(--execute)
+fi
+
+if command -v lexa >/dev/null 2>&1; then
+  lexa "${ARGS[@]}"
+else
+  echo "lexa binary not found; skipping host deregistration." >&2
+fi
+
+if [ "$REMOVE_PACKAGE" = "1" ] && command -v npm >/dev/null 2>&1; then
+  npm uninstall -g @goberomsu/lexa || true
+fi
+
+echo "Lexa uninstall complete. Vault content was not removed."

--- a/src/cli/lexa.ts
+++ b/src/cli/lexa.ts
@@ -10,6 +10,11 @@ import { resolveConcept } from "../ontology/resolver.js";
 import { parseNote } from "../conventions/frontmatter.js";
 import { validateFrontmatter } from "../conventions/validate.js";
 import { runMcpServer } from "../mcp/server.js";
+import {
+  formatHostOperationResults,
+  runHostOperation,
+  type RuntimeSelection,
+} from "../install/hosts.js";
 import type { Taxonomy, FolderBinding } from "../ontology/types.js";
 
 // ---------------------------------------------------------------------------
@@ -35,6 +40,16 @@ function bundledClaudeAdapterDir(): string {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = path.dirname(__filename);
   return path.resolve(__dirname, "../../adapters/claude-code");
+}
+
+/**
+ * Resolve the bundled `adapters` root so host installers can copy the
+ * runtime-specific adapter assets from either source or dist execution.
+ */
+function bundledAdapterRoot(): string {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  return path.resolve(__dirname, "../../adapters");
 }
 
 // ---------------------------------------------------------------------------
@@ -322,11 +337,15 @@ lexa — convention layer for Obsidian vaults
 
 Usage:
   lexa setup [--vault <path>] [--yes] [--install-claude]
+  lexa install [--vault <path>] [--runtime <auto|all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+  lexa uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
   lexa doctor [--vault <path>]
   lexa mcp [--vault <path>]
 
 Commands:
   setup    Adopt an existing vault into the Lexa convention.
+  install  Install Lexa host adapters and MCP registration.
+  uninstall Remove Lexa host adapters and MCP registration.
   doctor   Validate vault notes against the active ontology.
   mcp      Start the read/status MCP stdio server.
 
@@ -334,6 +353,9 @@ Options:
   --vault <path>   Path to the vault root (default: current directory).
   --yes            Non-interactive: accept all defaults (setup only).
   --install-claude Print Claude Code plugin install and MCP registration commands (dry-run).
+  --runtime <name> Select host runtime (default: auto for install, all for uninstall).
+  --dry-run        Preview host config changes without writing files.
+  --execute        Allow external host CLIs such as \`claude\` to run when available.
 `);
 }
 
@@ -341,10 +363,13 @@ async function main(): Promise<void> {
   const argv = process.argv.slice(2);
   const command = argv[0];
 
-  // Parse --vault and --yes flags.
+  // Parse shared flags.
   let vault = process.cwd();
   let yes = false;
   let installClaude = false;
+  let runtime: RuntimeSelection | undefined;
+  let dryRun = false;
+  let executeExternal = false;
 
   for (let i = 1; i < argv.length; i++) {
     if (argv[i] === "--vault" && argv[i + 1]) {
@@ -354,11 +379,48 @@ async function main(): Promise<void> {
       yes = true;
     } else if (argv[i] === "--install-claude") {
       installClaude = true;
+    } else if (argv[i] === "--runtime" && argv[i + 1]) {
+      const rawRuntime = argv[i + 1]!;
+      if (
+        rawRuntime === "auto" ||
+        rawRuntime === "all" ||
+        rawRuntime === "claude" ||
+        rawRuntime === "codex" ||
+        rawRuntime === "hermes"
+      ) {
+        runtime = rawRuntime;
+      } else {
+        console.error(`[lexa] Unsupported runtime: ${rawRuntime}`);
+        process.exitCode = 1;
+        return;
+      }
+      i++;
+    } else if (argv[i] === "--dry-run") {
+      dryRun = true;
+    } else if (argv[i] === "--execute") {
+      executeExternal = true;
     }
   }
 
   if (command === "setup") {
     await runSetup({ vault, yes, installClaude });
+  } else if (command === "install" || command === "uninstall") {
+    const selectedRuntime = runtime ?? (command === "install" ? "auto" : "all");
+    if (command === "uninstall" && !yes && !dryRun && process.env["LEXA_NON_INTERACTIVE"] !== "1") {
+      console.error("[lexa] Refusing uninstall without --yes or --dry-run.");
+      process.exitCode = 1;
+      return;
+    }
+    const results = await runHostOperation({
+      action: command,
+      runtime: selectedRuntime,
+      vault,
+      dryRun,
+      executeExternal,
+      yes,
+      adapterRoot: bundledAdapterRoot(),
+    });
+    console.log(formatHostOperationResults(results, dryRun));
   } else if (command === "doctor") {
     process.exitCode = await runDoctor({ vault });
   } else if (command === "mcp") {

--- a/src/install/hosts.test.ts
+++ b/src/install/hosts.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { runHostOperation, formatHostOperationResults } from "./hosts.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../..");
+const adapterRoot = path.join(repoRoot, "adapters");
+
+describe("host installer/uninstaller", () => {
+  it("installs and uninstalls Codex managed MCP config without removing unrelated sections", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "lexa-install-codex-"));
+    const codexDir = path.join(home, ".codex");
+    await writeFile(path.join(codexDir, "config.toml"), 'model = "gpt-5"\n\n[other]\nfoo = 1\n', { encoding: "utf-8" }).catch(async () => {
+      await import("node:fs/promises").then(({ mkdir }) => mkdir(codexDir, { recursive: true }));
+      await writeFile(path.join(codexDir, "config.toml"), 'model = "gpt-5"\n\n[other]\nfoo = 1\n', "utf-8");
+    });
+
+    await runHostOperation({ action: "install", runtime: "codex", vault: "/tmp/Vault", homeDir: home, adapterRoot });
+    const installed = await readFile(path.join(codexDir, "config.toml"), "utf-8");
+    expect(installed).toContain("# BEGIN LEXA MANAGED MCP");
+    expect(installed).toContain("[mcp_servers.lexa]");
+    expect(installed).toContain('@goberomsu/lexa');
+    expect(installed).toContain("[other]");
+    expect(existsSync(path.join(codexDir, "plugins", "lexa", "AGENTS.md"))).toBe(true);
+    expect(existsSync(path.join(codexDir, "rules", "lexa.md"))).toBe(true);
+    expect(existsSync(path.join(codexDir, "skills", "lexa-capture", "SKILL.md"))).toBe(true);
+
+    await runHostOperation({ action: "uninstall", runtime: "codex", vault: "/tmp/Vault", homeDir: home, adapterRoot });
+    const uninstalled = await readFile(path.join(codexDir, "config.toml"), "utf-8");
+    expect(uninstalled).not.toContain("mcp_servers.lexa");
+    expect(uninstalled).toContain("[other]");
+    expect(existsSync(path.join(codexDir, "plugins", "lexa"))).toBe(false);
+    expect(existsSync(path.join(codexDir, "rules", "lexa.md"))).toBe(false);
+    expect(existsSync(path.join(codexDir, "skills", "lexa-capture"))).toBe(false);
+  });
+
+  it("installs and uninstalls Hermes native skill bundle and MCP config", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "lexa-install-hermes-"));
+    await runHostOperation({ action: "install", runtime: "hermes", vault: "/tmp/Vault", homeDir: home, adapterRoot });
+    const config = await readFile(path.join(home, ".hermes", "config.yaml"), "utf-8");
+    expect(config).toContain("lexa:");
+    expect(config).toContain("command: npx");
+    expect(existsSync(path.join(home, ".hermes", "skills", "knowledge-management", "lexa", "capture", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(home, ".hermes", "adapters", "lexa", "SOUL.md"))).toBe(true);
+
+    await runHostOperation({ action: "uninstall", runtime: "hermes", vault: "/tmp/Vault", homeDir: home, adapterRoot });
+    const after = await readFile(path.join(home, ".hermes", "config.yaml"), "utf-8");
+    expect(after).not.toContain("lexa:");
+    expect(existsSync(path.join(home, ".hermes", "skills", "knowledge-management", "lexa"))).toBe(false);
+    expect(existsSync(path.join(home, ".hermes", "adapters", "lexa"))).toBe(false);
+  });
+
+  it("dry-run reports all host plans without mutating home", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "lexa-install-dry-"));
+    const results = await runHostOperation({ action: "install", runtime: "all", vault: "/tmp/Vault", homeDir: home, adapterRoot, dryRun: true });
+    expect(results.map((result) => result.runtime)).toEqual(["claude", "codex", "hermes"]);
+    expect(formatHostOperationResults(results, true)).toContain("dry-run");
+    expect(existsSync(path.join(home, ".codex"))).toBe(false);
+    expect(existsSync(path.join(home, ".hermes"))).toBe(false);
+  });
+});

--- a/src/install/hosts.ts
+++ b/src/install/hosts.ts
@@ -1,0 +1,497 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, lstatSync } from "node:fs";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+
+export type HostRuntime = "claude" | "codex" | "hermes";
+export type RuntimeSelection = HostRuntime | "auto" | "all";
+export type HostAction = "install" | "uninstall";
+
+export interface HostOperationOptions {
+  action: HostAction;
+  runtime: RuntimeSelection;
+  vault: string;
+  packageSpec?: string;
+  dryRun?: boolean;
+  executeExternal?: boolean;
+  yes?: boolean;
+  homeDir?: string;
+  adapterRoot: string;
+}
+
+export interface HostOperationResult {
+  runtime: HostRuntime;
+  action: HostAction;
+  changed: boolean;
+  skipped: boolean;
+  paths: string[];
+  commands: string[];
+  messages: string[];
+}
+
+const HOSTS: HostRuntime[] = ["claude", "codex", "hermes"];
+const MANAGED_CODEX_START = "# BEGIN LEXA MANAGED MCP";
+const MANAGED_CODEX_END = "# END LEXA MANAGED MCP";
+const DEFAULT_PACKAGE_SPEC = "@goberomsu/lexa";
+const CODEX_SKILL_PREFIX = "lexa-";
+const CODEX_RULE_FILENAME = "lexa.md";
+const HERMES_SKILL_CATEGORY = "knowledge-management";
+const HERMES_SKILL_NAME = "lexa";
+
+function commandExists(command: string): boolean {
+  const result = spawnSync(process.platform === "win32" ? "where" : "command", process.platform === "win32" ? [command] : ["-v", command], {
+    stdio: "ignore",
+    shell: process.platform !== "win32",
+  });
+  return result.status === 0;
+}
+
+export function detectAvailableHosts(): HostRuntime[] {
+  const detected: HostRuntime[] = [];
+  if (commandExists("claude")) detected.push("claude");
+  if (commandExists("codex")) detected.push("codex");
+  if (commandExists("hermes")) detected.push("hermes");
+  return detected;
+}
+
+export function resolveRuntimeSelection(selection: RuntimeSelection): HostRuntime[] {
+  if (selection === "all") return [...HOSTS];
+  if (selection === "auto") {
+    const detected = detectAvailableHosts();
+    return detected.length > 0 ? detected : ["claude"];
+  }
+  return [selection];
+}
+
+function hostHome(homeDir: string | undefined, dirname: string, envName: string): string {
+  return process.env[envName] ? path.resolve(process.env[envName]!) : path.join(homeDir ?? homedir(), dirname);
+}
+
+function packageSpec(options: HostOperationOptions): string {
+  return options.packageSpec ?? DEFAULT_PACKAGE_SPEC;
+}
+
+function mcpArgs(options: HostOperationOptions): string[] {
+  return [packageSpec(options), "mcp", "--vault", options.vault];
+}
+
+function jsonString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readJsonObject(file: string): Promise<Record<string, unknown>> {
+  try {
+    const parsed = JSON.parse(await readFile(file, "utf-8")) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeJsonObject(file: string, data: Record<string, unknown>, dryRun: boolean): Promise<boolean> {
+  if (dryRun) return false;
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+  return true;
+}
+
+async function readYamlObject(file: string): Promise<Record<string, unknown>> {
+  try {
+    const parsed = yamlParse(await readFile(file, "utf-8")) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeYamlObject(file: string, data: Record<string, unknown>, dryRun: boolean): Promise<boolean> {
+  if (dryRun) return false;
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, yamlStringify(data), "utf-8");
+  return true;
+}
+
+function mcpServerEntry(options: HostOperationOptions): Record<string, unknown> {
+  return {
+    command: "npx",
+    args: mcpArgs(options),
+  };
+}
+
+function refuseSymlinkedLeaf(target: string): void {
+  if (!existsSync(target)) return;
+  if (lstatSync(target).isSymbolicLink()) {
+    throw new Error(`Refusing to replace symlinked Lexa install target: ${target}`);
+  }
+}
+
+async function replaceDirectory(source: string, target: string, dryRun: boolean): Promise<boolean> {
+  if (dryRun) return false;
+  refuseSymlinkedLeaf(target);
+  await rm(target, { recursive: true, force: true });
+  await mkdir(path.dirname(target), { recursive: true });
+  await cp(source, target, { recursive: true });
+  return true;
+}
+
+async function upsertClaudeMcp(options: HostOperationOptions, claudeDir: string): Promise<boolean> {
+  const mcpPath = path.join(claudeDir, "mcp.json");
+  const data = await readJsonObject(mcpPath);
+  const existingServers = data["mcpServers"];
+  const mcpServers = isRecord(existingServers) ? existingServers : {};
+  mcpServers["lexa"] = mcpServerEntry(options);
+  data["mcpServers"] = mcpServers;
+  return writeJsonObject(mcpPath, data, Boolean(options.dryRun));
+}
+
+async function removeClaudeMcp(options: HostOperationOptions, claudeDir: string): Promise<boolean> {
+  const mcpPath = path.join(claudeDir, "mcp.json");
+  const data = await readJsonObject(mcpPath);
+  const existingServers = data["mcpServers"];
+  if (!isRecord(existingServers) || !("lexa" in existingServers)) return false;
+  delete existingServers["lexa"];
+  data["mcpServers"] = existingServers;
+  return writeJsonObject(mcpPath, data, Boolean(options.dryRun));
+}
+
+function runExternal(command: string, args: string[]): { ok: boolean; message: string } {
+  const result = spawnSync(command, args, { stdio: "pipe", encoding: "utf-8" });
+  if (result.status === 0) return { ok: true, message: `${command} ${args.join(" ")}` };
+  const stderr = result.stderr.trim();
+  const stdout = result.stdout.trim();
+  return { ok: false, message: stderr || stdout || `${command} exited ${result.status ?? "unknown"}` };
+}
+
+async function installClaude(options: HostOperationOptions): Promise<HostOperationResult> {
+  const claudeDir = hostHome(options.homeDir, ".claude", "LEXA_CLAUDE_HOME");
+  const pluginPath = path.join(options.adapterRoot, "claude-code");
+  const commands = [
+    `claude plugin install ${pluginPath}`,
+    `claude mcp add lexa -- npx ${mcpArgs(options).join(" ")}`,
+  ];
+  const messages = ["Claude Code adapter is installed through Claude's plugin/MCP surfaces."];
+  let changed = false;
+
+  if (options.executeExternal) {
+    if (!commandExists("claude")) {
+      messages.push("claude CLI was not found; wrote MCP config only and left plugin command for manual execution.");
+    } else if (!options.dryRun) {
+      const externalCommands: [string, ...string[]][] = [
+        ["claude", "plugin", "install", pluginPath],
+        ["claude", "mcp", "add", "lexa", "--", "npx", ...mcpArgs(options)],
+      ];
+      for (const [command, ...args] of externalCommands) {
+        const result = runExternal(command, args);
+        messages.push(result.ok ? `Executed: ${result.message}` : `External command failed: ${result.message}`);
+        changed = changed || result.ok;
+      }
+    }
+  }
+
+  const mcpChanged = await upsertClaudeMcp(options, claudeDir);
+  changed = changed || mcpChanged;
+
+  return {
+    runtime: "claude",
+    action: "install",
+    changed: changed && !options.dryRun,
+    skipped: false,
+    paths: [path.join(claudeDir, "mcp.json"), pluginPath],
+    commands,
+    messages,
+  };
+}
+
+async function uninstallClaude(options: HostOperationOptions): Promise<HostOperationResult> {
+  const claudeDir = hostHome(options.homeDir, ".claude", "LEXA_CLAUDE_HOME");
+  const commands = ["claude mcp remove lexa", "claude plugin uninstall lexa"];
+  const messages = ["Claude Code uninstall removes the Lexa MCP entry and, when requested, asks Claude CLI to uninstall the plugin."];
+  let changed = await removeClaudeMcp(options, claudeDir);
+
+  if (options.executeExternal && commandExists("claude") && !options.dryRun) {
+    const externalCommands: [string, ...string[]][] = [
+      ["claude", "mcp", "remove", "lexa"],
+      ["claude", "plugin", "uninstall", "lexa"],
+    ];
+    for (const [command, ...args] of externalCommands) {
+      const result = runExternal(command, args);
+      messages.push(result.ok ? `Executed: ${result.message}` : `External command failed: ${result.message}`);
+      changed = changed || result.ok;
+    }
+  }
+
+  return {
+    runtime: "claude",
+    action: "uninstall",
+    changed: changed && !options.dryRun,
+    skipped: false,
+    paths: [path.join(claudeDir, "mcp.json")],
+    commands,
+    messages,
+  };
+}
+
+function codexManagedBlock(options: HostOperationOptions): string {
+  const args = mcpArgs(options).map(jsonString).join(", ");
+  return [
+    MANAGED_CODEX_START,
+    "# Lexa MCP hookup for Codex CLI. Managed by `lexa install/uninstall`.",
+    "# Codex-native rules live in ~/.codex/rules/lexa.md; skills live in ~/.codex/skills/lexa-*.",
+    "[mcp_servers.lexa]",
+    'command = "npx"',
+    `args = [${args}]`,
+    "",
+    "[mcp_servers.lexa.env]",
+    'LEXA_AGENT_RUNTIME = "codex"',
+    MANAGED_CODEX_END,
+    "",
+  ].join("\n");
+}
+
+function isCodexLexaTable(line: string): boolean {
+  return line === "[mcp_servers.lexa]" || line.startsWith("[mcp_servers.lexa.");
+}
+
+function removeManagedCodexBlock(content: string): { content: string; removed: boolean } {
+  const markerPattern = new RegExp(`\\n?${MANAGED_CODEX_START.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\s\\S]*?${MANAGED_CODEX_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\n?`, "g");
+  const withoutMarkers = content.replace(markerPattern, "\n");
+  const markerRemoved = withoutMarkers !== content;
+  const lines = withoutMarkers.split(/\r?\n/);
+  const output: string[] = [];
+  let removedLegacy = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const trimmed = line.trim();
+    if (isCodexLexaTable(trimmed)) {
+      removedLegacy = true;
+      i++;
+      while (i < lines.length) {
+        const next = (lines[i] ?? "").trim();
+        const isTable = /^\[[^\]]+\]$/.test(next);
+        if (isTable && !isCodexLexaTable(next)) {
+          i--;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    if (line.includes("Lexa MCP hookup for Codex CLI")) {
+      removedLegacy = true;
+      continue;
+    }
+    output.push(line);
+  }
+  return { content: output.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n", removed: markerRemoved || removedLegacy };
+}
+
+async function installCodexNativeArtifacts(codexDir: string, options: HostOperationOptions): Promise<string[]> {
+  const paths: string[] = [];
+  const rulesSource = path.join(options.adapterRoot, "codex", "rules", CODEX_RULE_FILENAME);
+  const rulesTarget = path.join(codexDir, "rules", CODEX_RULE_FILENAME);
+  const skillsSource = path.join(options.adapterRoot, "codex", "skills");
+  const skillsTargetRoot = path.join(codexDir, "skills");
+
+  if (!options.dryRun) {
+    await mkdir(path.dirname(rulesTarget), { recursive: true });
+    await cp(rulesSource, rulesTarget);
+    await mkdir(skillsTargetRoot, { recursive: true });
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(skillsSource, { withFileTypes: true });
+    const desired = new Set(entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name));
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const target = path.join(skillsTargetRoot, entry.name);
+      if (!entry.name.startsWith(CODEX_SKILL_PREFIX)) {
+        throw new Error(`Codex skill directory must be namespaced ${CODEX_SKILL_PREFIX}*: ${entry.name}`);
+      }
+      await replaceDirectory(path.join(skillsSource, entry.name), target, false);
+      paths.push(target);
+    }
+    const installed = await readdir(skillsTargetRoot, { withFileTypes: true });
+    for (const entry of installed) {
+      if (entry.isDirectory() && entry.name.startsWith(CODEX_SKILL_PREFIX) && !desired.has(entry.name)) {
+        await rm(path.join(skillsTargetRoot, entry.name), { recursive: true, force: true });
+      }
+    }
+  } else {
+    paths.push(path.join(skillsTargetRoot, `${CODEX_SKILL_PREFIX}setup`));
+  }
+  return [rulesTarget, ...paths];
+}
+
+async function installCodex(options: HostOperationOptions): Promise<HostOperationResult> {
+  const codexDir = hostHome(options.homeDir, ".codex", "LEXA_CODEX_HOME");
+  const pluginSource = path.join(options.adapterRoot, "codex");
+  const pluginTarget = path.join(codexDir, "plugins", "lexa");
+  const configPath = path.join(codexDir, "config.toml");
+  const original = existsSync(configPath) ? await readFile(configPath, "utf-8") : "";
+  const stripped = removeManagedCodexBlock(original).content;
+  const next = `${stripped.trimEnd()}\n\n${codexManagedBlock(options)}`;
+  let nativePaths: string[] = [];
+  if (!options.dryRun) {
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(configPath, next, "utf-8");
+    await replaceDirectory(pluginSource, pluginTarget, false);
+    nativePaths = await installCodexNativeArtifacts(codexDir, options);
+  } else {
+    nativePaths = [
+      path.join(codexDir, "rules", CODEX_RULE_FILENAME),
+      path.join(codexDir, "skills", `${CODEX_SKILL_PREFIX}setup`),
+    ];
+  }
+  return {
+    runtime: "codex",
+    action: "install",
+    changed: !options.dryRun,
+    skipped: false,
+    paths: [configPath, pluginTarget, ...nativePaths],
+    commands: [`Codex MCP config: ${configPath}`],
+    messages: ["Installed Codex-native Lexa rules, namespaced skills, plugin assets, and managed MCP/env config."],
+  };
+}
+
+async function uninstallCodex(options: HostOperationOptions): Promise<HostOperationResult> {
+  const codexDir = hostHome(options.homeDir, ".codex", "LEXA_CODEX_HOME");
+  const pluginTarget = path.join(codexDir, "plugins", "lexa");
+  const configPath = path.join(codexDir, "config.toml");
+  const ruleTarget = path.join(codexDir, "rules", CODEX_RULE_FILENAME);
+  const skillsRoot = path.join(codexDir, "skills");
+  let changed = false;
+  if (existsSync(configPath)) {
+    const original = await readFile(configPath, "utf-8");
+    const removed = removeManagedCodexBlock(original);
+    changed = removed.removed;
+    if (removed.removed && !options.dryRun) await writeFile(configPath, removed.content, "utf-8");
+  }
+  for (const target of [pluginTarget, ruleTarget]) {
+    if (existsSync(target)) {
+      changed = true;
+      if (!options.dryRun) await rm(target, { recursive: true, force: true });
+    }
+  }
+  if (existsSync(skillsRoot)) {
+    const { readdir } = await import("node:fs/promises");
+    for (const entry of await readdir(skillsRoot, { withFileTypes: true })) {
+      if (entry.isDirectory() && entry.name.startsWith(CODEX_SKILL_PREFIX)) {
+        changed = true;
+        if (!options.dryRun) await rm(path.join(skillsRoot, entry.name), { recursive: true, force: true });
+      }
+    }
+  }
+  return {
+    runtime: "codex",
+    action: "uninstall",
+    changed: changed && !options.dryRun,
+    skipped: !changed,
+    paths: [configPath, pluginTarget, ruleTarget, path.join(skillsRoot, `${CODEX_SKILL_PREFIX}*`)],
+    commands: [],
+    messages: ["Removed Codex managed MCP block, Lexa rule, namespaced Lexa skills, and plugin assets."],
+  };
+}
+
+async function upsertHermesMcp(options: HostOperationOptions, hermesConfig: string): Promise<boolean> {
+  const data = await readYamlObject(hermesConfig);
+  const rawServers = data["mcp_servers"];
+  const servers = isRecord(rawServers) ? rawServers : {};
+  servers["lexa"] = { ...mcpServerEntry(options), enabled: true };
+  data["mcp_servers"] = servers;
+  return writeYamlObject(hermesConfig, data, Boolean(options.dryRun));
+}
+
+async function removeHermesMcp(options: HostOperationOptions, hermesConfig: string): Promise<boolean> {
+  const data = await readYamlObject(hermesConfig);
+  const rawServers = data["mcp_servers"];
+  if (!isRecord(rawServers) || !("lexa" in rawServers)) return false;
+  delete rawServers["lexa"];
+  data["mcp_servers"] = rawServers;
+  return writeYamlObject(hermesConfig, data, Boolean(options.dryRun));
+}
+
+async function installHermes(options: HostOperationOptions): Promise<HostOperationResult> {
+  const hermesDir = hostHome(options.homeDir, ".hermes", "LEXA_HERMES_HOME");
+  const pluginSource = path.join(options.adapterRoot, "hermes");
+  const legacyPluginTarget = path.join(hermesDir, "plugins", "lexa");
+  const legacyMcpPath = path.join(hermesDir, "mcp", "lexa.json");
+  const skillSource = path.join(options.adapterRoot, "hermes", "skills");
+  const skillTarget = path.join(hermesDir, "skills", HERMES_SKILL_CATEGORY, HERMES_SKILL_NAME);
+  const configPath = path.join(hermesDir, "config.yaml");
+  const adapterTarget = path.join(hermesDir, "adapters", "lexa");
+  if (!options.dryRun) {
+    await rm(legacyPluginTarget, { recursive: true, force: true });
+    await rm(legacyMcpPath, { force: true });
+    await replaceDirectory(pluginSource, adapterTarget, false);
+    await replaceDirectory(skillSource, skillTarget, false);
+    await upsertHermesMcp(options, configPath);
+  }
+  return {
+    runtime: "hermes",
+    action: "install",
+    changed: !options.dryRun,
+    skipped: false,
+    paths: [adapterTarget, skillTarget, configPath],
+    commands: [`Hermes MCP config: ${configPath}`],
+    messages: ["Installed Hermes-native Lexa skill bundle and registered mcp_servers.lexa in ~/.hermes/config.yaml."],
+  };
+}
+
+async function uninstallHermes(options: HostOperationOptions): Promise<HostOperationResult> {
+  const hermesDir = hostHome(options.homeDir, ".hermes", "LEXA_HERMES_HOME");
+  const adapterTarget = path.join(hermesDir, "adapters", "lexa");
+  const skillTarget = path.join(hermesDir, "skills", HERMES_SKILL_CATEGORY, HERMES_SKILL_NAME);
+  const legacyPluginTarget = path.join(hermesDir, "plugins", "lexa");
+  const legacyMcpPath = path.join(hermesDir, "mcp", "lexa.json");
+  const configPath = path.join(hermesDir, "config.yaml");
+  let changed = false;
+  if (existsSync(configPath)) changed = (await removeHermesMcp(options, configPath)) || changed;
+  for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath]) {
+    if (existsSync(target)) {
+      changed = true;
+      if (!options.dryRun) await rm(target, { recursive: true, force: true });
+    }
+  }
+  return {
+    runtime: "hermes",
+    action: "uninstall",
+    changed: changed && !options.dryRun,
+    skipped: !changed,
+    paths: [adapterTarget, skillTarget, configPath],
+    commands: [],
+    messages: ["Removed Hermes Lexa skill bundle, adapter copy, legacy descriptor files, and mcp_servers.lexa."],
+  };
+}
+
+export async function runHostOperation(options: HostOperationOptions): Promise<HostOperationResult[]> {
+  const runtimes = resolveRuntimeSelection(options.runtime);
+  const results: HostOperationResult[] = [];
+  for (const runtime of runtimes) {
+    if (options.action === "install") {
+      if (runtime === "claude") results.push(await installClaude(options));
+      if (runtime === "codex") results.push(await installCodex(options));
+      if (runtime === "hermes") results.push(await installHermes(options));
+    } else {
+      if (runtime === "claude") results.push(await uninstallClaude(options));
+      if (runtime === "codex") results.push(await uninstallCodex(options));
+      if (runtime === "hermes") results.push(await uninstallHermes(options));
+    }
+  }
+  return results;
+}
+
+export function formatHostOperationResults(results: HostOperationResult[], dryRun: boolean): string {
+  const lines: string[] = [];
+  lines.push(dryRun ? "Lexa host operation plan (dry-run)." : "Lexa host operation complete.");
+  for (const result of results) {
+    lines.push(`- ${result.runtime} ${result.action}: ${result.skipped ? "skipped" : result.changed || dryRun ? "ok" : "no changes"}`);
+    for (const message of result.messages) lines.push(`  ${message}`);
+    for (const filePath of result.paths) lines.push(`  path: ${filePath}`);
+    for (const command of result.commands) lines.push(`  command: ${command}`);
+  }
+  return lines.join("\n");
+}

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -57,3 +57,31 @@ describe("claude-code plugin DoD", () => {
     expect(content).toContain("npx @goberomsu/lexa");
   });
 });
+
+describe("codex and hermes adapter DoD", () => {
+  it("Codex adapter ships native rule, MCP descriptor, and namespaced skills", async () => {
+    const codexRoot = path.join(repoRoot, "adapters", "codex");
+    const raw = await readFile(path.join(codexRoot, ".codex-plugin", "plugin.json"), "utf-8");
+    const plugin = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(plugin["skills"]).toBe("./skills/");
+    expect(plugin["mcpServers"]).toBe("./.mcp.json");
+    await expect(access(path.join(codexRoot, ".mcp.json"))).resolves.toBeUndefined();
+    await expect(access(path.join(codexRoot, "rules", "lexa.md"))).resolves.toBeUndefined();
+
+    for (const name of ["lexa-setup", "lexa-install", "lexa-uninstall", "lexa-doctor", "lexa-capture", "lexa-retrieve"]) {
+      await expect(access(path.join(codexRoot, "skills", name, "SKILL.md"))).resolves.toBeUndefined();
+    }
+  });
+
+  it("Hermes adapter ships a local skill bundle for install", async () => {
+    const hermesRoot = path.join(repoRoot, "adapters", "hermes");
+    const raw = await readFile(path.join(hermesRoot, "manifest.json"), "utf-8");
+    const manifest = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(manifest["skills"]).toBe("./skills/");
+    for (const name of ["setup", "install", "uninstall", "doctor", "capture", "retrieve"]) {
+      await expect(access(path.join(hermesRoot, "skills", name, "SKILL.md"))).resolves.toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Promote Codex and Hermes adapters from stubs to native install surfaces with skills/rules/MCP config.
- Add reversible host install/uninstall logic and installer scripts for the packaged `@goberomsu/lexa` release.
- Bump package and adapter manifests to `0.1.1` and expand release smoke gates to cover native Codex/Hermes assets.

## Verification
- `npm run release:check`
- `git diff --check`

## Notes
- Claude plugin validation still reports the known root `CLAUDE.md` warning, but validation passes.
- Live interactive Codex/Hermes runtime invocation was not performed beyond dry-run host install and package smoke tests.
