### PR TITLE
Finish OMS naming inside packaged core guidance

### DIFF
--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -1,16 +1,16 @@
-# Lexa Vault Convention — SSOT for Host Agents
+# OMS Vault Convention — SSOT for Host Agents
 
 This file is the authoritative reference a host agent (Claude Code, Codex, Hermes, or any
-other) reads when working inside a Lexa-managed vault. It explains the convention model so
+other) reads when working inside a OMS-managed vault. It explains the convention model so
 the agent understands *why* knowledge is organized the way it is — not just *where*.
 
 ---
 
 ## What is a Convention?
 
-A Lexa **convention** is declarative semantic data the **user owns**. It lives in
-`vault/.lexa/` (copied there by `lexa setup`; Lexa ships the defaults in `core/ontology/`).
-The user edits it freely. Lexa enforces whatever is declared — it does not impose structure.
+A OMS **convention** is declarative semantic data the **user owns**. It lives in
+`vault/.oms/` (copied there by `oms setup`; OMS ships the defaults in `core/ontology/`).
+The user edits it freely. OMS enforces whatever is declared — it does not impose structure.
 
 The convention has four building blocks:
 
@@ -88,17 +88,17 @@ A folder may bind to one concept, multiple concepts (list), or `null` (not yet a
 | `onViolation` | `warn` | Violations are logged but never block writes (v0 is non-blocking). |
 | `additionalProperties` | `preserve` | Frontmatter keys not declared in the concept are left untouched. |
 
-Lexa enforces what the user declared; it does not touch anything else.
+OMS enforces what the user declared; it does not touch anything else.
 
 ---
 
 ## User Ownership
 
-1. `lexa setup` scans the vault's existing top-level folders and creates `vault/.lexa/`.
-2. It copies shipped default concepts into `vault/.lexa/concepts/` and writes
-   `vault/.lexa/taxonomy.yaml` — seeded with the user's real folders.
+1. `oms setup` scans the vault's existing top-level folders and creates `vault/.oms/`.
+2. It copies shipped default concepts into `vault/.oms/concepts/` and writes
+   `vault/.oms/taxonomy.yaml` — seeded with the user's real folders.
 3. The user fills in `intent` values and adds or removes fields/lenses freely.
-4. Lexa never imposes a folder structure; it adopts what already exists.
+4. OMS never imposes a folder structure; it adopts what already exists.
 
 ---
 

--- a/core/agents/librarian.md
+++ b/core/agents/librarian.md
@@ -18,10 +18,10 @@ It reads the convention first, then acts.
 ## Responsibilities
 
 1. **Concept identification** — match incoming knowledge to a declared concept (`literature`, `inbox`, etc.) by comparing content and purpose against each concept's `intent`.
-2. **Folder resolution** — look up the correct target folder from `vault/.lexa/taxonomy.yaml` based on the matched concept.
+2. **Folder resolution** — look up the correct target folder from `vault/.oms/taxonomy.yaml` based on the matched concept.
 3. **Frontmatter construction** — fill every `required: true` field; fill known optional fields; leave undeclared fields untouched.
 4. **Note creation** — write the file at the resolved path; use the concept's naming convention (default: `YYYY-MM-DD-<slug>.md`).
-5. **Post-capture validation** — run `npx lexa doctor` (non-blocking) to confirm the new note is clean.
+5. **Post-capture validation** — run `npx oms doctor` (non-blocking) to confirm the new note is clean.
 
 ## Decision rules
 

--- a/core/agents/retriever.md
+++ b/core/agents/retriever.md
@@ -27,7 +27,7 @@ then returns only the lens-selected fields.
 
 ```
 1. Parse user purpose → keyword(s)
-2. For each concept in vault/.lexa/concepts/*.yaml:
+2. For each concept in vault/.oms/concepts/*.yaml:
      for each lens in concept.lenses:
        score = semantic_overlap(purpose, lens.intent)
 3. Select lens with highest score


### PR DESCRIPTION
## Summary
- Rename packaged core agent guidance from Lexa/.lexa to OMS/.oms.
- Keep the OMS-only release tarball internally consistent.

## Verification
- `npm run release:check`
- Old-name grep over packaged source only leaves release-pack forbidden-path guard strings.
