### PR TITLE
Use release tarball for Lexa MCP runtime install

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -43,7 +43,7 @@ adapters/<host>/
 
 ### claude-code (REAL installable v0)
 
-Release contract: the npm tarball must include `adapters/claude-code/` because `npx @goberomsu/lexa setup --install-claude` prints a packaged adapter path for `claude plugin install`.
+Release contract: the npm tarball must include `adapters/claude-code/` because `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --install-claude` prints a packaged adapter path for `claude plugin install`.
 
 - **Manifest**: `.claude-plugin/plugin.json`
   - Schema: `{ name, version, description, author, license, keywords, skills: string[] }`
@@ -84,7 +84,7 @@ The MCP server currently exposes status/read/cache/capture tools:
 `lexa_graph_status`, `lexa_graph_build`, `lexa_list_concepts`,
 `lexa_retrieve_by_axis`, `lexa_lazy_load_note`, `lexa_validate_contract`,
 `lexa_capture_prepare`, and `lexa_capture_commit`.
-Capture commit is gated by path-safety, vault-confinement, and contract validation. The CLI (`npx @goberomsu/lexa setup`, `npx @goberomsu/lexa install`, `npx @goberomsu/lexa uninstall`, `npx @goberomsu/lexa doctor`) remains the real surface for lifecycle commands.
+Capture commit is gated by path-safety, vault-confinement, and contract validation. The CLI (`npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor`) remains the real surface for lifecycle commands.
 
 ---
 
@@ -93,6 +93,6 @@ Capture commit is gated by path-safety, vault-confinement, and contract validati
 1. Create `adapters/<host>/`.
 2. Write the host-specific manifest in the correct subdirectory and schema.
 3. Write the convention-file shim (`CLAUDE.md` / `AGENTS.md` / `SOUL.md` / whatever the host uses).
-4. Write skill wrappers that shell out to `npx @goberomsu/lexa <verb>` (for lifecycle) or call the MCP server (for capture/retrieve).
+4. Write skill wrappers that shell out to `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz <verb>` (for lifecycle) or call the MCP server (for capture/retrieve).
 5. Document the host's structural differences in this table.
 6. Do **not** modify `core/` or add host-specific logic to shared code.

