### PR TITLE
Guard OMS releases against stale legacy dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "node scripts/clean-dist.mjs && tsc -p tsconfig.json",
     "lint": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "audit": "npm audit --omit=dev",

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { rmSync } from "node:fs";
+
+rmSync("dist", { recursive: true, force: true });

--- a/scripts/release-pack.mjs
+++ b/scripts/release-pack.mjs
@@ -69,6 +69,19 @@ if (missing.length > 0) {
   fail(`package tarball is missing required release assets:\n${missing.map((item) => `  - ${item}`).join("\n")}\nUpdate package.json files or create the missing release docs.`);
 }
 
+const forbidden = [
+  "dist/cli/lexa.js",
+  "dist/cli/lexa.d.ts",
+  "dist/cli/lexa.js.map",
+  "adapters/codex/rules/lexa.md",
+  "adapters/codex/skills/lexa-setup/SKILL.md",
+  "adapters/codex/skills/lexa-capture/SKILL.md",
+  "adapters/codex/skills/lexa-retrieve/SKILL.md",
+].filter((forbiddenPath) => hasPath(files, forbiddenPath));
+if (forbidden.length > 0) {
+  fail(`package tarball includes forbidden legacy OMS assets:\n${forbidden.map((item) => `  - ${item}`).join("\n")}`);
+}
+
 const packageJson = JSON.parse(readFileSync("package.json", "utf-8"));
 const pluginJson = JSON.parse(readFileSync("adapters/claude-code/.claude-plugin/plugin.json", "utf-8"));
 if (packageJson.version !== pluginJson.version) {


### PR DESCRIPTION
## Summary
- Clean `dist/` before every build so renamed CLI outputs cannot leave stale files in release tarballs.
- Add release-pack forbidden-path checks for removed Lexa/Codex assets.

## Verification
- `npm run release:check`
- `npm pack --json` confirmed no legacy `lexa`/`lxa` file paths in the package listing.
