### PR TITLE
Rename npm package surface to lxa-vault

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -43,7 +43,7 @@ adapters/<host>/
 
 ### claude-code (REAL installable v0)
 
-Release contract: the npm tarball must include `adapters/claude-code/` because `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --install-claude` prints a packaged adapter path for `claude plugin install`.
+Release contract: the npm tarball must include `adapters/claude-code/` because `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup --install-claude` prints a packaged adapter path for `claude plugin install`.
 
 - **Manifest**: `.claude-plugin/plugin.json`
   - Schema: `{ name, version, description, author, license, keywords, skills: string[] }`
@@ -60,7 +60,7 @@ Release contract: the npm tarball must include `adapters/claude-code/` because `
   - Schema differs from claude-code: codex uses a unified `codex-native-hook.mjs` instead of `hooks.json`.
   - Skills are invoked with `$` sigil instead of `/`.
 - **Convention file**: `AGENTS.md` — append `adapters/codex/AGENTS.md` to your project's `AGENTS.md`.
-- **Status**: v0 native install. `lexa install --runtime codex` installs `~/.codex/rules/lexa.md`, namespaced `~/.codex/skills/lexa-*`, a managed `[mcp_servers.lexa]` block in `~/.codex/config.toml`, and a copy of the adapter under `~/.codex/plugins/lexa`.
+- **Status**: v0 native install. `lxa install --runtime codex` installs `~/.codex/rules/lexa.md`, namespaced `~/.codex/skills/lexa-*`, a managed `[mcp_servers.lexa]` block in `~/.codex/config.toml`, and a copy of the adapter under `~/.codex/plugins/lexa`.
 
 ### hermes (native skills + MCP install v0)
 
@@ -68,7 +68,7 @@ Release contract: the npm tarball must include `adapters/claude-code/` because `
   - Hermes skills register on agentskills.io; no local manifest equivalent exists yet.
 - **Convention file**: `SOUL.md` + context files — append `adapters/hermes/SOUL.md` to your Hermes session context.
 - **Sigil**: N/A (Hermes uses built-in tools + MCP, not a `/`/`$` sigil system).
-- **Status**: v0 native install. `lexa install --runtime hermes` installs the skill bundle under `~/.hermes/skills/knowledge-management/lexa/`, registers `mcp_servers.lexa` in `~/.hermes/config.yaml`, and keeps an adapter copy under `~/.hermes/adapters/lexa`.
+- **Status**: v0 native install. `lxa install --runtime hermes` installs the skill bundle under `~/.hermes/skills/knowledge-management/lexa/`, registers `mcp_servers.lexa` in `~/.hermes/config.yaml`, and keeps an adapter copy under `~/.hermes/adapters/lexa`.
 
 ---
 
@@ -78,13 +78,13 @@ The cross-host mechanism is an **MCP server** (`src/mcp/server.ts`) that exposes
 contract validation, retrieve, graph/status, and gated capture tools.
 
 All three hosts natively support MCP (`.mcp.json` for claude-code and codex; "any MCP server" for Hermes).
-In the current repository, `src/mcp/server.ts` starts a real stdio MCP server via `lexa mcp`.
+In the current repository, `src/mcp/server.ts` starts a real stdio MCP server via `lxa mcp`.
 
 The MCP server currently exposes status/read/cache/capture tools:
 `lexa_graph_status`, `lexa_graph_build`, `lexa_list_concepts`,
 `lexa_retrieve_by_axis`, `lexa_lazy_load_note`, `lexa_validate_contract`,
 `lexa_capture_prepare`, and `lexa_capture_commit`.
-Capture commit is gated by path-safety, vault-confinement, and contract validation. The CLI (`npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor`) remains the real surface for lifecycle commands.
+Capture commit is gated by path-safety, vault-confinement, and contract validation. The CLI (`npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall`, `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor`) remains the real surface for lifecycle commands.
 
 ---
 
@@ -93,6 +93,6 @@ Capture commit is gated by path-safety, vault-confinement, and contract validati
 1. Create `adapters/<host>/`.
 2. Write the host-specific manifest in the correct subdirectory and schema.
 3. Write the convention-file shim (`CLAUDE.md` / `AGENTS.md` / `SOUL.md` / whatever the host uses).
-4. Write skill wrappers that shell out to `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz <verb>` (for lifecycle) or call the MCP server (for capture/retrieve).
+4. Write skill wrappers that shell out to `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz <verb>` (for lifecycle) or call the MCP server (for capture/retrieve).
 5. Document the host's structural differences in this table.
 6. Do **not** modify `core/` or add host-specific logic to shared code.

--- a/adapters/claude-code/.claude-plugin/plugin.json
+++ b/adapters/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lexa",
-  "version": "0.1.2",
-  "description": "Host-agnostic convention layer for Obsidian vaults — capture, retrieve, and validate knowledge under a declared semantic convention.",
+  "version": "0.1.3",
+  "description": "Host-agnostic convention layer for Obsidian vaults \u2014 capture, retrieve, and validate knowledge under a declared semantic convention.",
   "author": {
     "name": "gobeumsu"
   },

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -8,7 +8,7 @@ This vault is governed by Lexa conventions stored in `.lexa/`.
 All knowledge capture and retrieval must follow the declared semantic convention.
 
 **Before working with vault notes:**
-- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` to validate existing notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` to validate existing notes against the convention (exits 0, non-blocking).
 - Read `.lexa/taxonomy.yaml` to understand which folders hold which concepts.
 - Read `.lexa/concepts/*.yaml` to understand field requirements and lenses.
 
@@ -23,4 +23,4 @@ All knowledge capture and retrieval must follow the declared semantic convention
 - Return only the fields the lens specifies — do not dump full frontmatter.
 
 **Convention violations are warnings, not errors (v0).**
-`npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` always exits 0. Fix violations incrementally.
+`npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` always exits 0. Fix violations incrementally.