--- a/adapters/claude-code/.claude-plugin/plugin.json
+++ b/adapters/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lexa",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Host-agnostic convention layer for Obsidian vaults — capture, retrieve, and validate knowledge under a declared semantic convention.",
   "author": {
     "name": "gobeumsu"

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -8,7 +8,7 @@ This vault is governed by Lexa conventions stored in `.lexa/`.
 All knowledge capture and retrieval must follow the declared semantic convention.
 
 **Before working with vault notes:**
-- Run `npx @goberomsu/lexa doctor` to validate existing notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` to validate existing notes against the convention (exits 0, non-blocking).
 - Read `.lexa/taxonomy.yaml` to understand which folders hold which concepts.
 - Read `.lexa/concepts/*.yaml` to understand field requirements and lenses.
 
@@ -23,4 +23,4 @@ All knowledge capture and retrieval must follow the declared semantic convention
 - Return only the fields the lens specifies — do not dump full frontmatter.
 
 **Convention violations are warnings, not errors (v0).**
-`npx @goberomsu/lexa doctor` always exits 0. Fix violations incrementally.
+`npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` always exits 0. Fix violations incrementally.

--- a/adapters/claude-code/skills/capture/SKILL.md
+++ b/adapters/claude-code/skills/capture/SKILL.md
@@ -27,7 +27,7 @@ after prepare returns `ready` or the user has supplied missing fields.
 5. If required fields are missing, ask for them; do not write.
 6. If placement is ambiguous, route to inbox.
 7. Commit only through `lexa_capture_commit` (`create` or `append`).
-8. Shell out: `npx @goberomsu/lexa doctor` (non-blocking, exits 0) to confirm the note is clean.
+8. Shell out: `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` (non-blocking, exits 0) to confirm the note is clean.
 
 ## Example
 

--- a/adapters/claude-code/skills/define/SKILL.md
+++ b/adapters/claude-code/skills/define/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-define
-description: Grow the vault convention by adding a metadata field to a concept. Entry point is npx @goberomsu/lexa define (roadmap).
+description: Grow the vault convention by adding a metadata field to a concept. Entry point is npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz define (roadmap).
 ---
 
 # Skill: lexa-define (Claude Code)
@@ -19,7 +19,7 @@ Each frontmatter key is a unit of convention with a declared `intent`, type, and
 Intended to shell out to:
 
 ```bash
-npx @goberomsu/lexa define
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz define
 ```
 
 **Roadmap note:** The `lexa define` interactive runtime is not yet implemented in v0.
@@ -34,7 +34,7 @@ Today this skill guides you through the same steps manually (agent-guided).
 5. Choose **required**: yes / no.
 6. Optionally set **normalize** (e.g. `lowercase`) or **immutable** (lock after creation).
 7. Append the entry to `vault/.lexa/concepts/<concept>.yaml`.
-8. Run `npx @goberomsu/lexa doctor` to validate existing notes against the updated schema.
+8. Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` to validate existing notes against the updated schema.
 
 ## YAML snippet to append
 
@@ -48,4 +48,4 @@ fields:
 
 ## When the runtime ships
 
-`npx @goberomsu/lexa define` will run the same Q&A interactively and write the YAML for you.
+`npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz define` will run the same Q&A interactively and write the YAML for you.

--- a/adapters/claude-code/skills/doctor/SKILL.md
+++ b/adapters/claude-code/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-doctor
-description: Validate vault notes against the Lexa convention by running npx @goberomsu/lexa doctor.
+description: Validate vault notes against the Lexa convention by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor.
 ---
 
 # Skill: lexa-doctor (Claude Code)
@@ -19,7 +19,7 @@ This skill is **REAL in v0** — it shells out to the fully-implemented CLI.
 Shells out to:
 
 ```bash
-npx @goberomsu/lexa doctor [--vault <path>]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor [--vault <path>]
 ```
 
 The CLI will:
@@ -39,7 +39,7 @@ The CLI will:
 ## Example
 
 ```bash
-npx @goberomsu/lexa doctor --vault ~/Documents/MyVault
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault ~/Documents/MyVault
 ```
 
 ## Sample output

--- a/adapters/claude-code/skills/retrieve/SKILL.md
+++ b/adapters/claude-code/skills/retrieve/SKILL.md
@@ -18,7 +18,7 @@ Surface the right notes and fields for a given purpose using the vault's declare
 Conceptually shells out to:
 
 ```bash
-npx @goberomsu/lexa retrieve
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz retrieve
 ```
 
 **Runtime note:** Retrieval is available through MCP tools (`lexa_retrieve_by_axis`

--- a/adapters/claude-code/skills/setup/SKILL.md
+++ b/adapters/claude-code/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-setup
-description: Adopt an existing Obsidian vault into the Lexa convention by running npx @goberomsu/lexa setup.
+description: Adopt an existing Obsidian vault into the Lexa convention by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup.
 ---
 
 # Skill: lexa-setup (Claude Code)
@@ -19,8 +19,8 @@ This skill is **REAL in v0** — it shells out to the fully-implemented CLI.
 Shells out to:
 
 ```bash
-npx @goberomsu/lexa setup [--vault <path>] [--yes] [--install-claude]
-npx @goberomsu/lexa install [--runtime <auto|all|claude|codex|hermes>] [--vault <path>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup [--vault <path>] [--yes] [--install-claude]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install [--runtime <auto|all|claude|codex|hermes>] [--vault <path>] [--dry-run] [--execute] [--yes]
 ```
 
 The CLI will:
@@ -43,19 +43,19 @@ The CLI will:
 
 ```bash
 # Interactive (recommended first run):
-npx @goberomsu/lexa setup --vault ~/Documents/MyVault
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault ~/Documents/MyVault
 
 # Non-interactive (CI / scripted):
-npx @goberomsu/lexa setup --vault ~/Documents/MyVault --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault ~/Documents/MyVault --yes
 
 # Preview all host adapter installs:
-npx @goberomsu/lexa install --runtime all --vault ~/Documents/MyVault --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime all --vault ~/Documents/MyVault --dry-run
 
 # Install all host adapter/MCP registrations:
-npx @goberomsu/lexa install --runtime all --vault ~/Documents/MyVault --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime all --vault ~/Documents/MyVault --yes
 
 # Also run external host CLIs where available:
-npx @goberomsu/lexa install --runtime claude --vault ~/Documents/MyVault --yes --execute
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime claude --vault ~/Documents/MyVault --yes --execute
 ```
 
 ## After setup

--- a/adapters/claude-code/skills/uninstall/SKILL.md
+++ b/adapters/claude-code/skills/uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-uninstall
-description: Remove Lexa host adapter and MCP registrations by running npx @goberomsu/lexa uninstall.
+description: Remove Lexa host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall.
 ---
 
 # Skill: lexa-uninstall (Claude Code)
@@ -18,17 +18,17 @@ Remove Lexa host registrations and adapter files. This does **not** delete vault
 Shells out to:
 
 ```bash
-npx @goberomsu/lexa uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
 ```
 
 ## Recommended flow
 
 ```bash
 # Preview first:
-npx @goberomsu/lexa uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --dry-run
 
 # Remove Lexa host registrations:
-npx @goberomsu/lexa uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --yes
 ```
 
 Use `--execute` only when you want Lexa to call external host CLIs such as `claude mcp remove lexa` or `claude plugin uninstall lexa`.

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lexa",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Lexa convention layer for Obsidian vaults — Codex native rules, skills, and MCP adapter.",
   "_note": "lexa install writes Codex MCP config, installs ~/.codex/rules/lexa.md, and installs ~/.codex/skills/lexa-*.",
   "skills": "./skills/",

--- a/adapters/codex/.mcp.json
+++ b/adapters/codex/.mcp.json
@@ -2,7 +2,13 @@
   "mcpServers": {
     "lexa": {
       "command": "npx",
-      "args": ["@goberomsu/lexa", "mcp", "--vault", "."]
+      "args": [
+        "-y",
+        "https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz",
+        "mcp",
+        "--vault",
+        "."
+      ]
     }
   }
 }

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -7,7 +7,7 @@
 This vault is governed by Lexa conventions stored in `.lexa/`.
 
 **Before working with vault notes:**
-- Run `npx @goberomsu/lexa doctor` to validate notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
 - Read `.lexa/taxonomy.yaml` and `.lexa/concepts/*.yaml` for folder and field declarations.
 
 **Capture:** Use `$lexa-capture` skill or follow the librarian persona.

--- a/adapters/codex/rules/lexa.md
+++ b/adapters/codex/rules/lexa.md
@@ -10,10 +10,10 @@ Lexa is a convention harness, not a content generator. The user owns the ontolog
 
 | User intent | Preferred Lexa surface |
 |---|---|
-| adopt a vault | `$lexa-setup` or `npx @goberomsu/lexa setup --vault <path>` |
-| install host integration | `$lexa-install` or `npx @goberomsu/lexa install --runtime codex --vault <path> --yes` |
-| uninstall host integration | `$lexa-uninstall` or `npx @goberomsu/lexa uninstall --runtime codex --yes` |
-| validate notes | `$lexa-doctor` or `npx @goberomsu/lexa doctor --vault <path>` |
+| adopt a vault | `$lexa-setup` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault <path>` |
+| install host integration | `$lexa-install` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime codex --vault <path> --yes` |
+| uninstall host integration | `$lexa-uninstall` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime codex --yes` |
+| validate notes | `$lexa-doctor` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault <path>` |
 | capture knowledge | use MCP `lexa_capture_prepare` then `lexa_capture_commit` |
 | retrieve knowledge | use MCP `lexa_retrieve_by_axis`, then `lexa_lazy_load_note` only when needed |
 

--- a/adapters/codex/skills/lexa-doctor/SKILL.md
+++ b/adapters/codex/skills/lexa-doctor/SKILL.md
@@ -8,7 +8,7 @@ description: Validate vault notes against the active Lexa ontology.
 Run:
 
 ```bash
-npx @goberomsu/lexa doctor --vault <vault>
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault <vault>
 ```
 
 The command is advisory in v0 and exits 0 even when warnings are found.

--- a/adapters/codex/skills/lexa-install/SKILL.md
+++ b/adapters/codex/skills/lexa-install/SKILL.md
@@ -8,7 +8,7 @@ description: Install Lexa Codex/Hermes/Claude host adapters and MCP registration
 Use for host lifecycle installation.
 
 ```bash
-npx @goberomsu/lexa install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
 ```
 
 For Codex, this installs:

--- a/adapters/codex/skills/lexa-setup/SKILL.md
+++ b/adapters/codex/skills/lexa-setup/SKILL.md
@@ -10,13 +10,13 @@ Use when the user wants to initialize Lexa for a vault.
 Run:
 
 ```bash
-npx @goberomsu/lexa setup --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault <vault> --yes
 ```
 
 Then, when host registration is desired:
 
 ```bash
-npx @goberomsu/lexa install --runtime codex --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime codex --vault <vault> --yes
 ```
 
 Do not modify vault notes during setup. Lexa writes only `vault/.lexa/taxonomy.yaml` and `vault/.lexa/concepts/`.

--- a/adapters/codex/skills/lexa-uninstall/SKILL.md
+++ b/adapters/codex/skills/lexa-uninstall/SKILL.md
@@ -8,13 +8,13 @@ description: Remove Lexa host adapter files and MCP registration without deletin
 Preview first:
 
 ```bash
-npx @goberomsu/lexa uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --dry-run
 ```
 
 Remove host registrations:
 
 ```bash
-npx @goberomsu/lexa uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --yes
 ```
 
 Never delete vault notes or `vault/.lexa/` as part of host uninstall.

--- a/adapters/hermes/SOUL.md
+++ b/adapters/hermes/SOUL.md
@@ -7,12 +7,12 @@
 This vault is governed by Lexa conventions stored in `.lexa/`.
 
 **Before working with vault notes:**
-- Run `npx @goberomsu/lexa doctor` to validate notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
 - Read `.lexa/taxonomy.yaml` for folder-to-concept bindings.
 - Read `.lexa/concepts/*.yaml` for field declarations and lenses.
 
 **Capture:** Follow the librarian persona — resolve concept, resolve folder from taxonomy,
-construct required frontmatter, write note, then run `npx @goberomsu/lexa doctor`.
+construct required frontmatter, write note, then run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor`.
 
 **Retrieve:** Follow the retriever persona — identify purpose, match lens, project lens fields only.
 

--- a/adapters/hermes/manifest.json
+++ b/adapters/hermes/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "lexa",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Lexa convention layer for Obsidian vaults — Hermes skill bundle and MCP adapter.",
   "_note": "lexa install writes ~/.hermes/config.yaml mcp_servers.lexa and installs skills under ~/.hermes/skills/knowledge-management/lexa/.",
   "skills": "./skills/"

--- a/adapters/hermes/skills/doctor/SKILL.md
+++ b/adapters/hermes/skills/doctor/SKILL.md
@@ -8,7 +8,7 @@ description: Validate vault notes against the active Lexa ontology.
 Run:
 
 ```bash
-npx @goberomsu/lexa doctor --vault <vault>
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault <vault>
 ```
 
 The command is advisory in v0 and exits 0 even when warnings are found.

--- a/adapters/hermes/skills/install/SKILL.md
+++ b/adapters/hermes/skills/install/SKILL.md
@@ -8,7 +8,7 @@ description: Install Lexa Codex/Hermes/Claude host adapters and MCP registration
 Use for host lifecycle installation.
 
 ```bash
-npx @goberomsu/lexa install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
 ```
 
 For Codex, this installs:

--- a/adapters/hermes/skills/setup/SKILL.md
+++ b/adapters/hermes/skills/setup/SKILL.md
@@ -10,13 +10,13 @@ Use when the user wants to initialize Lexa for a vault.
 Run:
 
 ```bash
-npx @goberomsu/lexa setup --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault <vault> --yes
 ```
 
 Then, when host registration is desired:
 
 ```bash
-npx @goberomsu/lexa install --runtime codex --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime codex --vault <vault> --yes
 ```
 
 Do not modify vault notes during setup. Lexa writes only `vault/.lexa/taxonomy.yaml` and `vault/.lexa/concepts/`.

--- a/adapters/hermes/skills/uninstall/SKILL.md
+++ b/adapters/hermes/skills/uninstall/SKILL.md
@@ -8,13 +8,13 @@ description: Remove Lexa host adapter files and MCP registration without deletin
 Preview first:
 
 ```bash
-npx @goberomsu/lexa uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --dry-run
 ```
 
 Remove host registrations:
 
 ```bash
-npx @goberomsu/lexa uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --yes
 ```
 
 Never delete vault notes or `vault/.lexa/` as part of host uninstall.

--- a/core/skills/uninstall/SKILL.md
+++ b/core/skills/uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-uninstall
-description: Remove Lexa host adapter and MCP registrations by running npx @goberomsu/lexa uninstall.
+description: Remove Lexa host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall.
 ---
 
 # Skill: lexa-uninstall (Claude Code)
@@ -18,17 +18,17 @@ Remove Lexa host registrations and adapter files. This does **not** delete vault
 Shells out to:
 
 ```bash
-npx @goberomsu/lexa uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
 ```
 
 ## Recommended flow
 
 ```bash
 # Preview first:
-npx @goberomsu/lexa uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --dry-run
 
 # Remove Lexa host registrations:
-npx @goberomsu/lexa uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --yes
 ```
 
 Use `--execute` only when you want Lexa to call external host CLIs such as `claude mcp remove lexa` or `claude plugin uninstall lexa`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ All knowledge logic (validation, ontology loading, folder resolution, graph/cach
 │                                                                  │
 │  host ADAPTER                                                    │
 │  ├─ plugin.json / rule+skill bundle / SOUL.md fragment              │
-│  └─ shells out to: npx @goberomsu/lexa setup | lexa doctor | lexa define    │
+│  └─ shells out to: npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup | lexa doctor | lexa define    │
 └───────────────────────────┬──────────────────────────────────────┘
                             │ invokes
                             ▼

--- a/docs/harness-architecture.md
+++ b/docs/harness-architecture.md
@@ -162,7 +162,7 @@ Docs must not describe MCP write/capture runtime as present tense until the serv
 The Phase 1 command surface is intentionally dry-run for Claude runtime registration:
 
 ```bash
-npx @goberomsu/lexa setup --vault /path/to/vault --yes --install-claude
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault /path/to/vault --yes --install-claude
 ```
 
 This initializes `.lexa/` and prints a Claude Code plugin install command plus a `claude mcp add ...` command. It does not mutate Claude config. Capture/write tools are only available through the gated safe-write path.

--- a/docs/install.md
+++ b/docs/install.md
@@ -46,8 +46,8 @@ From a checkout or installed package:
 ```bash
 npm ci
 npm run build
-npx @goberomsu/lexa install --runtime all --vault /path/to/vault --dry-run
-npx @goberomsu/lexa install --runtime all --vault /path/to/vault --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime all --vault /path/to/vault --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime all --vault /path/to/vault --yes
 ```
 
 Runtime selection follows the Ouroboros pattern:
@@ -72,14 +72,14 @@ All host writes are namespaced under `lexa` and are reversible with `lexa uninst
 `setup` still adopts a vault into the Lexa ontology and can print the Claude Code plan:
 
 ```bash
-npx @goberomsu/lexa setup --vault /path/to/vault --yes --install-claude
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault /path/to/vault --yes --install-claude
 ```
 
 Typical printed commands look like:
 
 ```bash
 claude plugin install /path/to/lexa/adapters/claude-code
-claude mcp add lexa -- npx @goberomsu/lexa mcp --vault /path/to/vault
+claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz mcp --vault /path/to/vault
 ```
 
 ## Uninstall
@@ -107,7 +107,7 @@ The uninstaller removes Lexa host registrations and adapter files. It does **not
 ## Verify the install
 
 ```bash
-npx @goberomsu/lexa doctor --vault /path/to/vault
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault /path/to/vault
 lexa install --runtime all --vault /path/to/vault --dry-run
 claude plugin validate adapters/claude-code
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@goberomsu/lexa",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goberomsu/lexa",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goberomsu/lexa",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A host-agnostic, user-owned convention layer for Obsidian (plain-markdown) knowledge bases. Invoked from inside Claude Code, Codex, and Hermes to make knowledge capture and retrieval happen under a declared semantic convention.",
   "type": "module",
   "license": "MIT",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/install.sh | bash
 set -euo pipefail
 
-PACKAGE_SPEC="${LEXA_PACKAGE_SPEC:-https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.1/goberomsu-lexa-0.1.1.tgz}"
+PACKAGE_SPEC="${LEXA_PACKAGE_SPEC:-https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz}"
 RUNTIME="${LEXA_INSTALL_RUNTIME:-auto}"
 VAULT="${LEXA_VAULT:-$PWD}"
 EXECUTE="${LEXA_EXECUTE_EXTERNAL:-0}"

--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -75,7 +75,9 @@ function setupSmoke(packageRoot, vault) {
   assertPath(path.join(vault, ".lexa/taxonomy.yaml"), "vault taxonomy");
   assertPath(path.join(vault, ".lexa/concepts"), "vault concepts directory");
   if (!output.includes("claude plugin install")) fail("setup output did not include Claude plugin install command");
-  if (!output.includes("claude mcp add lexa -- npx @goberomsu/lexa mcp --vault")) fail("setup output did not include Claude MCP registration command");
+  if (!output.includes("claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz mcp --vault")) {
+    fail("setup output did not include Claude MCP registration command");
+  }
   const pluginPathLine = output.split(/\r?\n/).find((line) => line.includes("Plugin path:"));
   if (!pluginPathLine) fail("setup output did not include Plugin path line");
   const pluginPath = pluginPathLine.replace(/^.*Plugin path:\s*/, "").trim();