--- a/adapters/claude-code/skills/capture/SKILL.md
+++ b/adapters/claude-code/skills/capture/SKILL.md
@@ -27,7 +27,7 @@ after prepare returns `ready` or the user has supplied missing fields.
 5. If required fields are missing, ask for them; do not write.
 6. If placement is ambiguous, route to inbox.
 7. Commit only through `lexa_capture_commit` (`create` or `append`).
-8. Shell out: `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` (non-blocking, exits 0) to confirm the note is clean.
+8. Shell out: `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` (non-blocking, exits 0) to confirm the note is clean.
 
 ## Example
 

--- a/adapters/claude-code/skills/define/SKILL.md
+++ b/adapters/claude-code/skills/define/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-define
-description: Grow the vault convention by adding a metadata field to a concept. Entry point is npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz define (roadmap).
+description: Grow the vault convention by adding a metadata field to a concept. Entry point is npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz define (roadmap).
 ---
 
 # Skill: lexa-define (Claude Code)
@@ -19,10 +19,10 @@ Each frontmatter key is a unit of convention with a declared `intent`, type, and
 Intended to shell out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz define
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz define
 ```
 
-**Roadmap note:** The `lexa define` interactive runtime is not yet implemented in v0.
+**Roadmap note:** The `lxa define` interactive runtime is not yet implemented in v0.
 Today this skill guides you through the same steps manually (agent-guided).
 
 ## Agent-guided steps (v0)
@@ -34,7 +34,7 @@ Today this skill guides you through the same steps manually (agent-guided).
 5. Choose **required**: yes / no.
 6. Optionally set **normalize** (e.g. `lowercase`) or **immutable** (lock after creation).
 7. Append the entry to `vault/.lexa/concepts/<concept>.yaml`.
-8. Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` to validate existing notes against the updated schema.
+8. Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` to validate existing notes against the updated schema.
 
 ## YAML snippet to append
 
@@ -48,4 +48,4 @@ fields:
 
 ## When the runtime ships
 
-`npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz define` will run the same Q&A interactively and write the YAML for you.
+`npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz define` will run the same Q&A interactively and write the YAML for you.

--- a/adapters/claude-code/skills/doctor/SKILL.md
+++ b/adapters/claude-code/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-doctor
-description: Validate vault notes against the Lexa convention by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor.
+description: Validate vault notes against the Lexa convention by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor.
 ---
 
 # Skill: lexa-doctor (Claude Code)
@@ -19,7 +19,7 @@ This skill is **REAL in v0** — it shells out to the fully-implemented CLI.
 Shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor [--vault <path>]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor [--vault <path>]
 ```
 
 The CLI will:
@@ -39,7 +39,7 @@ The CLI will:
 ## Example
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault ~/Documents/MyVault
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor --vault ~/Documents/MyVault
 ```
 
 ## Sample output
@@ -54,5 +54,5 @@ Checked 12 notes. 2 violations found. (exits 0)
 
 ## Roadmap
 
-Doctor is fully real in v0. Run it after any `lexa setup`, `lexa define`,
+Doctor is fully real in v0. Run it after any `lxa setup`, `lxa define`,
 or bulk note edit to keep your vault clean.

--- a/adapters/claude-code/skills/retrieve/SKILL.md
+++ b/adapters/claude-code/skills/retrieve/SKILL.md
@@ -18,7 +18,7 @@ Surface the right notes and fields for a given purpose using the vault's declare
 Conceptually shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz retrieve
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz retrieve
 ```
 
 **Runtime note:** Retrieval is available through MCP tools (`lexa_retrieve_by_axis`

--- a/adapters/claude-code/skills/setup/SKILL.md
+++ b/adapters/claude-code/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-setup
-description: Adopt an existing Obsidian vault into the Lexa convention by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup.
+description: Adopt an existing Obsidian vault into the Lexa convention by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup.
 ---
 
 # Skill: lexa-setup (Claude Code)
@@ -19,8 +19,8 @@ This skill is **REAL in v0** — it shells out to the fully-implemented CLI.
 Shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup [--vault <path>] [--yes] [--install-claude]
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install [--runtime <auto|all|claude|codex|hermes>] [--vault <path>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup [--vault <path>] [--yes] [--install-claude]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install [--runtime <auto|all|claude|codex|hermes>] [--vault <path>] [--dry-run] [--execute] [--yes]
 ```
 
 The CLI will:
@@ -43,19 +43,19 @@ The CLI will:
 
 ```bash
 # Interactive (recommended first run):
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault ~/Documents/MyVault
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup --vault ~/Documents/MyVault
 
 # Non-interactive (CI / scripted):
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault ~/Documents/MyVault --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup --vault ~/Documents/MyVault --yes
 
 # Preview all host adapter installs:
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime all --vault ~/Documents/MyVault --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime all --vault ~/Documents/MyVault --dry-run
 
 # Install all host adapter/MCP registrations:
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime all --vault ~/Documents/MyVault --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime all --vault ~/Documents/MyVault --yes
 
 # Also run external host CLIs where available:
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime claude --vault ~/Documents/MyVault --yes --execute
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime claude --vault ~/Documents/MyVault --yes --execute
 ```
 
 ## After setup
@@ -64,7 +64,7 @@ Run `/lexa-doctor` to validate your existing notes against the convention.
 
 ## Roadmap
 
-Setup plus `lexa install`/`lexa uninstall` host lifecycle commands are real and release-gated by unpacked npm tarball smoke tests. The MCP command starts
+Setup plus `lxa install`/`lxa uninstall` host lifecycle commands are real and release-gated by unpacked npm tarball smoke tests. The MCP command starts
 the status/read/cache/capture runtime (`lexa_graph_status`, `lexa_graph_build`,
 `lexa_list_concepts`, `lexa_retrieve_by_axis`, `lexa_lazy_load_note`,
 `lexa_validate_contract`, `lexa_capture_prepare`, `lexa_capture_commit`).

--- a/adapters/claude-code/skills/uninstall/SKILL.md
+++ b/adapters/claude-code/skills/uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-uninstall
-description: Remove Lexa host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall.
+description: Remove Lexa host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall.
 ---
 
 # Skill: lexa-uninstall (Claude Code)
@@ -18,17 +18,17 @@ Remove Lexa host registrations and adapter files. This does **not** delete vault
 Shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
 ```
 
 ## Recommended flow
 
 ```bash
 # Preview first:
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime all --dry-run
 
 # Remove Lexa host registrations:
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime all --yes
 ```
 
 Use `--execute` only when you want Lexa to call external host CLIs such as `claude mcp remove lexa` or `claude plugin uninstall lexa`.

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "lexa",
-  "version": "0.1.2",
-  "description": "Lexa convention layer for Obsidian vaults — Codex native rules, skills, and MCP adapter.",
-  "_note": "lexa install writes Codex MCP config, installs ~/.codex/rules/lexa.md, and installs ~/.codex/skills/lexa-*.",
+  "version": "0.1.3",
+  "description": "Lexa convention layer for Obsidian vaults \u2014 Codex native rules, skills, and MCP adapter.",
+  "_note": "lxa install writes Codex MCP config, installs ~/.codex/rules/lexa.md, and installs ~/.codex/skills/lexa-*.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/adapters/codex/.mcp.json
+++ b/adapters/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz",
+        "https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz",
         "mcp",
         "--vault",
         "."

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -7,10 +7,10 @@
 This vault is governed by Lexa conventions stored in `.lexa/`.
 
 **Before working with vault notes:**
-- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
 - Read `.lexa/taxonomy.yaml` and `.lexa/concepts/*.yaml` for folder and field declarations.
 
 **Capture:** Use `$lexa-capture` skill or follow the librarian persona.
 **Retrieve:** Use `$lexa-retrieve` skill or follow the retriever persona with declared lenses.
 
-> **v0 native install:** `lexa install --runtime codex` installs Codex rules, `$lexa-*` skills, and a managed Codex MCP config. Use Lexa MCP tools for capture/retrieve and CLI commands for lifecycle.
+> **v0 native install:** `lxa install --runtime codex` installs Codex rules, `$lexa-*` skills, and a managed Codex MCP config. Use Lexa MCP tools for capture/retrieve and CLI commands for lifecycle.

--- a/adapters/codex/rules/lexa.md
+++ b/adapters/codex/rules/lexa.md
@@ -10,10 +10,10 @@ Lexa is a convention harness, not a content generator. The user owns the ontolog
 
 | User intent | Preferred Lexa surface |
 |---|---|
-| adopt a vault | `$lexa-setup` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault <path>` |
-| install host integration | `$lexa-install` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime codex --vault <path> --yes` |
-| uninstall host integration | `$lexa-uninstall` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime codex --yes` |
-| validate notes | `$lexa-doctor` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault <path>` |
+| adopt a vault | `$lexa-setup` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup --vault <path>` |
+| install host integration | `$lexa-install` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime codex --vault <path> --yes` |
+| uninstall host integration | `$lexa-uninstall` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime codex --yes` |
+| validate notes | `$lexa-doctor` or `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor --vault <path>` |
 | capture knowledge | use MCP `lexa_capture_prepare` then `lexa_capture_commit` |
 | retrieve knowledge | use MCP `lexa_retrieve_by_axis`, then `lexa_lazy_load_note` only when needed |
 

--- a/adapters/codex/skills/lexa-doctor/SKILL.md
+++ b/adapters/codex/skills/lexa-doctor/SKILL.md
@@ -8,7 +8,7 @@ description: Validate vault notes against the active Lexa ontology.
 Run:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault <vault>
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor --vault <vault>
 ```
 
 The command is advisory in v0 and exits 0 even when warnings are found.

--- a/adapters/codex/skills/lexa-install/SKILL.md
+++ b/adapters/codex/skills/lexa-install/SKILL.md
@@ -8,7 +8,7 @@ description: Install Lexa Codex/Hermes/Claude host adapters and MCP registration
 Use for host lifecycle installation.
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
 ```
 
 For Codex, this installs:

--- a/adapters/codex/skills/lexa-setup/SKILL.md
+++ b/adapters/codex/skills/lexa-setup/SKILL.md
@@ -10,13 +10,13 @@ Use when the user wants to initialize Lexa for a vault.
 Run:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup --vault <vault> --yes
 ```
 
 Then, when host registration is desired:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime codex --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime codex --vault <vault> --yes
 ```
 
 Do not modify vault notes during setup. Lexa writes only `vault/.lexa/taxonomy.yaml` and `vault/.lexa/concepts/`.

--- a/adapters/codex/skills/lexa-uninstall/SKILL.md
+++ b/adapters/codex/skills/lexa-uninstall/SKILL.md
@@ -8,13 +8,13 @@ description: Remove Lexa host adapter files and MCP registration without deletin
 Preview first:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime all --dry-run
 ```
 
 Remove host registrations:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime all --yes
 ```
 
 Never delete vault notes or `vault/.lexa/` as part of host uninstall.

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -1,6 +1,6 @@
 # Lexa Hermes Adapter
 
-Installed by `lexa install --runtime hermes` into:
+Installed by `lxa install --runtime hermes` into:
 
 - `~/.hermes/skills/knowledge-management/lexa/`
 - `~/.hermes/config.yaml` as `mcp_servers.lexa`

--- a/adapters/hermes/SOUL.md
+++ b/adapters/hermes/SOUL.md
@@ -7,13 +7,13 @@
 This vault is governed by Lexa conventions stored in `.lexa/`.
 
 **Before working with vault notes:**
-- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
 - Read `.lexa/taxonomy.yaml` for folder-to-concept bindings.
 - Read `.lexa/concepts/*.yaml` for field declarations and lenses.
 
 **Capture:** Follow the librarian persona — resolve concept, resolve folder from taxonomy,
-construct required frontmatter, write note, then run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor`.
+construct required frontmatter, write note, then run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor`.
 
 **Retrieve:** Follow the retriever persona — identify purpose, match lens, project lens fields only.
 
-> **v0 native install:** `lexa install --runtime hermes` installs a Hermes skill bundle and registers Lexa MCP in `~/.hermes/config.yaml`. Use Lexa MCP tools for capture/retrieve and CLI commands for lifecycle.
+> **v0 native install:** `lxa install --runtime hermes` installs a Hermes skill bundle and registers Lexa MCP in `~/.hermes/config.yaml`. Use Lexa MCP tools for capture/retrieve and CLI commands for lifecycle.

--- a/adapters/hermes/manifest.json
+++ b/adapters/hermes/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "lexa",
-  "version": "0.1.2",
-  "description": "Lexa convention layer for Obsidian vaults — Hermes skill bundle and MCP adapter.",
-  "_note": "lexa install writes ~/.hermes/config.yaml mcp_servers.lexa and installs skills under ~/.hermes/skills/knowledge-management/lexa/.",
+  "version": "0.1.3",
+  "description": "Lexa convention layer for Obsidian vaults \u2014 Hermes skill bundle and MCP adapter.",
+  "_note": "lxa install writes ~/.hermes/config.yaml mcp_servers.lexa and installs skills under ~/.hermes/skills/knowledge-management/lexa/.",
   "skills": "./skills/"
 }

--- a/adapters/hermes/skills/doctor/SKILL.md
+++ b/adapters/hermes/skills/doctor/SKILL.md
@@ -8,7 +8,7 @@ description: Validate vault notes against the active Lexa ontology.
 Run:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault <vault>
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor --vault <vault>
 ```
 
 The command is advisory in v0 and exits 0 even when warnings are found.

--- a/adapters/hermes/skills/install/SKILL.md
+++ b/adapters/hermes/skills/install/SKILL.md
@@ -8,7 +8,7 @@ description: Install Lexa Codex/Hermes/Claude host adapters and MCP registration
 Use for host lifecycle installation.
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
 ```
 
 For Codex, this installs:

--- a/adapters/hermes/skills/setup/SKILL.md
+++ b/adapters/hermes/skills/setup/SKILL.md
@@ -10,13 +10,13 @@ Use when the user wants to initialize Lexa for a vault.
 Run:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup --vault <vault> --yes
 ```
 
 Then, when host registration is desired:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime codex --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime codex --vault <vault> --yes
 ```
 
 Do not modify vault notes during setup. Lexa writes only `vault/.lexa/taxonomy.yaml` and `vault/.lexa/concepts/`.

--- a/adapters/hermes/skills/uninstall/SKILL.md
+++ b/adapters/hermes/skills/uninstall/SKILL.md
@@ -8,13 +8,13 @@ description: Remove Lexa host adapter files and MCP registration without deletin
 Preview first:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime all --dry-run
 ```
 
 Remove host registrations:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime all --yes
 ```
 
 Never delete vault notes or `vault/.lexa/` as part of host uninstall.

--- a/core/skills/capture/SKILL.md
+++ b/core/skills/capture/SKILL.md
@@ -18,7 +18,7 @@ The librarian persona governs this action.
    - Fill optional fields where values are known.
    - Leave undeclared (extra) frontmatter fields untouched (`additionalProperties: preserve`).
 5. Write the note body after the frontmatter block.
-6. Run `npx lexa doctor` (non-blocking, exits 0) to confirm the new note passes field validation.
+6. Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` (non-blocking, exits 0) to confirm the new note passes field validation.
 
 ## Conceptual shell-out (roadmap — NOT wired in v0)
 
@@ -40,7 +40,7 @@ User: "Save this paper: 'Attention Is All You Need', arxiv.org/abs/1706.03762"
      source-url: "https://arxiv.org/abs/1706.03762"
      captured-at: "2026-05-31"
 5. write note body
-6. npx lexa doctor  ← verify (exits 0, non-blocking)
+6. npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor  ← verify (exits 0, non-blocking)
 ```
 
 ## Persona

--- a/core/skills/define/SKILL.md
+++ b/core/skills/define/SKILL.md
@@ -12,7 +12,7 @@ type, and optional rules (`required`, `normalize`, `immutable`).
 ## Entry point
 
 ```bash
-npx lexa define
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz define
 ```
 
 This is the intended user-facing command (roadmap: interactive runtime not built yet).
@@ -27,7 +27,7 @@ Use `define` as **agent-guided convention editing** until the interactive runtim
 4. Ask: **type** (`string` | `string[]` | `date` | `url` | `boolean`), **required** (yes/no).
 5. Optionally ask: `normalize` (e.g. `lowercase`), `immutable` (lock after creation).
 6. Open `vault/.lexa/concepts/<concept>.yaml` and append the new field entry.
-7. Run `npx lexa doctor` to validate existing notes against the updated schema (exits 0).
+7. Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` to validate existing notes against the updated schema (exits 0).
 
 ## Convention YAML shape (one field entry)
 
@@ -55,5 +55,5 @@ vault/.lexa/
   taxonomy.yaml
 ```
 
-Lexa ships defaults (from `core/ontology/`); `lexa setup` copies them into the vault.
+Lexa ships defaults (from `core/ontology/`); `lxa setup` copies them into the vault.
 The user then edits them at will — Lexa only enforces, never overwrites.

--- a/core/skills/doctor/SKILL.md
+++ b/core/skills/doctor/SKILL.md
@@ -11,7 +11,7 @@ This skill is **REAL in v0** — the CLI command is fully implemented.
 ## Shell-out
 
 ```bash
-npx lexa doctor [--vault <path>]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor [--vault <path>]
 ```
 
 - `--vault <path>` — path to your Obsidian vault root (default: current directory).
@@ -40,10 +40,10 @@ Undeclared frontmatter fields are **never** reported as violations
 
 ## Recommended usage
 
-Run `npx lexa doctor` after:
-- Any `lexa setup` run
-- Adding a new field via `lexa define`
+Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` after:
+- Any `lxa setup` run
+- Adding a new field via `lxa define`
 - Bulk-editing notes
 
-Integrate into CI by adding `npx lexa doctor --vault ./vault` to your workflow.
+Integrate into CI by adding `npx lxa doctor --vault ./vault` to your workflow.
 It will never fail the build in v0.

--- a/core/skills/setup/SKILL.md
+++ b/core/skills/setup/SKILL.md
@@ -11,7 +11,7 @@ This skill is **REAL in v0** — the CLI command is fully implemented.
 ## Shell-out
 
 ```bash
-npx lexa setup [--vault <path>] [--yes]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup [--vault <path>] [--yes]
 ```
 
 - `--vault <path>` — path to your Obsidian vault root (default: current directory).
@@ -27,7 +27,7 @@ npx lexa setup [--vault <path>] [--yes]
 6. Copies the shipped default concepts into `vault/.lexa/concepts/`.
 
 After setup, the vault is governed by Lexa conventions.
-Run `npx lexa doctor` at any time to validate existing notes.
+Run `npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor` at any time to validate existing notes.
 
 ## What setup does NOT do
 
@@ -40,5 +40,5 @@ Run `npx lexa doctor` at any time to validate existing notes.
 Run the `doctor` skill to check your notes against the convention:
 
 ```bash
-npx lexa doctor [--vault <path>]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor [--vault <path>]
 ```

--- a/core/skills/uninstall/SKILL.md
+++ b/core/skills/uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lexa-uninstall
-description: Remove Lexa host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall.
+description: Remove Lexa host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall.
 ---
 
 # Skill: lexa-uninstall (Claude Code)
@@ -18,17 +18,17 @@ Remove Lexa host registrations and adapter files. This does **not** delete vault
 Shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
 ```
 
 ## Recommended flow
 
 ```bash
 # Preview first:
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime all --dry-run
 
 # Remove Lexa host registrations:
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz uninstall --runtime all --yes
 ```
 
 Use `--execute` only when you want Lexa to call external host CLIs such as `claude mcp remove lexa` or `claude plugin uninstall lexa`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ All knowledge logic (validation, ontology loading, folder resolution, graph/cach
 | Convention file | `CLAUDE.md` / `AGENTS.md` | `AGENTS.md` | `SOUL.md` + context files |
 | Local vault access | yes | yes | yes |
 
-`adapters/claude-code/`, `adapters/codex/`, and `adapters/hermes/` all ship installable v0 host surfaces. `lexa install` copies host assets, installs Codex/Hermes skills or rules where the host expects them, and writes host MCP registration.
+`adapters/claude-code/`, `adapters/codex/`, and `adapters/hermes/` all ship installable v0 host surfaces. `lxa install` copies host assets, installs Codex/Hermes skills or rules where the host expects them, and writes host MCP registration.
 
 ## Flow Diagram
 
@@ -47,7 +47,7 @@ All knowledge logic (validation, ontology loading, folder resolution, graph/cach
 │                                                                  │
 │  host ADAPTER                                                    │
 │  ├─ plugin.json / rule+skill bundle / SOUL.md fragment              │
-│  └─ shells out to: npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup | lexa doctor | lexa define    │
+│  └─ shells out to: npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup | lxa doctor | lxa define    │
 └───────────────────────────┬──────────────────────────────────────┘
                             │ invokes
                             ▼
@@ -77,13 +77,13 @@ All knowledge logic (validation, ontology loading, folder resolution, graph/cach
 
 ## MCP Backbone — Current Boundary and Roadmap
 
-MCP is the shared cross-host transport for retrieve, graph/status, validation, cache, and safe capture operations. In the current repository, `src/mcp/server.ts` starts a real stdio MCP server through `lexa mcp`.
+MCP is the shared cross-host transport for retrieve, graph/status, validation, cache, and safe capture operations. In the current repository, `src/mcp/server.ts` starts a real stdio MCP server through `lxa mcp`.
 
 The correct runtime framing is:
 
 1. **Now**: CLI setup/doctor and convention engine are real; Claude Code skills exist as installable/guided surfaces.
-2. **Next**: install shell can print exact dry-run Claude plugin and MCP registration commands (`lexa setup --install-claude`) without claiming a live runtime.
-3. **Now in Phase 2**: real stdio MCP read/status tools are available through `lexa mcp`.
+2. **Next**: install shell can print exact dry-run Claude plugin and MCP registration commands (`lxa setup --install-claude`) without claiming a live runtime.
+3. **Now in Phase 2**: real stdio MCP read/status tools are available through `lxa mcp`.
 4. **Now in Phase 3**: derived graph/search cache tools are available for axis-first retrieval and lazy body load.
 5. **Now in Phase 4**: safe capture prepare/commit tools are available after path-safety and vault-confinement tests.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -118,7 +118,7 @@ Each frontmatter key is an independent unit of convention and a retrieval axis. 
 1. Open the concept file in `vault/.lexa/concepts/<concept>.yaml`.
 2. Append a new entry under `fields:`.
 3. Provide at minimum `name`, `type`, and `intent`. Set `required: true` only for keys that every note in that folder must have.
-4. Run `lexa doctor` — it will report any existing notes that are now missing the new required field (as warnings, never blocking).
+4. Run `lxa doctor` — it will report any existing notes that are now missing the new required field (as warnings, never blocking).
 
 You never need to add all fields upfront. Start with the two or three that matter for your current retrieval use case and grow the convention over time. Good capture is measured by future retrieval quality: if a field helps you find and reuse notes later, it is a strong candidate axis.
 
@@ -136,7 +136,7 @@ Example: a `synthesis` retrieval view can show citation fields needed for writin
 
 ## taxonomy.yaml
 
-The taxonomy binds folders to concepts and gives each folder a declared `intent`. `lexa setup` generates this file by scanning your vault's existing top-level folders — it never imposes a folder structure.
+The taxonomy binds folders to concepts and gives each folder a declared `intent`. `lxa setup` generates this file by scanning your vault's existing top-level folders — it never imposes a folder structure.
 
 ```yaml
 # vault/.lexa/taxonomy.yaml
@@ -173,11 +173,11 @@ A folder with `concept: null` is still meaningful: its `intent` tells agents wha
 
 ### `onViolation: warn` (non-blocking in v0)
 
-When `validateFrontmatter` finds a violation it returns a `ValidationResult { valid, violations[] }` and **never throws**. The `lexa doctor` command prints a violation summary and always exits 0. This means:
+When `validateFrontmatter` finds a violation it returns a `ValidationResult { valid, violations[] }` and **never throws**. The `lxa doctor` command prints a violation summary and always exits 0. This means:
 
 - A missing required field is surfaced as a warning, not an error.
 - Agent workflows are never blocked by a convention mismatch.
-- You can run `lexa doctor` at any time with zero risk of breaking a build.
+- You can run `lxa doctor` at any time with zero risk of breaking a build.
 
 ### `additionalProperties: preserve`
 
@@ -189,10 +189,10 @@ A field may be declared `immutable: true`. In v0 this is recorded in the schema 
 
 ## User Ownership
 
-Lexa ships default concepts in `core/ontology/` (inside the npm package). Running `lexa setup` copies them into `vault/.lexa/concepts/` — from that point on, **you own those files**. Lexa enforces whatever you declare; it does not pull updates over the files you have edited.
+Lexa ships default concepts in `core/ontology/` (inside the npm package). Running `lxa setup` copies them into `vault/.lexa/concepts/` — from that point on, **you own those files**. Lexa enforces whatever you declare; it does not pull updates over the files you have edited.
 
 The separation is:
 - `core/ontology/` — Lexa's shipped defaults (read-only from your perspective).
 - `vault/.lexa/` — your live convention (user-owned, edited freely, never overwritten by Lexa after setup).
 
-To reset a concept to the shipped default, delete the file in `vault/.lexa/concepts/` and re-run `lexa setup`.
+To reset a concept to the shipped default, delete the file in `vault/.lexa/concepts/` and re-run `lxa setup`.

--- a/docs/decisions/0001-validate-returns-result.md
+++ b/docs/decisions/0001-validate-returns-result.md
@@ -51,7 +51,7 @@ The function collects all violations into an array and returns them. It does not
 
 The `immutable` rule within `Violation.rule` is intentionally kept in the union even though no code path emits it in v0. When a field is declared `immutable: true`, the field is validated for presence and type only; the immutability constraint is silently skipped. JSDoc on the function states this explicitly.
 
-`lexa doctor` inspects the returned `ValidationResult`, formats violations as human-readable warnings, and **exits 0 regardless of `valid`**. There is no exit code that signals "convention violated" in v0.
+`lxa doctor` inspects the returned `ValidationResult`, formats violations as human-readable warnings, and **exits 0 regardless of `valid`**. There is no exit code that signals "convention violated" in v0.
 
 ## Consequences
 
@@ -75,5 +75,5 @@ A throwing implementation would align with the fail-fast style common in parsers
 This was rejected because:
 
 1. Lexa's declared enforcement policy is `onViolation: warn`. An exception-throwing function implements `onViolation: error` at the API level and forces every caller to add try/catch boilerplate to recover the non-blocking behavior promised by the policy.
-2. `lexa doctor` needs to validate an entire vault and report a summary. A throwing validator would require either catching and continuing in a loop (awkward) or a separate "collect" wrapper on top of the throwing function (duplication).
+2. `lxa doctor` needs to validate an entire vault and report a summary. A throwing validator would require either catching and continuing in a loop (awkward) or a separate "collect" wrapper on top of the throwing function (duplication).
 3. Host agents invoking validation inside a larger workflow must not be aborted by a missing frontmatter field. The convention layer must be transparent to the host's own error handling.

--- a/docs/harness-architecture.md
+++ b/docs/harness-architecture.md
@@ -152,7 +152,7 @@ Current-vs-target boundary:
 | Phase | Status | Scope |
 |---|---|---|
 | Phase 0 | docs/plan | This architecture and terminology lock. |
-| Phase 1 | install shell | Claude Code skills, `lexa setup`, and dry-run MCP registration guidance. |
+| Phase 1 | install shell | Claude Code skills, `lxa setup`, and dry-run MCP registration guidance. |
 | Phase 2 | runtime | Real stdio MCP read/status tools: `lexa_graph_status`, `lexa_list_concepts`, and `lexa_validate_contract`. Write tools remain gated. |
 | Phase 3 | derived cache | Ontology graph/search cache, invalidation slices, axis-first retrieval, and qmd-style lazy body access. |
 | Phase 4 | safe writes | Capture prepare/commit tools after path-safety and vault-confinement tests. |
@@ -162,7 +162,7 @@ Docs must not describe MCP write/capture runtime as present tense until the serv
 The Phase 1 command surface is intentionally dry-run for Claude runtime registration:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault /path/to/vault --yes --install-claude
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup --vault /path/to/vault --yes --install-claude
 ```
 
 This initializes `.lexa/` and prints a Claude Code plugin install command plus a `claude mcp add ...` command. It does not mutate Claude config. Capture/write tools are only available through the gated safe-write path.

--- a/docs/install.md
+++ b/docs/install.md
@@ -46,8 +46,8 @@ From a checkout or installed package:
 ```bash
 npm ci
 npm run build
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime all --vault /path/to/vault --dry-run
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz install --runtime all --vault /path/to/vault --yes
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime all --vault /path/to/vault --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz install --runtime all --vault /path/to/vault --yes
 ```
 
 Runtime selection follows the Ouroboros pattern:
@@ -65,21 +65,21 @@ Runtime selection follows the Ouroboros pattern:
 | Codex | Installs `~/.codex/rules/lexa.md`, `~/.codex/skills/lexa-*`, copies adapter files to `~/.codex/plugins/lexa`, and writes a managed `[mcp_servers.lexa]` block plus `LEXA_AGENT_RUNTIME=codex` env in `~/.codex/config.toml`. |
 | Hermes | Installs `~/.hermes/skills/knowledge-management/lexa/`, copies adapter files to `~/.hermes/adapters/lexa`, and writes `mcp_servers.lexa` in `~/.hermes/config.yaml`. |
 
-All host writes are namespaced under `lexa` and are reversible with `lexa uninstall`.
+All host writes are namespaced under `lexa` and are reversible with `lxa uninstall`.
 
 ## Legacy setup flow
 
 `setup` still adopts a vault into the Lexa ontology and can print the Claude Code plan:
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz setup --vault /path/to/vault --yes --install-claude
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz setup --vault /path/to/vault --yes --install-claude
 ```
 
 Typical printed commands look like:
 
 ```bash
 claude plugin install /path/to/lexa/adapters/claude-code
-claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz mcp --vault /path/to/vault
+claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz mcp --vault /path/to/vault
 ```
 
 ## Uninstall
@@ -87,13 +87,13 @@ claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/downloa
 Preview first:
 
 ```bash
-lexa uninstall --runtime all --dry-run
+lxa uninstall --runtime all --dry-run
 ```
 
 Remove host registrations and adapter files:
 
 ```bash
-lexa uninstall --runtime all --yes
+lxa uninstall --runtime all --yes
 ```
 
 One-line uninstall:
@@ -107,8 +107,8 @@ The uninstaller removes Lexa host registrations and adapter files. It does **not
 ## Verify the install
 
 ```bash
-npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor --vault /path/to/vault
-lexa install --runtime all --vault /path/to/vault --dry-run
+npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor --vault /path/to/vault
+lxa install --runtime all --vault /path/to/vault --dry-run
 claude plugin validate adapters/claude-code
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -81,7 +81,7 @@ The v0 release workflow is **manual dispatch only** so the operator must provide
 
 Before the first public release:
 
-1. Verify that the scoped `@goberomsu/lexa` npm package name is available to the publisher.
+1. Verify that the scoped `lxa-vault` npm package name is available to the publisher.
 2. Bump `package.json` to a real semver release.
 3. Keep `adapters/claude-code/.claude-plugin/plugin.json` version in sync with `package.json` unless a future ADR deliberately splits package/plugin versioning.
 4. Confirm release notes list Codex rules/skills and Hermes skill-bundle install paths, plus the MCP registration files that make capture/retrieve tools available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
-  "name": "@goberomsu/lexa",
-  "version": "0.1.2",
+  "name": "lxa-vault",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@goberomsu/lexa",
-      "version": "0.1.2",
+      "name": "lxa-vault",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "yaml": "^2.5.0"
       },
       "bin": {
+        "lxa": "dist/cli/lexa.js",
         "lexa": "dist/cli/lexa.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "@goberomsu/lexa",
-  "version": "0.1.2",
+  "name": "lxa-vault",
+  "version": "0.1.3",
   "description": "A host-agnostic, user-owned convention layer for Obsidian (plain-markdown) knowledge bases. Invoked from inside Claude Code, Codex, and Hermes to make knowledge capture and retrieval happen under a declared semantic convention.",
   "type": "module",
   "license": "MIT",
   "bin": {
+    "lxa": "dist/cli/lexa.js",
     "lexa": "dist/cli/lexa.js"
   },
   "main": "dist/index.js",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/GoBeromsu/lexa/main/scripts/install.sh | bash
 set -euo pipefail
 
-PACKAGE_SPEC="${LEXA_PACKAGE_SPEC:-https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz}"
+PACKAGE_SPEC="${LEXA_PACKAGE_SPEC:-https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz}"
 RUNTIME="${LEXA_INSTALL_RUNTIME:-auto}"
 VAULT="${LEXA_VAULT:-$PWD}"
 EXECUTE="${LEXA_EXECUTE_EXTERNAL:-0}"
@@ -39,7 +39,11 @@ if [ "$EXECUTE" = "1" ]; then
   ARGS+=(--execute)
 fi
 
-lexa "${ARGS[@]}"
+if command -v lxa >/dev/null 2>&1; then
+  lxa "${ARGS[@]}"
+else
+  lexa "${ARGS[@]}"
+fi
 
 echo
-echo "Lexa install complete. Run: lexa doctor --vault \"$VAULT\""
+echo "Lexa install complete. Run: lxa doctor --vault \"$VAULT\""

--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -75,7 +75,7 @@ function setupSmoke(packageRoot, vault) {
   assertPath(path.join(vault, ".lexa/taxonomy.yaml"), "vault taxonomy");
   assertPath(path.join(vault, ".lexa/concepts"), "vault concepts directory");
   if (!output.includes("claude plugin install")) fail("setup output did not include Claude plugin install command");
-  if (!output.includes("claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz mcp --vault")) {
+  if (!output.includes("claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz mcp --vault")) {
     fail("setup output did not include Claude MCP registration command");
   }
   const pluginPathLine = output.split(/\r?\n/).find((line) => line.includes("Plugin path:"));

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -44,13 +44,16 @@ if [ "$EXECUTE" = "1" ]; then
   ARGS+=(--execute)
 fi
 
-if command -v lexa >/dev/null 2>&1; then
+if command -v lxa >/dev/null 2>&1; then
+  lxa "${ARGS[@]}"
+elif command -v lexa >/dev/null 2>&1; then
   lexa "${ARGS[@]}"
 else
-  echo "lexa binary not found; skipping host deregistration." >&2
+  echo "lxa/lexa binary not found; skipping host deregistration." >&2
 fi
 
 if [ "$REMOVE_PACKAGE" = "1" ] && command -v npm >/dev/null 2>&1; then
+  npm uninstall -g lxa-vault || true
   npm uninstall -g @goberomsu/lexa || true
 fi
 

--- a/src/cli/lexa.ts
+++ b/src/cli/lexa.ts
@@ -18,7 +18,7 @@ import {
 import type { Taxonomy, FolderBinding } from "../ontology/types.js";
 
 const DEFAULT_RELEASE_PACKAGE_SPEC =
-  "https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz";
+  "https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz";
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -220,7 +220,7 @@ export async function runSetup(opts: {
 
   // Write the vault-local ontology. `.lexa/` IS the ontology directory:
   // `.lexa/taxonomy.yaml` + `.lexa/concepts/*.yaml`, matching loadOntology's
-  // contract so `lexa doctor` can load it directly.
+  // contract so `lxa doctor` can load it directly.
   const lexaDir = path.join(vault, ".lexa");
   const conceptsOutDir = path.join(lexaDir, "concepts");
   await mkdir(conceptsOutDir, { recursive: true });
@@ -253,7 +253,7 @@ export async function runSetup(opts: {
   console.log(`  Written:  ${path.join(lexaDir, "taxonomy.yaml")}`);
   console.log(`  Concepts: ${copiedFiles.join(", ") || "(none)"}`);
   console.log(`  Folders:  ${Object.keys(folderBindings).join(", ") || "(none)"}`);
-  console.log(`\nRun "npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz doctor" to validate existing notes.\n`);
+  console.log(`\nRun "npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz doctor" to validate existing notes.\n`);
 
   if (installClaude) {
     printClaudeInstallPlan(buildClaudeInstallPlan({ vault }));
@@ -336,14 +336,14 @@ export async function runDoctor(opts: { vault: string }): Promise<number> {
 
 function printUsage(): void {
   console.log(`
-lexa — convention layer for Obsidian vaults
+lxa — Lexa convention layer for Obsidian vaults
 
 Usage:
-  lexa setup [--vault <path>] [--yes] [--install-claude]
-  lexa install [--vault <path>] [--runtime <auto|all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
-  lexa uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
-  lexa doctor [--vault <path>]
-  lexa mcp [--vault <path>]
+  lxa setup [--vault <path>] [--yes] [--install-claude]
+  lxa install [--vault <path>] [--runtime <auto|all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+  lxa uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+  lxa doctor [--vault <path>]
+  lxa mcp [--vault <path>]
 
 Commands:
   setup    Adopt an existing vault into the Lexa convention.

--- a/src/install/hosts.test.ts
+++ b/src/install/hosts.test.ts
@@ -24,7 +24,7 @@ describe("host installer/uninstaller", () => {
     const installed = await readFile(path.join(codexDir, "config.toml"), "utf-8");
     expect(installed).toContain("# BEGIN LEXA MANAGED MCP");
     expect(installed).toContain("[mcp_servers.lexa]");
-    expect(installed).toContain("lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz");
+    expect(installed).toContain("lxa-v0.1.3/lxa-vault-0.1.3.tgz");
     expect(installed).toContain("[other]");
     expect(existsSync(path.join(codexDir, "plugins", "lexa", "AGENTS.md"))).toBe(true);
     expect(existsSync(path.join(codexDir, "rules", "lexa.md"))).toBe(true);

--- a/src/install/hosts.ts
+++ b/src/install/hosts.ts
@@ -35,7 +35,7 @@ const HOSTS: HostRuntime[] = ["claude", "codex", "hermes"];
 const MANAGED_CODEX_START = "# BEGIN LEXA MANAGED MCP";
 const MANAGED_CODEX_END = "# END LEXA MANAGED MCP";
 const DEFAULT_PACKAGE_SPEC =
-  "https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz";
+  "https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz";
 const CODEX_SKILL_PREFIX = "lexa-";
 const CODEX_RULE_FILENAME = "lexa.md";
 const HERMES_SKILL_CATEGORY = "knowledge-management";
@@ -242,7 +242,7 @@ function codexManagedBlock(options: HostOperationOptions): string {
   const args = mcpArgs(options).map(jsonString).join(", ");
   return [
     MANAGED_CODEX_START,
-    "# Lexa MCP hookup for Codex CLI. Managed by `lexa install/uninstall`.",
+    "# Lexa MCP hookup for Codex CLI. Managed by `lxa install/uninstall`.",
     "# Codex-native rules live in ~/.codex/rules/lexa.md; skills live in ~/.codex/skills/lexa-*.",
     "[mcp_servers.lexa]",
     'command = "npx"',

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -50,11 +50,11 @@ describe("claude-code plugin DoD", () => {
     }
   });
 
-  it("the setup skill SKILL.md mentions 'npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz'", async () => {
+  it("the setup skill SKILL.md mentions 'npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz'", async () => {
     // The setup skill entry is "./skills/setup/" relative to the plugin root.
     const setupSkillPath = path.resolve(pluginRoot, "./skills/setup/SKILL.md");
     const content = await readFile(setupSkillPath, "utf-8");
-    expect(content).toContain("npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz");
+    expect(content).toContain("npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz");
   });
 });
 

--- a/src/setup.e2e.test.ts
+++ b/src/setup.e2e.test.ts
@@ -60,7 +60,7 @@ describe("runSetup --yes E2E", () => {
     expect(plan.pluginPath).toContain("adapters/claude-code");
     expect(plan.pluginInstallCommand).toContain("claude plugin install");
     expect(plan.mcpRegistrationCommand).toBe(
-      "claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lexa-v0.1.2/goberomsu-lexa-0.1.2.tgz mcp --vault '/tmp/My Vault'",
+      "claude mcp add lexa -- npx -y https://github.com/GoBeromsu/lexa/releases/download/lxa-v0.1.3/lxa-vault-0.1.3.tgz mcp --vault '/tmp/My Vault'",
     );
     expect(plan.mcpRuntimeStatus).toBe("read-status-runtime");
   });


### PR DESCRIPTION
## Summary
- Rename the npm package surface from `@goberomsu/lexa` to `lxa-vault`.
- Add `lxa` as the primary executable while retaining `lexa` as a compatibility alias.
- Move generated install/MCP release tarball references to `lxa-v0.1.3/lxa-vault-0.1.3.tgz`.

## Why not `lxa` package directly?
`npm view lxa` shows an existing package (`lxa@1.0.0`, lexical analysis / regex engine), so the exact unscoped package name is unavailable. This keeps the user-facing command as `lxa` without colliding on npm.

## Verification
- `npm run release:check`
- `node dist/cli/lexa.js --help`
- `node dist/cli/lexa.js install --runtime all --vault /tmp/Vault --dry-run`
- `npm pack --json`