--- a/src/cli/lexa.ts
+++ b/src/cli/lexa.ts
@@ -17,6 +17,9 @@ import {
 } from "../install/hosts.js";
 import type { Taxonomy, FolderBinding } from "../ontology/types.js";
 
+const DEFAULT_RELEASE_PACKAGE_SPEC =
+  "https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz";
+
 // ---------------------------------------------------------------------------
 // Path helpers
 // ---------------------------------------------------------------------------
@@ -81,7 +84,7 @@ export function buildClaudeInstallPlan(opts: { vault: string }): ClaudeInstallPl
   return {
     pluginPath,
     pluginInstallCommand: `claude plugin install ${shellQuote(pluginPath)}`,
-    mcpRegistrationCommand: `claude mcp add lexa -- npx @goberomsu/lexa mcp --vault ${shellQuote(opts.vault)}`,
+    mcpRegistrationCommand: `claude mcp add lexa -- npx -y ${shellQuote(DEFAULT_RELEASE_PACKAGE_SPEC)} mcp --vault ${shellQuote(opts.vault)}`,
     mcpRuntimeStatus: "read-status-runtime",
   };
 }
@@ -250,7 +253,7 @@ export async function runSetup(opts: {
   console.log(`  Written:  ${path.join(lexaDir, "taxonomy.yaml")}`);
   console.log(`  Concepts: ${copiedFiles.join(", ") || "(none)"}`);
   console.log(`  Folders:  ${Object.keys(folderBindings).join(", ") || "(none)"}`);
-  console.log(`\nRun "npx @goberomsu/lexa doctor" to validate existing notes.\n`);
+  console.log(`\nRun "npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor" to validate existing notes.\n`);
 
   if (installClaude) {
     printClaudeInstallPlan(buildClaudeInstallPlan({ vault }));

--- a/src/install/hosts.test.ts
+++ b/src/install/hosts.test.ts
@@ -24,7 +24,7 @@ describe("host installer/uninstaller", () => {
     const installed = await readFile(path.join(codexDir, "config.toml"), "utf-8");
     expect(installed).toContain("# BEGIN LEXA MANAGED MCP");
     expect(installed).toContain("[mcp_servers.lexa]");
-    expect(installed).toContain('@goberomsu/lexa');
+    expect(installed).toContain("lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz");
     expect(installed).toContain("[other]");
     expect(existsSync(path.join(codexDir, "plugins", "lexa", "AGENTS.md"))).toBe(true);
     expect(existsSync(path.join(codexDir, "rules", "lexa.md"))).toBe(true);

--- a/src/install/hosts.ts
+++ b/src/install/hosts.ts
@@ -34,7 +34,8 @@ export interface HostOperationResult {
 const HOSTS: HostRuntime[] = ["claude", "codex", "hermes"];
 const MANAGED_CODEX_START = "# BEGIN LEXA MANAGED MCP";
 const MANAGED_CODEX_END = "# END LEXA MANAGED MCP";
-const DEFAULT_PACKAGE_SPEC = "@goberomsu/lexa";
+const DEFAULT_PACKAGE_SPEC =
+  "https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz";
 const CODEX_SKILL_PREFIX = "lexa-";
 const CODEX_RULE_FILENAME = "lexa.md";
 const HERMES_SKILL_CATEGORY = "knowledge-management";
@@ -74,7 +75,7 @@ function packageSpec(options: HostOperationOptions): string {
 }
 
 function mcpArgs(options: HostOperationOptions): string[] {
-  return [packageSpec(options), "mcp", "--vault", options.vault];
+  return ["-y", packageSpec(options), "mcp", "--vault", options.vault];
 }
 
 function jsonString(value: string): string {

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -50,11 +50,11 @@ describe("claude-code plugin DoD", () => {
     }
   });
 
-  it("the setup skill SKILL.md mentions 'npx @goberomsu/lexa'", async () => {
+  it("the setup skill SKILL.md mentions 'npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz'", async () => {
     // The setup skill entry is "./skills/setup/" relative to the plugin root.
     const setupSkillPath = path.resolve(pluginRoot, "./skills/setup/SKILL.md");
     const content = await readFile(setupSkillPath, "utf-8");
-    expect(content).toContain("npx @goberomsu/lexa");
+    expect(content).toContain("npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz");
   });
 });
 

--- a/src/setup.e2e.test.ts
+++ b/src/setup.e2e.test.ts
@@ -60,7 +60,7 @@ describe("runSetup --yes E2E", () => {
     expect(plan.pluginPath).toContain("adapters/claude-code");
     expect(plan.pluginInstallCommand).toContain("claude plugin install");
     expect(plan.mcpRegistrationCommand).toBe(
-      "claude mcp add lexa -- npx @goberomsu/lexa mcp --vault '/tmp/My Vault'",
+      "claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz mcp --vault '/tmp/My Vault'",
     );
     expect(plan.mcpRuntimeStatus).toBe("read-status-runtime");
   });


### PR DESCRIPTION
## Summary
- Bump Lexa to `0.1.2`.
- Switch generated MCP registrations from `npx @goberomsu/lexa` to `npx -y <GitHub release tarball>` so installs work before npm publication exists.
- Update host docs/skills/tests and release smoke expectations to match the tarball runtime path.

## Verification
- `npm run release:check`
- `node dist/cli/lexa.js install --runtime all --vault /tmp/Vault --dry-run`
- `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.1/goberomsu-lexa-0.1.1.tgz --help`

## Release note
The `0.1.1` GitHub release exists, but this PR supersedes it because npm registry resolution is not available yet. `0.1.2` should be the installable release asset.
