### PR TITLE
Name the project Oh My Second Brain

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation-slice.md
+++ b/.github/ISSUE_TEMPLATE/implementation-slice.md
@@ -1,6 +1,6 @@
 ---
 name: Implementation slice
-about: Plan one focused OMS implementation issue
+about: Plan one focused Oh My Second Brain implementation issue
 ---
 
 ## Goal

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,4 @@
 ## Risks / follow-ups
 
 ## Reference policy check
-- [ ] If OMC was referenced, the PR keeps the attribution explicit and does not broaden OMS scope wholesale.
+- [ ] If OMC was referenced, the PR keeps the attribution explicit and does not broaden Oh My Second Brain scope wholesale.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -2,7 +2,7 @@
 
 ## Principle
 
-OMS's **core** (ontology loading, convention validation, graph/search runtime targets, and MCP server once implemented) is written once.
+Oh My Second Brain's **core** (ontology loading, convention validation, graph/search runtime targets, and MCP server once implemented) is written once.
 Each **adapter** absorbs exactly one host's structural differences — manifest schema,
 hook format, invocation sigil, and convention-file name — so adding a new host
 means adding one new adapter directory, not touching core.
@@ -43,7 +43,7 @@ adapters/<host>/
 
 ### claude-code (REAL installable v0)
 
-Release contract: the npm tarball must include `adapters/claude-code/` because `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup --install-claude` prints a packaged adapter path for `claude plugin install`.
+Release contract: the npm tarball must include `adapters/claude-code/` because `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup --install-claude` prints a packaged adapter path for `claude plugin install`.
 
 - **Manifest**: `.claude-plugin/plugin.json`
   - Schema: `{ name, version, description, author, license, keywords, skills: string[] }`
@@ -84,7 +84,7 @@ The MCP server currently exposes status/read/cache/capture tools:
 `oms_graph_status`, `oms_graph_build`, `oms_list_concepts`,
 `oms_retrieve_by_axis`, `oms_lazy_load_note`, `oms_validate_contract`,
 `oms_capture_prepare`, and `oms_capture_commit`.
-Capture commit is gated by path-safety, vault-confinement, and contract validation. The CLI (`npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup`, `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install`, `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall`, `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor`) remains the real surface for lifecycle commands.
+Capture commit is gated by path-safety, vault-confinement, and contract validation. The CLI (`npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup`, `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install`, `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall`, `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor`) remains the real surface for lifecycle commands.
 
 ---
 
@@ -93,6 +93,6 @@ Capture commit is gated by path-safety, vault-confinement, and contract validati
 1. Create `adapters/<host>/`.
 2. Write the host-specific manifest in the correct subdirectory and schema.
 3. Write the convention-file shim (`CLAUDE.md` / `AGENTS.md` / `SOUL.md` / whatever the host uses).
-4. Write skill wrappers that shell out to `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz <verb>` (for lifecycle) or call the MCP server (for capture/retrieve).
+4. Write skill wrappers that shell out to `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz <verb>` (for lifecycle) or call the MCP server (for capture/retrieve).
 5. Document the host's structural differences in this table.
 6. Do **not** modify `core/` or add host-specific logic to shared code.

--- a/adapters/claude-code/.claude-plugin/plugin.json
+++ b/adapters/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oms",
-  "version": "0.1.4",
-  "description": "Host-agnostic convention layer for Obsidian vaults \u2014 capture, retrieve, and validate knowledge under a declared semantic convention.",
+  "version": "0.1.5",
+  "description": "Oh My Second Brain convention layer for Obsidian vaults \u2014 capture, retrieve, and validate knowledge under a declared semantic convention.",
   "author": {
     "name": "gobeumsu"
   },

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -1,14 +1,14 @@
-# OMS Convention Fragment
+# Oh My Second Brain Convention Fragment
 
-<!-- Append this block to your project's CLAUDE.md to activate OMS conventions in Claude Code. -->
+<!-- Append this block to your project's CLAUDE.md to activate Oh My Second Brain conventions in Claude Code. -->
 
-## Vault Convention (OMS)
+## Vault Convention (Oh My Second Brain)
 
-This vault is governed by OMS conventions stored in `.oms/`.
+This vault is governed by Oh My Second Brain conventions stored in `.oms/`.
 All knowledge capture and retrieval must follow the declared semantic convention.
 
 **Before working with vault notes:**
-- Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` to validate existing notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` to validate existing notes against the convention (exits 0, non-blocking).
 - Read `.oms/taxonomy.yaml` to understand which folders hold which concepts.
 - Read `.oms/concepts/*.yaml` to understand field requirements and lenses.
 
@@ -23,4 +23,4 @@ All knowledge capture and retrieval must follow the declared semantic convention
 - Return only the fields the lens specifies — do not dump full frontmatter.
 
 **Convention violations are warnings, not errors (v0).**
-`npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` always exits 0. Fix violations incrementally.
+`npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` always exits 0. Fix violations incrementally.

--- a/adapters/claude-code/skills/capture/SKILL.md
+++ b/adapters/claude-code/skills/capture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oms-capture
-description: Capture knowledge into the vault under the OMS convention using gated MCP prepare/commit tools.
+description: Capture knowledge into the vault under the Oh My Second Brain convention using gated MCP prepare/commit tools.
 ---
 
 # Skill: oms-capture (Claude Code)
@@ -27,7 +27,7 @@ after prepare returns `ready` or the user has supplied missing fields.
 5. If required fields are missing, ask for them; do not write.
 6. If placement is ambiguous, route to inbox.
 7. Commit only through `oms_capture_commit` (`create` or `append`).
-8. Shell out: `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` (non-blocking, exits 0) to confirm the note is clean.
+8. Shell out: `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` (non-blocking, exits 0) to confirm the note is clean.
 
 ## Example
 

--- a/adapters/claude-code/skills/define/SKILL.md
+++ b/adapters/claude-code/skills/define/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oms-define
-description: Grow the vault convention by adding a metadata field to a concept. Entry point is npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz define (roadmap).
+description: Grow the vault convention by adding a metadata field to a concept. Entry point is npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz define (roadmap).
 ---
 
 # Skill: oms-define (Claude Code)
@@ -19,7 +19,7 @@ Each frontmatter key is a unit of convention with a declared `intent`, type, and
 Intended to shell out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz define
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz define
 ```
 
 **Roadmap note:** The `oms define` interactive runtime is not yet implemented in v0.
@@ -34,7 +34,7 @@ Today this skill guides you through the same steps manually (agent-guided).
 5. Choose **required**: yes / no.
 6. Optionally set **normalize** (e.g. `lowercase`) or **immutable** (lock after creation).
 7. Append the entry to `vault/.oms/concepts/<concept>.yaml`.
-8. Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` to validate existing notes against the updated schema.
+8. Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` to validate existing notes against the updated schema.
 
 ## YAML snippet to append
 
@@ -48,4 +48,4 @@ fields:
 
 ## When the runtime ships
 
-`npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz define` will run the same Q&A interactively and write the YAML for you.
+`npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz define` will run the same Q&A interactively and write the YAML for you.

--- a/adapters/claude-code/skills/doctor/SKILL.md
+++ b/adapters/claude-code/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oms-doctor
-description: Validate vault notes against the OMS convention by running npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor.
+description: Validate vault notes against the Oh My Second Brain convention by running npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor.
 ---
 
 # Skill: oms-doctor (Claude Code)
@@ -19,7 +19,7 @@ This skill is **REAL in v0** — it shells out to the fully-implemented CLI.
 Shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor [--vault <path>]
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor [--vault <path>]
 ```
 
 The CLI will:
@@ -39,7 +39,7 @@ The CLI will:
 ## Example
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor --vault ~/Documents/MyVault
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor --vault ~/Documents/MyVault
 ```
 
 ## Sample output

--- a/adapters/claude-code/skills/retrieve/SKILL.md
+++ b/adapters/claude-code/skills/retrieve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oms-retrieve
-description: Retrieve knowledge from the vault through declared OMS retrieval views and axes (agent-guided; runtime is roadmap).
+description: Retrieve knowledge from the vault through declared Oh My Second Brain retrieval views and axes (agent-guided; runtime is roadmap).
 ---
 
 # Skill: oms-retrieve (Claude Code)
@@ -18,7 +18,7 @@ Surface the right notes and fields for a given purpose using the vault's declare
 Conceptually shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz retrieve
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz retrieve
 ```
 
 **Runtime note:** Retrieval is available through MCP tools (`oms_retrieve_by_axis`

--- a/adapters/claude-code/skills/setup/SKILL.md
+++ b/adapters/claude-code/skills/setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oms-setup
-description: Adopt an existing Obsidian vault into the OMS convention by running npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup.
+description: Adopt an existing Obsidian vault into the Oh My Second Brain convention by running npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup.
 ---
 
 # Skill: oms-setup (Claude Code)
 
-Adopt your Obsidian vault into the OMS convention.
+Adopt your Obsidian vault into the Oh My Second Brain convention.
 This skill is **REAL in v0** — it shells out to the fully-implemented CLI.
 
 ## Invocation
@@ -19,8 +19,8 @@ This skill is **REAL in v0** — it shells out to the fully-implemented CLI.
 Shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup [--vault <path>] [--yes] [--install-claude]
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install [--runtime <auto|all|claude|codex|hermes>] [--vault <path>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup [--vault <path>] [--yes] [--install-claude]
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install [--runtime <auto|all|claude|codex|hermes>] [--vault <path>] [--dry-run] [--execute] [--yes]
 ```
 
 The CLI will:
@@ -43,19 +43,19 @@ The CLI will:
 
 ```bash
 # Interactive (recommended first run):
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup --vault ~/Documents/MyVault
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup --vault ~/Documents/MyVault
 
 # Non-interactive (CI / scripted):
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup --vault ~/Documents/MyVault --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup --vault ~/Documents/MyVault --yes
 
 # Preview all host adapter installs:
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime all --vault ~/Documents/MyVault --dry-run
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime all --vault ~/Documents/MyVault --dry-run
 
 # Install all host adapter/MCP registrations:
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime all --vault ~/Documents/MyVault --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime all --vault ~/Documents/MyVault --yes
 
 # Also run external host CLIs where available:
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime claude --vault ~/Documents/MyVault --yes --execute
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime claude --vault ~/Documents/MyVault --yes --execute
 ```
 
 ## After setup

--- a/adapters/claude-code/skills/uninstall/SKILL.md
+++ b/adapters/claude-code/skills/uninstall/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oms-uninstall
-description: Remove OMS host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall.
+description: Remove Oh My Second Brain host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall.
 ---
 
 # Skill: oms-uninstall (Claude Code)
 
-Remove OMS host registrations and adapter files. This does **not** delete vault notes or `vault/.oms/` ontology data.
+Remove Oh My Second Brain host registrations and adapter files. This does **not** delete vault notes or `vault/.oms/` ontology data.
 
 ## Invocation
 
@@ -18,17 +18,17 @@ Remove OMS host registrations and adapter files. This does **not** delete vault 
 Shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
 ```
 
 ## Recommended flow
 
 ```bash
 # Preview first:
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime all --dry-run
 
-# Remove OMS host registrations:
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime all --yes
+# Remove Oh My Second Brain host registrations:
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime all --yes
 ```
 
-Use `--execute` only when you want OMS to call external host CLIs such as `claude mcp remove oms` or `claude plugin uninstall oms`.
+Use `--execute` only when you want Oh My Second Brain to call external host CLIs such as `claude mcp remove oms` or `claude plugin uninstall oms`.

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oms",
-  "version": "0.1.4",
-  "description": "OMS convention layer for Obsidian vaults \u2014 Codex native rules, skills, and MCP adapter.",
+  "version": "0.1.5",
+  "description": "Oh My Second Brain convention layer for Obsidian vaults \u2014 Codex native rules, skills, and MCP adapter.",
   "_note": "oms install writes Codex MCP config, installs ~/.codex/rules/oms.md, and installs ~/.codex/skills/oms-*.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/adapters/codex/.mcp.json
+++ b/adapters/codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz",
+        "https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz",
         "mcp",
         "--vault",
         "."

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -1,16 +1,16 @@
-# OMS Convention Shim — Codex
+# Oh My Second Brain Convention Shim — Codex
 
-<!-- Append this block to your project's AGENTS.md to activate OMS conventions in Codex (oh-my-codex). -->
+<!-- Append this block to your project's AGENTS.md to activate Oh My Second Brain conventions in Codex (oh-my-codex). -->
 
-## Vault Convention (OMS)
+## Vault Convention (Oh My Second Brain)
 
-This vault is governed by OMS conventions stored in `.oms/`.
+This vault is governed by Oh My Second Brain conventions stored in `.oms/`.
 
 **Before working with vault notes:**
-- Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
 - Read `.oms/taxonomy.yaml` and `.oms/concepts/*.yaml` for folder and field declarations.
 
 **Capture:** Use `$oms-capture` skill or follow the librarian persona.
 **Retrieve:** Use `$oms-retrieve` skill or follow the retriever persona with declared lenses.
 
-> **v0 native install:** `oms install --runtime codex` installs Codex rules, `$oms-*` skills, and a managed Codex MCP config. Use OMS MCP tools for capture/retrieve and CLI commands for lifecycle.
+> **v0 native install:** `oms install --runtime codex` installs Codex rules, `$oms-*` skills, and a managed Codex MCP config. Use Oh My Second Brain MCP tools for capture/retrieve and CLI commands for lifecycle.

--- a/adapters/codex/rules/oms.md
+++ b/adapters/codex/rules/oms.md
@@ -1,19 +1,19 @@
-# OMS for Codex
+# Oh My Second Brain for Codex
 
-Use OMS when the user asks to set up, validate, capture into, retrieve from, or inspect an Obsidian/Markdown vault governed by `vault/.oms/`.
+Use Oh My Second Brain when the user asks to set up, validate, capture into, retrieve from, or inspect an Obsidian/Markdown vault governed by `vault/.oms/`.
 
 ## Core rule
 
-OMS is a convention harness, not a content generator. The user owns the ontology in `vault/.oms/`; agents must use the declared folder axis, frontmatter/property axes, wikilinks, and retrieval lenses before reading or writing notes.
+Oh My Second Brain is a convention harness, not a content generator. The user owns the ontology in `vault/.oms/`; agents must use the declared folder axis, frontmatter/property axes, wikilinks, and retrieval lenses before reading or writing notes.
 
 ## Command mapping
 
-| User intent | Preferred OMS surface |
+| User intent | Preferred Oh My Second Brain surface |
 |---|---|
-| adopt a vault | `$oms-setup` or `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup --vault <path>` |
-| install host integration | `$oms-install` or `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime codex --vault <path> --yes` |
-| uninstall host integration | `$oms-uninstall` or `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime codex --yes` |
-| validate notes | `$oms-doctor` or `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor --vault <path>` |
+| adopt a vault | `$oms-setup` or `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup --vault <path>` |
+| install host integration | `$oms-install` or `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime codex --vault <path> --yes` |
+| uninstall host integration | `$oms-uninstall` or `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime codex --yes` |
+| validate notes | `$oms-doctor` or `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor --vault <path>` |
 | capture knowledge | use MCP `oms_capture_prepare` then `oms_capture_commit` |
 | retrieve knowledge | use MCP `oms_retrieve_by_axis`, then `oms_lazy_load_note` only when needed |
 

--- a/adapters/codex/skills/oms-capture/SKILL.md
+++ b/adapters/codex/skills/oms-capture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oms-capture
-description: Capture knowledge into the vault through OMS's folder/frontmatter contract.
+description: Capture knowledge into the vault through Oh My Second Brain's folder/frontmatter contract.
 ---
 
 # oms-capture

--- a/adapters/codex/skills/oms-doctor/SKILL.md
+++ b/adapters/codex/skills/oms-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oms-doctor
-description: Validate vault notes against the active OMS ontology.
+description: Validate vault notes against the active Oh My Second Brain ontology.
 ---
 
 # oms-doctor
@@ -8,7 +8,7 @@ description: Validate vault notes against the active OMS ontology.
 Run:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor --vault <vault>
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor --vault <vault>
 ```
 
 The command is advisory in v0 and exits 0 even when warnings are found.

--- a/adapters/codex/skills/oms-install/SKILL.md
+++ b/adapters/codex/skills/oms-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oms-install
-description: Install OMS Codex/Hermes/Claude host adapters and MCP registration.
+description: Install Oh My Second Brain Codex/Hermes/Claude host adapters and MCP registration.
 ---
 
 # oms-install
@@ -8,7 +8,7 @@ description: Install OMS Codex/Hermes/Claude host adapters and MCP registration.
 Use for host lifecycle installation.
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
 ```
 
 For Codex, this installs:

--- a/adapters/codex/skills/oms-setup/SKILL.md
+++ b/adapters/codex/skills/oms-setup/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: oms-setup
-description: Adopt an Obsidian markdown vault into the OMS convention and optionally install host MCP integration.
+description: Adopt an Obsidian markdown vault into the Oh My Second Brain convention and optionally install host MCP integration.
 ---
 
 # oms-setup
 
-Use when the user wants to initialize OMS for a vault.
+Use when the user wants to initialize Oh My Second Brain for a vault.
 
 Run:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup --vault <vault> --yes
 ```
 
 Then, when host registration is desired:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime codex --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime codex --vault <vault> --yes
 ```
 
-Do not modify vault notes during setup. OMS writes only `vault/.oms/taxonomy.yaml` and `vault/.oms/concepts/`.
+Do not modify vault notes during setup. Oh My Second Brain writes only `vault/.oms/taxonomy.yaml` and `vault/.oms/concepts/`.

--- a/adapters/codex/skills/oms-uninstall/SKILL.md
+++ b/adapters/codex/skills/oms-uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oms-uninstall
-description: Remove OMS host adapter files and MCP registration without deleting vault notes or vault ontology.
+description: Remove Oh My Second Brain host adapter files and MCP registration without deleting vault notes or vault ontology.
 ---
 
 # oms-uninstall
@@ -8,13 +8,13 @@ description: Remove OMS host adapter files and MCP registration without deleting
 Preview first:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime all --dry-run
 ```
 
 Remove host registrations:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime all --yes
 ```
 
 Never delete vault notes or `vault/.oms/` as part of host uninstall.

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -1,8 +1,8 @@
-# OMS Hermes Adapter
+# Oh My Second Brain Hermes Adapter
 
 Installed by `oms install --runtime hermes` into:
 
 - `~/.hermes/skills/knowledge-management/oms/`
 - `~/.hermes/config.yaml` as `mcp_servers.oms`
 
-The skill bundle mirrors OMS's capture/retrieve/setup/doctor lifecycle and uses the OMS MCP server for runtime operations.
+The skill bundle mirrors Oh My Second Brain's capture/retrieve/setup/doctor lifecycle and uses the Oh My Second Brain MCP server for runtime operations.

--- a/adapters/hermes/SOUL.md
+++ b/adapters/hermes/SOUL.md
@@ -1,19 +1,19 @@
-# OMS Convention Shim — Hermes
+# Oh My Second Brain Convention Shim — Hermes
 
-<!-- Add this as a context file in your Hermes session to activate OMS conventions. -->
+<!-- Add this as a context file in your Hermes session to activate Oh My Second Brain conventions. -->
 
-## Vault Convention (OMS)
+## Vault Convention (Oh My Second Brain)
 
-This vault is governed by OMS conventions stored in `.oms/`.
+This vault is governed by Oh My Second Brain conventions stored in `.oms/`.
 
 **Before working with vault notes:**
-- Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
+- Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` to validate notes against the convention (exits 0, non-blocking).
 - Read `.oms/taxonomy.yaml` for folder-to-concept bindings.
 - Read `.oms/concepts/*.yaml` for field declarations and lenses.
 
 **Capture:** Follow the librarian persona — resolve concept, resolve folder from taxonomy,
-construct required frontmatter, write note, then run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor`.
+construct required frontmatter, write note, then run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor`.
 
 **Retrieve:** Follow the retriever persona — identify purpose, match lens, project lens fields only.
 
-> **v0 native install:** `oms install --runtime hermes` installs a Hermes skill bundle and registers OMS MCP in `~/.hermes/config.yaml`. Use OMS MCP tools for capture/retrieve and CLI commands for lifecycle.
+> **v0 native install:** `oms install --runtime hermes` installs a Hermes skill bundle and registers Oh My Second Brain MCP in `~/.hermes/config.yaml`. Use Oh My Second Brain MCP tools for capture/retrieve and CLI commands for lifecycle.

--- a/adapters/hermes/manifest.json
+++ b/adapters/hermes/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "oms",
-  "version": "0.1.4",
-  "description": "OMS convention layer for Obsidian vaults \u2014 Hermes skill bundle and MCP adapter.",
+  "version": "0.1.5",
+  "description": "Oh My Second Brain convention layer for Obsidian vaults \u2014 Hermes skill bundle and MCP adapter.",
   "_note": "oms install writes ~/.hermes/config.yaml mcp_servers.oms and installs skills under ~/.hermes/skills/knowledge-management/oms/.",
   "skills": "./skills/"
 }

--- a/adapters/hermes/skills/capture/SKILL.md
+++ b/adapters/hermes/skills/capture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: capture
-description: Capture knowledge into the vault through OMS's folder/frontmatter contract.
+description: Capture knowledge into the vault through Oh My Second Brain's folder/frontmatter contract.
 ---
 
 # oms-capture

--- a/adapters/hermes/skills/doctor/SKILL.md
+++ b/adapters/hermes/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doctor
-description: Validate vault notes against the active OMS ontology.
+description: Validate vault notes against the active Oh My Second Brain ontology.
 ---
 
 # oms-doctor
@@ -8,7 +8,7 @@ description: Validate vault notes against the active OMS ontology.
 Run:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor --vault <vault>
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor --vault <vault>
 ```
 
 The command is advisory in v0 and exits 0 even when warnings are found.

--- a/adapters/hermes/skills/install/SKILL.md
+++ b/adapters/hermes/skills/install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install
-description: Install OMS Codex/Hermes/Claude host adapters and MCP registration.
+description: Install Oh My Second Brain Codex/Hermes/Claude host adapters and MCP registration.
 ---
 
 # oms-install
@@ -8,7 +8,7 @@ description: Install OMS Codex/Hermes/Claude host adapters and MCP registration.
 Use for host lifecycle installation.
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime <auto|all|claude|codex|hermes> --vault <vault> --yes
 ```
 
 For Codex, this installs:

--- a/adapters/hermes/skills/setup/SKILL.md
+++ b/adapters/hermes/skills/setup/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: setup
-description: Adopt an Obsidian markdown vault into the OMS convention and optionally install host MCP integration.
+description: Adopt an Obsidian markdown vault into the Oh My Second Brain convention and optionally install host MCP integration.
 ---
 
 # oms-setup
 
-Use when the user wants to initialize OMS for a vault.
+Use when the user wants to initialize Oh My Second Brain for a vault.
 
 Run:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup --vault <vault> --yes
 ```
 
 Then, when host registration is desired:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime codex --vault <vault> --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime codex --vault <vault> --yes
 ```
 
-Do not modify vault notes during setup. OMS writes only `vault/.oms/taxonomy.yaml` and `vault/.oms/concepts/`.
+Do not modify vault notes during setup. Oh My Second Brain writes only `vault/.oms/taxonomy.yaml` and `vault/.oms/concepts/`.

--- a/adapters/hermes/skills/uninstall/SKILL.md
+++ b/adapters/hermes/skills/uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uninstall
-description: Remove OMS host adapter files and MCP registration without deleting vault notes or vault ontology.
+description: Remove Oh My Second Brain host adapter files and MCP registration without deleting vault notes or vault ontology.
 ---
 
 # oms-uninstall
@@ -8,13 +8,13 @@ description: Remove OMS host adapter files and MCP registration without deleting
 Preview first:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime all --dry-run
 ```
 
 Remove host registrations:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime all --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime all --yes
 ```
 
 Never delete vault notes or `vault/.oms/` as part of host uninstall.

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -1,16 +1,16 @@
-# OMS Vault Convention — SSOT for Host Agents
+# Oh My Second Brain Vault Convention — SSOT for Host Agents
 
 This file is the authoritative reference a host agent (Claude Code, Codex, Hermes, or any
-other) reads when working inside a OMS-managed vault. It explains the convention model so
+other) reads when working inside a vault managed by Oh My Second Brain. It explains the convention model so
 the agent understands *why* knowledge is organized the way it is — not just *where*.
 
 ---
 
 ## What is a Convention?
 
-A OMS **convention** is declarative semantic data the **user owns**. It lives in
-`vault/.oms/` (copied there by `oms setup`; OMS ships the defaults in `core/ontology/`).
-The user edits it freely. OMS enforces whatever is declared — it does not impose structure.
+An Oh My Second Brain **convention** is declarative semantic data the **user owns**. It lives in
+`vault/.oms/` (copied there by `oms setup`; Oh My Second Brain ships the defaults in `core/ontology/`).
+The user edits it freely. Oh My Second Brain enforces whatever is declared — it does not impose structure.
 
 The convention has four building blocks:
 
@@ -88,7 +88,7 @@ A folder may bind to one concept, multiple concepts (list), or `null` (not yet a
 | `onViolation` | `warn` | Violations are logged but never block writes (v0 is non-blocking). |
 | `additionalProperties` | `preserve` | Frontmatter keys not declared in the concept are left untouched. |
 
-OMS enforces what the user declared; it does not touch anything else.
+Oh My Second Brain enforces what the user declared; it does not touch anything else.
 
 ---
 
@@ -98,7 +98,7 @@ OMS enforces what the user declared; it does not touch anything else.
 2. It copies shipped default concepts into `vault/.oms/concepts/` and writes
    `vault/.oms/taxonomy.yaml` — seeded with the user's real folders.
 3. The user fills in `intent` values and adds or removes fields/lenses freely.
-4. OMS never imposes a folder structure; it adopts what already exists.
+4. Oh My Second Brain never imposes a folder structure; it adopts what already exists.
 
 ---
 

--- a/core/skills/capture/SKILL.md
+++ b/core/skills/capture/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: capture
-description: Capture knowledge into the vault under the declared OMS convention.
+description: Capture knowledge into the vault under the declared Oh My Second Brain convention.
 ---
 
 # Skill: capture
 
-Place a piece of knowledge into the vault according to the OMS convention.
+Place a piece of knowledge into the vault according to the Oh My Second Brain convention.
 The librarian persona governs this action.
 
 ## What this skill does
@@ -18,7 +18,7 @@ The librarian persona governs this action.
    - Fill optional fields where values are known.
    - Leave undeclared (extra) frontmatter fields untouched (`additionalProperties: preserve`).
 5. Write the note body after the frontmatter block.
-6. Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` (non-blocking, exits 0) to confirm the new note passes field validation.
+6. Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` (non-blocking, exits 0) to confirm the new note passes field validation.
 
 ## Conceptual shell-out (roadmap — NOT wired in v0)
 
@@ -40,7 +40,7 @@ User: "Save this paper: 'Attention Is All You Need', arxiv.org/abs/1706.03762"
      source-url: "https://arxiv.org/abs/1706.03762"
      captured-at: "2026-05-31"
 5. write note body
-6. npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor  ← verify (exits 0, non-blocking)
+6. npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor  ← verify (exits 0, non-blocking)
 ```
 
 ## Persona

--- a/core/skills/define/SKILL.md
+++ b/core/skills/define/SKILL.md
@@ -5,14 +5,14 @@ description: Grow the vault convention by adding or editing a metadata field on 
 
 # Skill: define
 
-Extend your OMS convention field-by-field.
+Extend your Oh My Second Brain convention field-by-field.
 Each frontmatter key is a **unit of convention**: it carries a declared `intent`,
 type, and optional rules (`required`, `normalize`, `immutable`).
 
 ## Entry point
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz define
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz define
 ```
 
 This is the intended user-facing command (roadmap: interactive runtime not built yet).
@@ -27,7 +27,7 @@ Use `define` as **agent-guided convention editing** until the interactive runtim
 4. Ask: **type** (`string` | `string[]` | `date` | `url` | `boolean`), **required** (yes/no).
 5. Optionally ask: `normalize` (e.g. `lowercase`), `immutable` (lock after creation).
 6. Open `vault/.oms/concepts/<concept>.yaml` and append the new field entry.
-7. Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` to validate existing notes against the updated schema (exits 0).
+7. Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` to validate existing notes against the updated schema (exits 0).
 
 ## Convention YAML shape (one field entry)
 
@@ -55,5 +55,5 @@ vault/.oms/
   taxonomy.yaml
 ```
 
-OMS ships defaults (from `core/ontology/`); `oms setup` copies them into the vault.
-The user then edits them at will — OMS only enforces, never overwrites.
+Oh My Second Brain ships defaults (from `core/ontology/`); `oms setup` copies them into the vault.
+The user then edits them at will — Oh My Second Brain only enforces, never overwrites.

--- a/core/skills/doctor/SKILL.md
+++ b/core/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doctor
-description: Validate vault notes against the OMS convention and report violations (REAL today).
+description: Validate vault notes against the Oh My Second Brain convention and report violations (REAL today).
 ---
 
 # Skill: doctor
@@ -11,7 +11,7 @@ This skill is **REAL in v0** — the CLI command is fully implemented.
 ## Shell-out
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor [--vault <path>]
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor [--vault <path>]
 ```
 
 - `--vault <path>` — path to your Obsidian vault root (default: current directory).
@@ -40,7 +40,7 @@ Undeclared frontmatter fields are **never** reported as violations
 
 ## Recommended usage
 
-Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` after:
+Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` after:
 - Any `oms setup` run
 - Adding a new field via `oms define`
 - Bulk-editing notes

--- a/core/skills/retrieve/SKILL.md
+++ b/core/skills/retrieve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retrieve
-description: Retrieve knowledge from the vault through declared OMS lenses (인출).
+description: Retrieve knowledge from the vault through declared Oh My Second Brain lenses (인출).
 ---
 
 # Skill: retrieve

--- a/core/skills/setup/SKILL.md
+++ b/core/skills/setup/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: setup
-description: Adopt an existing Obsidian vault into the OMS convention (REAL today).
+description: Adopt an existing Obsidian vault into the Oh My Second Brain convention (REAL today).
 ---
 
 # Skill: setup
 
-Adopt your existing vault into the OMS convention.
+Adopt your existing vault into the Oh My Second Brain convention.
 This skill is **REAL in v0** — the CLI command is fully implemented.
 
 ## Shell-out
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup [--vault <path>] [--yes]
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup [--vault <path>] [--yes]
 ```
 
 - `--vault <path>` — path to your Obsidian vault root (default: current directory).
@@ -26,8 +26,8 @@ npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.t
 5. Writes `vault/.oms/taxonomy.yaml` (with `version: 0`).
 6. Copies the shipped default concepts into `vault/.oms/concepts/`.
 
-After setup, the vault is governed by OMS conventions.
-Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor` at any time to validate existing notes.
+After setup, the vault is governed by Oh My Second Brain conventions.
+Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor` at any time to validate existing notes.
 
 ## What setup does NOT do
 
@@ -40,5 +40,5 @@ Run `npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.
 Run the `doctor` skill to check your notes against the convention:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor [--vault <path>]
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor [--vault <path>]
 ```

--- a/core/skills/uninstall/SKILL.md
+++ b/core/skills/uninstall/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oms-uninstall
-description: Remove OMS host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall.
+description: Remove Oh My Second Brain host adapter and MCP registrations by running npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall.
 ---
 
 # Skill: oms-uninstall (Claude Code)
 
-Remove OMS host registrations and adapter files. This does **not** delete vault notes or `vault/.oms/` ontology data.
+Remove Oh My Second Brain host registrations and adapter files. This does **not** delete vault notes or `vault/.oms/` ontology data.
 
 ## Invocation
 
@@ -18,17 +18,17 @@ Remove OMS host registrations and adapter files. This does **not** delete vault 
 Shells out to:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
 ```
 
 ## Recommended flow
 
 ```bash
 # Preview first:
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime all --dry-run
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime all --dry-run
 
-# Remove OMS host registrations:
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz uninstall --runtime all --yes
+# Remove Oh My Second Brain host registrations:
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz uninstall --runtime all --yes
 ```
 
-Use `--execute` only when you want OMS to call external host CLIs such as `claude mcp remove oms` or `claude plugin uninstall oms`.
+Use `--execute` only when you want Oh My Second Brain to call external host CLIs such as `claude mcp remove oms` or `claude plugin uninstall oms`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,21 +1,21 @@
-# OMS Architecture
+# Oh My Second Brain Architecture
 
 > Canonical product architecture lives in [`docs/harness-architecture.md`](./harness-architecture.md).
 > This file summarizes the host/runtime posture and current repository reality.
 
 ## Posture: Axis Graph Harness Inside the Host
 
-OMS lives *inside* each host agent and operates beneath it. The control direction is:
+Oh My Second Brain lives *inside* each host agent and operates beneath it. The control direction is:
 
 ```
 Host agent (Claude Code / Codex / Hermes)
-  └── invokes OMS
+  └── invokes Oh My Second Brain
         └── reads/writes Obsidian vault (plain markdown)
 ```
 
-This is the opposite of an OS-above orchestrator (e.g., ouroboros in its orchestrator mode), which drives host agents top-down. OMS borrows the installable harness idea — skills, deterministic gates, and eventually MCP state/runtime surfaces — but it is not in charge of the host agent.
+This is the opposite of an OS-above orchestrator (e.g., ouroboros in its orchestrator mode), which drives host agents top-down. Oh My Second Brain borrows the installable harness idea — skills, deterministic gates, and eventually MCP state/runtime surfaces — but it is not in charge of the host agent.
 
-OMS's product posture is an **axis graph harness**:
+Oh My Second Brain's product posture is an **axis graph harness**:
 
 - frontmatter fields are user-owned retrieval axes,
 - folders create physical folder-to-concept placement edges,
@@ -23,7 +23,7 @@ OMS's product posture is an **axis graph harness**:
 - note bodies are payload loaded after axis/search narrowing,
 - capture and retrieval are separate flows over the same ontology contract.
 
-The full terminology lock is in the harness architecture doc. In short: OMS helps the user operate their own knowledge system so notes can be retrieved and reused later; it does not fill the body content for them.
+The full terminology lock is in the harness architecture doc. In short: Oh My Second Brain helps the user operate their own knowledge system so notes can be retrieved and reused later; it does not fill the body content for them.
 
 ## The 3-Host Handshake: Shared CORE + Host ADAPTERS
 
@@ -47,12 +47,12 @@ All knowledge logic (validation, ontology loading, folder resolution, graph/cach
 │                                                                  │
 │  host ADAPTER                                                    │
 │  ├─ plugin.json / rule+skill bundle / SOUL.md fragment              │
-│  └─ shells out to: npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup | oms doctor | oms define    │
+│  └─ shells out to: npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup | oms doctor | oms define    │
 └───────────────────────────┬──────────────────────────────────────┘
                             │ invokes
                             ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│  OMS convention layer  (src/ — TypeScript, Node ≥18)            │
+│  Oh My Second Brain convention layer  (src/ — TypeScript, Node ≥18)            │
 │                                                                  │
 │  src/cli/oms.ts          CLI verbs: setup / doctor / define     │
 │  src/ontology/loader.ts   load concepts/*.yaml + taxonomy.yaml   │
@@ -96,5 +96,5 @@ Existing concept YAML may use `lenses`. Keep that key backward-compatible, but e
 - **TypeScript** (`module: NodeNext`, Node ≥ 18) — runtime for the CLI, convention engine, and adapter interfaces.
 - **Markdown** — conventions, skills, agents, and adapter documentation.
 - **YAML** — ontology data files (`concepts/*.yaml`, `taxonomy.yaml`); parsed by the `yaml` npm package (the only runtime dependency in v0).
-- **No Obsidian app dependency** — a vault is just a folder of markdown files. OMS reads and writes it directly via the filesystem.
+- **No Obsidian app dependency** — a vault is just a folder of markdown files. Oh My Second Brain reads and writes it directly via the filesystem.
 - **No new heavy dependencies** — any additional dep requires explicit approval (spec constraint).

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,6 +1,6 @@
-# OMS Conventions Guide
+# Oh My Second Brain Conventions Guide
 
-A OMS convention is **declarative data you own**. It lives in your vault under `vault/.oms/` and tells host agents what your frontmatter means, not just what keys exist. This guide covers the format, how to grow it, and what OMS enforces.
+An Oh My Second Brain convention is **declarative data you own**. It lives in your vault under `vault/.oms/` and tells host agents what your frontmatter means, not just what keys exist. This guide covers the format, how to grow it, and what Oh My Second Brain enforces.
 
 ## The Convention Format
 
@@ -11,7 +11,7 @@ The convention is a semantic ontology with four interlocking pieces:
 - **Retrieval view** — a named output shape that selects which fields matter for a specific retrieval purpose. In YAML this is still stored under the backward-compatible `lenses` key.
 - **Taxonomy** — binds folders to concepts and declares a per-folder `intent` ("the folder itself is information").
 
-OMS's heavier harness architecture treats folders, frontmatter fields, frontmatter values, and wikilinks as the intentional graph surface for retrieval. The note body remains user payload: OMS can lazy-load it after retrieval narrowing, but it does not judge or generate the body content.
+Oh My Second Brain's heavier harness architecture treats folders, frontmatter fields, frontmatter values, and wikilinks as the intentional graph surface for retrieval. The note body remains user payload: Oh My Second Brain can lazy-load it after retrieval narrowing, but it does not judge or generate the body content.
 
 ## Worked Example: the `literature` Concept
 
@@ -86,7 +86,7 @@ my-rating: 5
 Body of the note...
 ```
 
-`my-rating` is not declared in the concept. OMS leaves it untouched (`additionalProperties: preserve`).
+`my-rating` is not declared in the concept. Oh My Second Brain leaves it untouched (`additionalProperties: preserve`).
 
 ## Field Types
 
@@ -124,12 +124,12 @@ You never need to add all fields upfront. Start with the two or three that matte
 
 ## Retrieval Views (`lenses`)
 
-Concept files keep the `lenses` key for compatibility. In prose, OMS calls these **retrieval views**.
+Concept files keep the `lenses` key for compatibility. In prose, Oh My Second Brain calls these **retrieval views**.
 
 A retrieval view is not the graph itself and does not replace frontmatter axes. It shapes the result after retrieval:
 
-1. OMS narrows candidate notes through folder/concept/property/wikilink axes.
-2. OMS may optionally rank candidates with lexical/vector/hybrid search once that derived search layer exists.
+1. Oh My Second Brain narrows candidate notes through folder/concept/property/wikilink axes.
+2. Oh My Second Brain may optionally rank candidates with lexical/vector/hybrid search once that derived search layer exists.
 3. The retrieval view selects which fields or excerpts should be shown for the current purpose.
 
 Example: a `synthesis` retrieval view can show citation fields needed for writing, while an `audit` retrieval view can show status/completeness fields. Both views reuse the same underlying frontmatter axes.
@@ -181,18 +181,18 @@ When `validateFrontmatter` finds a violation it returns a `ValidationResult { va
 
 ### `additionalProperties: preserve`
 
-Frontmatter keys that are not declared in the concept's `fields` array are left completely untouched. OMS does not emit a violation for them and does not remove them. Your existing Obsidian plugins, templates, and personal keys coexist safely with the declared convention.
+Frontmatter keys that are not declared in the concept's `fields` array are left completely untouched. Oh My Second Brain does not emit a violation for them and does not remove them. Your existing Obsidian plugins, templates, and personal keys coexist safely with the declared convention.
 
 ### `immutable` (v0 no-op, forward-compatible)
 
-A field may be declared `immutable: true`. In v0 this is recorded in the schema but **never enforced** — no violation is emitted for an immutable field that has changed, because OMS does not maintain a baseline snapshot to compare against. The union member is kept so that v1 can begin enforcing without a breaking schema change.
+A field may be declared `immutable: true`. In v0 this is recorded in the schema but **never enforced** — no violation is emitted for an immutable field that has changed, because Oh My Second Brain does not maintain a baseline snapshot to compare against. The union member is kept so that v1 can begin enforcing without a breaking schema change.
 
 ## User Ownership
 
-OMS ships default concepts in `core/ontology/` (inside the npm package). Running `oms setup` copies them into `vault/.oms/concepts/` — from that point on, **you own those files**. OMS enforces whatever you declare; it does not pull updates over the files you have edited.
+Oh My Second Brain ships default concepts in `core/ontology/` (inside the npm package). Running `oms setup` copies them into `vault/.oms/concepts/` — from that point on, **you own those files**. Oh My Second Brain enforces whatever you declare; it does not pull updates over the files you have edited.
 
 The separation is:
-- `core/ontology/` — OMS's shipped defaults (read-only from your perspective).
-- `vault/.oms/` — your live convention (user-owned, edited freely, never overwritten by OMS after setup).
+- `core/ontology/` — Oh My Second Brain's shipped defaults (read-only from your perspective).
+- `vault/.oms/` — your live convention (user-owned, edited freely, never overwritten by Oh My Second Brain after setup).
 
 To reset a concept to the shipped default, delete the file in `vault/.oms/concepts/` and re-run `oms setup`.

--- a/docs/decisions/0001-validate-returns-result.md
+++ b/docs/decisions/0001-validate-returns-result.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-OMS's v0 enforcement model is `onViolation: warn` — convention mismatches are informational, not blocking. The `validateFrontmatter` function is the central enforcement point: it receives a note's parsed frontmatter and a `Concept` definition and decides whether the frontmatter satisfies the declared field schema.
+Oh My Second Brain's v0 enforcement model is `onViolation: warn` — convention mismatches are informational, not blocking. The `validateFrontmatter` function is the central enforcement point: it receives a note's parsed frontmatter and a `Concept` definition and decides whether the frontmatter satisfies the declared field schema.
 
 Two implementation shapes were considered:
 
@@ -74,6 +74,6 @@ A throwing implementation would align with the fail-fast style common in parsers
 
 This was rejected because:
 
-1. OMS's declared enforcement policy is `onViolation: warn`. An exception-throwing function implements `onViolation: error` at the API level and forces every caller to add try/catch boilerplate to recover the non-blocking behavior promised by the policy.
+1. Oh My Second Brain's declared enforcement policy is `onViolation: warn`. An exception-throwing function implements `onViolation: error` at the API level and forces every caller to add try/catch boilerplate to recover the non-blocking behavior promised by the policy.
 2. `oms doctor` needs to validate an entire vault and report a summary. A throwing validator would require either catching and continuing in a loop (awkward) or a separate "collect" wrapper on top of the throwing function (duplication).
 3. Host agents invoking validation inside a larger workflow must not be aborted by a missing frontmatter field. The convention layer must be transparent to the host's own error handling.

--- a/docs/harness-architecture.md
+++ b/docs/harness-architecture.md
@@ -1,19 +1,19 @@
-# OMS Harness Architecture
+# Oh My Second Brain Harness Architecture
 
-OMS is an **axis graph harness** for an Obsidian markdown vault. Its purpose is not to generate note content for the user. Its purpose is to give host agents a deterministic contract for where knowledge belongs, which frontmatter axes describe it, how it links to other notes, and how it should be retrieved later.
+Oh My Second Brain is an **axis graph harness** for an Obsidian markdown vault. Its purpose is not to generate note content for the user. Its purpose is to give host agents a deterministic contract for where knowledge belongs, which frontmatter axes describe it, how it links to other notes, and how it should be retrieved later.
 
 The architecture is docs-first because the core product claim is semantic: capture is only good when it makes future retrieval and reuse easier.
 
 ## 1. Retrieval and reuse are the telos
 
-OMS treats note making as a retrieval problem. A new note is successful when it can be found and reused later through the user's own knowledge axes.
+Oh My Second Brain treats note making as a retrieval problem. A new note is successful when it can be found and reused later through the user's own knowledge axes.
 
 That means capture and retrieval are separate flows over the same substrate:
 
 - **Capture**: place the note under the right folder/concept, fill the frontmatter axes, preserve user body content, and validate contract conformity.
 - **Retrieval**: narrow by folder/concept/frontmatter/wikilink axes first, optionally rank by search, then lazy-load the selected note bodies as payload.
 
-OMS therefore optimizes for future reuse, not for the shortest possible write path.
+Oh My Second Brain therefore optimizes for future reuse, not for the shortest possible write path.
 
 ## 2. User-owned ontology
 
@@ -23,11 +23,11 @@ The ontology is owned by the vault:
 - `vault/.oms/concepts/*.yaml` declares concepts, frontmatter fields, and retrieval views.
 - Markdown notes remain ordinary Obsidian notes.
 
-OMS ships defaults, but setup copies them into the vault. After that, the live ontology is the user's editable contract. OMS must not impose a fixed taxonomy or silently overwrite user convention files.
+Oh My Second Brain ships defaults, but setup copies them into the vault. After that, the live ontology is the user's editable contract. Oh My Second Brain must not impose a fixed taxonomy or silently overwrite user convention files.
 
 ## 3. Axes: frontmatter, folders, and wikilinks
 
-OMS's intentional graph is built from user-authored structure:
+Oh My Second Brain's intentional graph is built from user-authored structure:
 
 | Primitive | Meaning |
 |---|---|
@@ -46,7 +46,7 @@ A note has two operational layers:
 1. **Graph surface**: path, folder, frontmatter, and wikilinks. This layer is used to validate the contract and build the intentional ontology graph.
 2. **Body payload**: prose, excerpts, evidence, and free-form markdown. This layer is loaded lazily after axis/search narrowing.
 
-OMS does not judge whether the body is true, complete, or high quality. Body content belongs to the user. OMS only checks whether the note conforms to the declared retrieval contract.
+Oh My Second Brain does not judge whether the body is true, complete, or high quality. Body content belongs to the user. Oh My Second Brain only checks whether the note conforms to the declared retrieval contract.
 
 ## 5. Capture flow
 
@@ -84,7 +84,7 @@ This is the main difference from generic search. Search is useful, but it is not
 
 ## 7. Retrieval views, not "lens projection"
 
-Existing concept files may contain `lenses`. OMS keeps this schema for compatibility, but user-facing docs should call them **retrieval views**.
+Existing concept files may contain `lenses`. Oh My Second Brain keeps this schema for compatibility, but user-facing docs should call them **retrieval views**.
 
 A retrieval view is not the graph itself. It is an output shape applied after candidate notes have been selected by axis graph narrowing and optional search. For example, a `synthesis` retrieval view may choose to show `title`, `source-url`, and `author`, while an `audit` view may show `status` and `date-read`.
 
@@ -98,7 +98,7 @@ Avoid the phrase "lens projection" unless a document defines it locally. Prefer 
 
 ## 8. Contract-conformity gates
 
-OMS gates structural conformity, not content quality.
+Oh My Second Brain gates structural conformity, not content quality.
 
 Contract checks include:
 
@@ -141,7 +141,7 @@ Graph status should report stale slices separately: schema stale, graph stale, s
 
 ## 10. Claude Code skill/MCP installation surface
 
-The first installable target is Claude Code. The harness surface should make OMS usable where the user is already working:
+The first installable target is Claude Code. The harness surface should make Oh My Second Brain usable where the user is already working:
 
 - skills for setup, doctor, capture, retrieve, and graph/status operations
 - CLI commands for deterministic local actions
@@ -162,7 +162,7 @@ Docs must not describe MCP write/capture runtime as present tense until the serv
 The Phase 1 command surface is intentionally dry-run for Claude runtime registration:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup --vault /path/to/vault --yes --install-claude
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup --vault /path/to/vault --yes --install-claude
 ```
 
 This initializes `.oms/` and prints a Claude Code plugin install command plus a `claude mcp add ...` command. It does not mutate Claude config. Capture/write tools are only available through the gated safe-write path.
@@ -191,10 +191,10 @@ The write path rejects absolute paths, `..` escapes, non-markdown targets, `.oms
 
 ## 11. External inspiration boundaries
 
-OMS borrows patterns, not product identity:
+Oh My Second Brain borrows patterns, not product identity:
 
 - **QMD**: anywhere access to a local markdown knowledge base through CLI/MCP/skills; qmd-like lexical/vector search is a derived support layer.
-- **Graphify**: graph effect as a useful retrieval affordance; OMS's graph is grounded in intentional frontmatter/folder/wikilink axes instead of inferred body concepts by default.
-- **Ouroboros**: installable harness posture, stateful MCP/skill surfaces, and deterministic gates; OMS is not an OS-above host orchestrator.
+- **Graphify**: graph effect as a useful retrieval affordance; Oh My Second Brain's graph is grounded in intentional frontmatter/folder/wikilink axes instead of inferred body concepts by default.
+- **Ouroboros**: installable harness posture, stateful MCP/skill surfaces, and deterministic gates; Oh My Second Brain is not an OS-above host orchestrator.
 
-The boundary matters: OMS is a user-owned ontology harness for Obsidian markdown folders, not a generic search engine, automatic graph extractor, or content generator.
+The boundary matters: Oh My Second Brain is a user-owned ontology harness for Obsidian markdown folders, not a generic search engine, automatic graph extractor, or content generator.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
-# Install OMS
+# Install Oh My Second Brain
 
-OMS v0 is distributed as one npm/GitHub-release package that contains the CLI/runtime, the default ontology, host adapter assets, host-native skill/rule bundles, and shell installers. Claude Code, Codex, and Hermes all install a OMS host surface backed by the same MCP capture/retrieve runtime.
+Oh My Second Brain v0 is distributed as one npm/GitHub-release package that contains the CLI/runtime, the default ontology, host adapter assets, host-native skill/rule bundles, and shell installers. Claude Code, Codex, and Hermes all install an `oms` host surface for Oh My Second Brain backed by the same MCP capture/retrieve runtime.
 
 ## Prerequisites
 
@@ -23,7 +23,7 @@ Useful overrides:
 # Pick one host instead of auto-detection.
 curl -fsSL https://raw.githubusercontent.com/GoBeromsu/oms/main/scripts/install.sh | bash -s -- --runtime claude
 
-# Install every host adapter and point OMS at a specific vault.
+# Install every host adapter and point Oh My Second Brain at a specific vault.
 curl -fsSL https://raw.githubusercontent.com/GoBeromsu/oms/main/scripts/install.sh | bash -s -- --runtime all --vault /path/to/vault
 
 # Also execute external host CLIs where available, e.g. claude plugin/mcp commands.
@@ -46,8 +46,8 @@ From a checkout or installed package:
 ```bash
 npm ci
 npm run build
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime all --vault /path/to/vault --dry-run
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz install --runtime all --vault /path/to/vault --yes
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime all --vault /path/to/vault --dry-run
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz install --runtime all --vault /path/to/vault --yes
 ```
 
 Runtime selection follows the Ouroboros pattern:
@@ -69,17 +69,17 @@ All host writes are namespaced under `oms` and are reversible with `oms uninstal
 
 ## Legacy setup flow
 
-`setup` still adopts a vault into the OMS ontology and can print the Claude Code plan:
+`setup` still adopts a vault into the Oh My Second Brain ontology and can print the Claude Code plan:
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz setup --vault /path/to/vault --yes --install-claude
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz setup --vault /path/to/vault --yes --install-claude
 ```
 
 Typical printed commands look like:
 
 ```bash
 claude plugin install /path/to/oms/adapters/claude-code
-claude mcp add oms -- npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz mcp --vault /path/to/vault
+claude mcp add oms -- npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz mcp --vault /path/to/vault
 ```
 
 ## Uninstall
@@ -102,14 +102,14 @@ One-line uninstall:
 curl -fsSL https://raw.githubusercontent.com/GoBeromsu/oms/main/scripts/uninstall.sh | bash -s -- --yes
 ```
 
-The uninstaller removes OMS host registrations and adapter files. It does **not** remove vault notes or `vault/.oms/` ontology data. Pass `--keep-package` to the shell uninstaller if you want to keep the globally installed package.
+The uninstaller removes Oh My Second Brain host registrations and adapter files. It does **not** remove vault notes or `vault/.oms/` ontology data. Pass `--keep-package` to the shell uninstaller if you want to keep the globally installed package.
 
 ## Verify the install
 
 ```bash
-npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor --vault /path/to/vault
+npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor --vault /path/to/vault
 oms install --runtime all --vault /path/to/vault --dry-run
 claude plugin validate adapters/claude-code
 ```
 
-Inside a host runtime, verify the MCP server by listing MCP tools or asking for OMS graph/status. The server exposes status, graph build, axis retrieval, lazy note loading, contract validation, and gated capture tools.
+Inside a host runtime, verify the MCP server by listing MCP tools or asking for Oh My Second Brain graph/status. The server exposes status, graph build, axis retrieval, lazy note loading, contract validation, and gated capture tools.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
-# Release OMS
+# Release Oh My Second Brain
 
-OMS releases are npm-first and Claude Code validated. The release process must prove the published tarball works, not merely the repository checkout.
+Oh My Second Brain releases are npm-first and Claude Code validated. The release process must prove the published tarball works, not merely the repository checkout.
 
 ## Release contract
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oms",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oms",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oms",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Oh My Second Brain: a host-agnostic, user-owned convention layer for Obsidian and plain-markdown knowledge vaults.",
   "type": "module",
   "license": "MIT",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# OMS installer — installs the package and registers host adapters.
+# Oh My Second Brain installer — installs the package and registers host adapters.
 # Usage: curl -fsSL https://raw.githubusercontent.com/GoBeromsu/oms/main/scripts/install.sh | bash
 set -euo pipefail
 
-PACKAGE_SPEC="${OMS_PACKAGE_SPEC:-https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz}"
+PACKAGE_SPEC="${OMS_PACKAGE_SPEC:-https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz}"
 RUNTIME="${OMS_INSTALL_RUNTIME:-auto}"
 VAULT="${OMS_VAULT:-$PWD}"
 EXECUTE="${OMS_EXECUTE_EXTERNAL:-0}"
@@ -22,11 +22,11 @@ while [ "$#" -gt 0 ]; do
 done
 
 if ! command -v npm >/dev/null 2>&1; then
-  echo "Error: npm is required to install OMS." >&2
+  echo "Error: npm is required to install Oh My Second Brain." >&2
   exit 1
 fi
 
-echo "OMS Installer"
+echo "Oh My Second Brain Installer"
 echo "  package: $PACKAGE_SPEC"
 echo "  runtime: $RUNTIME"
 echo "  vault:   $VAULT"
@@ -46,4 +46,4 @@ else
 fi
 
 echo
-echo "OMS install complete. Run: oms doctor --vault \"$VAULT\""
+echo "Oh My Second Brain install complete. Run: oms doctor --vault \"$VAULT\""

--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -75,7 +75,7 @@ function setupSmoke(packageRoot, vault) {
   assertPath(path.join(vault, ".oms/taxonomy.yaml"), "vault taxonomy");
   assertPath(path.join(vault, ".oms/concepts"), "vault concepts directory");
   if (!output.includes("claude plugin install")) fail("setup output did not include Claude plugin install command");
-  if (!output.includes("claude mcp add oms -- npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz mcp --vault")) {
+  if (!output.includes("claude mcp add oms -- npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz mcp --vault")) {
     fail("setup output did not include Claude MCP registration command");
   }
   const pluginPathLine = output.split(/\r?\n/).find((line) => line.includes("Plugin path:"));
@@ -139,9 +139,9 @@ try {
   assertPath(path.join(packageRoot, "dist"), "dist directory");
   assertPath(path.join(packageRoot, "core"), "core directory");
   assertPath(path.join(packageRoot, "adapters/claude-code/.claude-plugin/plugin.json"), "Claude plugin manifest");
-  assertPath(path.join(packageRoot, "adapters/codex/rules/oms.md"), "Codex OMS rule");
-  assertPath(path.join(packageRoot, "adapters/codex/skills/oms-capture/SKILL.md"), "Codex OMS capture skill");
-  assertPath(path.join(packageRoot, "adapters/hermes/skills/capture/SKILL.md"), "Hermes OMS capture skill");
+  assertPath(path.join(packageRoot, "adapters/codex/rules/oms.md"), "Codex Oh My Second Brain rule");
+  assertPath(path.join(packageRoot, "adapters/codex/skills/oms-capture/SKILL.md"), "Codex Oh My Second Brain capture skill");
+  assertPath(path.join(packageRoot, "adapters/hermes/skills/capture/SKILL.md"), "Hermes Oh My Second Brain capture skill");
   assertPath(path.join(packageRoot, "docs/install.md"), "install docs");
   assertPath(path.join(packageRoot, "docs/release.md"), "release docs");
   assertPath(path.join(packageRoot, "scripts/install.sh"), "install shell script");

--- a/scripts/release-pack.mjs
+++ b/scripts/release-pack.mjs
@@ -79,7 +79,7 @@ const forbidden = [
   "adapters/codex/skills/lexa-retrieve/SKILL.md",
 ].filter((forbiddenPath) => hasPath(files, forbiddenPath));
 if (forbidden.length > 0) {
-  fail(`package tarball includes forbidden legacy OMS assets:\n${forbidden.map((item) => `  - ${item}`).join("\n")}`);
+  fail(`package tarball includes forbidden legacy removed assets:\n${forbidden.map((item) => `  - ${item}`).join("\n")}`);
 }
 
 const packageJson = JSON.parse(readFileSync("package.json", "utf-8"));

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# OMS uninstaller — removes host adapter registrations and optionally the package.
+# Oh My Second Brain uninstaller — removes host adapter registrations and optionally the package.
 # Usage: curl -fsSL https://raw.githubusercontent.com/GoBeromsu/oms/main/scripts/uninstall.sh | bash
 set -euo pipefail
 
@@ -24,10 +24,10 @@ done
 
 if [ "$YES" != "1" ]; then
   if [ -t 0 ]; then
-    printf 'Remove OMS host registrations for runtime=%s? (y/N) ' "$RUNTIME"
+    printf 'Remove Oh My Second Brain host registrations for runtime=%s? (y/N) ' "$RUNTIME"
     read -r REPLY
   elif [ -c /dev/tty ]; then
-    printf 'Remove OMS host registrations for runtime=%s? (y/N) ' "$RUNTIME" >&2
+    printf 'Remove Oh My Second Brain host registrations for runtime=%s? (y/N) ' "$RUNTIME" >&2
     read -r REPLY < /dev/tty
   else
     echo "Non-interactive uninstall requires --yes or OMS_UNINSTALL_CONFIRM=1." >&2
@@ -46,15 +46,12 @@ fi
 
 if command -v oms >/dev/null 2>&1; then
   oms "${ARGS[@]}"
-elif command -v oms >/dev/null 2>&1; then
-  oms "${ARGS[@]}"
 else
-  echo "oms/oms binary not found; skipping host deregistration." >&2
+  echo "oms binary not found; skipping host deregistration." >&2
 fi
 
 if [ "$REMOVE_PACKAGE" = "1" ] && command -v npm >/dev/null 2>&1; then
   npm uninstall -g oms || true
-  npm uninstall -g oms || true
 fi
 
-echo "OMS uninstall complete. Vault content was not removed."
+echo "Oh My Second Brain uninstall complete. Vault content was not removed."

--- a/src/capture/safe.test.ts
+++ b/src/capture/safe.test.ts
@@ -22,7 +22,7 @@ afterEach(async () => {
 });
 
 describe("safe capture", () => {
-  it("rejects paths outside the vault and internal OMS folders", () => {
+  it("rejects paths outside the vault and internal Oh My Second Brain folders", () => {
     expect(() => safeVaultNotePath("/tmp/vault", "../escape.md")).toThrow(/unsafe|inside/);
     expect(() => safeVaultNotePath("/tmp/vault", "/tmp/vault/note.md")).toThrow(/relative/);
     expect(() => safeVaultNotePath("/tmp/vault", ".oms/cache/bad.md")).toThrow(/internal/);

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -18,7 +18,7 @@ import {
 import type { Taxonomy, FolderBinding } from "../ontology/types.js";
 
 const DEFAULT_RELEASE_PACKAGE_SPEC =
-  "https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz";
+  "https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz";
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -174,7 +174,7 @@ export async function runSetup(opts: {
     const conceptNames = Array.from(ontology.concepts.keys());
 
     try {
-      console.log("\nOMS Setup — adopting existing vault folders.\n");
+      console.log("\nOh My Second Brain Setup — adopting existing vault folders.\n");
       console.log(`Available shipped concepts: ${conceptNames.join(", ") || "(none)"}\n`);
 
       for (const folder of folders) {
@@ -248,12 +248,12 @@ export async function runSetup(opts: {
   }
 
   // Summary
-  console.log(`\nOMS setup complete.`);
+  console.log(`\nOh My Second Brain setup complete.`);
   console.log(`  Vault:    ${vault}`);
   console.log(`  Written:  ${path.join(omsDir, "taxonomy.yaml")}`);
   console.log(`  Concepts: ${copiedFiles.join(", ") || "(none)"}`);
   console.log(`  Folders:  ${Object.keys(folderBindings).join(", ") || "(none)"}`);
-  console.log(`\nRun "npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz doctor" to validate existing notes.\n`);
+  console.log(`\nRun "npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz doctor" to validate existing notes.\n`);
 
   if (installClaude) {
     printClaudeInstallPlan(buildClaudeInstallPlan({ vault }));
@@ -319,7 +319,7 @@ export async function runDoctor(opts: { vault: string }): Promise<number> {
     }
 
     console.log(
-      `\nOMS doctor: ${totalNotes} notes checked, ${notesWithViolations} with violations, ${totalViolations} total violations.`,
+      `\nOh My Second Brain doctor: ${totalNotes} notes checked, ${notesWithViolations} with violations, ${totalViolations} total violations.`,
     );
     console.log("All violations are warnings (onViolation: warn). Exit 0.\n");
   } catch (err) {
@@ -336,7 +336,7 @@ export async function runDoctor(opts: { vault: string }): Promise<number> {
 
 function printUsage(): void {
   console.log(`
-oms — OMS convention layer for Obsidian vaults
+oms — Oh My Second Brain convention layer for Obsidian vaults
 
 Usage:
   oms setup [--vault <path>] [--yes] [--install-claude]
@@ -346,9 +346,9 @@ Usage:
   oms mcp [--vault <path>]
 
 Commands:
-  setup    Adopt an existing vault into the OMS convention.
-  install  Install OMS host adapters and MCP registration.
-  uninstall Remove OMS host adapters and MCP registration.
+  setup    Adopt an existing vault into the Oh My Second Brain convention.
+  install  Install Oh My Second Brain host adapters and MCP registration.
+  uninstall Remove Oh My Second Brain host adapters and MCP registration.
   doctor   Validate vault notes against the active ontology.
   mcp      Start the read/status MCP stdio server.
 

--- a/src/install/hosts.test.ts
+++ b/src/install/hosts.test.ts
@@ -24,7 +24,7 @@ describe("host installer/uninstaller", () => {
     const installed = await readFile(path.join(codexDir, "config.toml"), "utf-8");
     expect(installed).toContain("# BEGIN OMS MANAGED MCP");
     expect(installed).toContain("[mcp_servers.oms]");
-    expect(installed).toContain("oms-v0.1.4/oms-0.1.4.tgz");
+    expect(installed).toContain("oms-v0.1.5/oms-0.1.5.tgz");
     expect(installed).toContain("[other]");
     expect(existsSync(path.join(codexDir, "plugins", "oms", "AGENTS.md"))).toBe(true);
     expect(existsSync(path.join(codexDir, "rules", "oms.md"))).toBe(true);

--- a/src/install/hosts.ts
+++ b/src/install/hosts.ts
@@ -35,7 +35,7 @@ const HOSTS: HostRuntime[] = ["claude", "codex", "hermes"];
 const MANAGED_CODEX_START = "# BEGIN OMS MANAGED MCP";
 const MANAGED_CODEX_END = "# END OMS MANAGED MCP";
 const DEFAULT_PACKAGE_SPEC =
-  "https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz";
+  "https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz";
 const CODEX_SKILL_PREFIX = "oms-";
 const CODEX_RULE_FILENAME = "oms.md";
 const HERMES_SKILL_CATEGORY = "knowledge-management";
@@ -128,7 +128,7 @@ function mcpServerEntry(options: HostOperationOptions): Record<string, unknown> 
 function refuseSymlinkedLeaf(target: string): void {
   if (!existsSync(target)) return;
   if (lstatSync(target).isSymbolicLink()) {
-    throw new Error(`Refusing to replace symlinked OMS install target: ${target}`);
+    throw new Error(`Refusing to replace symlinked Oh My Second Brain install target: ${target}`);
   }
 }
 
@@ -212,7 +212,7 @@ async function installClaude(options: HostOperationOptions): Promise<HostOperati
 async function uninstallClaude(options: HostOperationOptions): Promise<HostOperationResult> {
   const claudeDir = hostHome(options.homeDir, ".claude", "OMS_CLAUDE_HOME");
   const commands = ["claude mcp remove oms", "claude plugin uninstall oms"];
-  const messages = ["Claude Code uninstall removes the OMS MCP entry and, when requested, asks Claude CLI to uninstall the plugin."];
+  const messages = ["Claude Code uninstall removes the Oh My Second Brain MCP entry and, when requested, asks Claude CLI to uninstall the plugin."];
   let changed = await removeClaudeMcp(options, claudeDir);
 
   if (options.executeExternal && commandExists("claude") && !options.dryRun) {
@@ -354,7 +354,7 @@ async function installCodex(options: HostOperationOptions): Promise<HostOperatio
     skipped: false,
     paths: [configPath, pluginTarget, ...nativePaths],
     commands: [`Codex MCP config: ${configPath}`],
-    messages: ["Installed Codex-native OMS rules, namespaced skills, plugin assets, and managed MCP/env config."],
+    messages: ["Installed Codex-native Oh My Second Brain rules, namespaced skills, plugin assets, and managed MCP/env config."],
   };
 }
 
@@ -393,7 +393,7 @@ async function uninstallCodex(options: HostOperationOptions): Promise<HostOperat
     skipped: !changed,
     paths: [configPath, pluginTarget, ruleTarget, path.join(skillsRoot, `${CODEX_SKILL_PREFIX}*`)],
     commands: [],
-    messages: ["Removed Codex managed MCP block, OMS rule, namespaced OMS skills, and plugin assets."],
+    messages: ["Removed Codex managed MCP block, Oh My Second Brain rule, namespaced Oh My Second Brain skills, and plugin assets."],
   };
 }
 
@@ -438,7 +438,7 @@ async function installHermes(options: HostOperationOptions): Promise<HostOperati
     skipped: false,
     paths: [adapterTarget, skillTarget, configPath],
     commands: [`Hermes MCP config: ${configPath}`],
-    messages: ["Installed Hermes-native OMS skill bundle and registered mcp_servers.oms in ~/.hermes/config.yaml."],
+    messages: ["Installed Hermes-native Oh My Second Brain skill bundle and registered mcp_servers.oms in ~/.hermes/config.yaml."],
   };
 }
 
@@ -464,7 +464,7 @@ async function uninstallHermes(options: HostOperationOptions): Promise<HostOpera
     skipped: !changed,
     paths: [adapterTarget, skillTarget, configPath],
     commands: [],
-    messages: ["Removed Hermes OMS skill bundle, adapter copy, legacy descriptor files, and mcp_servers.oms."],
+    messages: ["Removed Hermes Oh My Second Brain skill bundle, adapter copy, legacy descriptor files, and mcp_servers.oms."],
   };
 }
 
@@ -487,7 +487,7 @@ export async function runHostOperation(options: HostOperationOptions): Promise<H
 
 export function formatHostOperationResults(results: HostOperationResult[], dryRun: boolean): string {
   const lines: string[] = [];
-  lines.push(dryRun ? "OMS host operation plan (dry-run)." : "OMS host operation complete.");
+  lines.push(dryRun ? "Oh My Second Brain host operation plan (dry-run)." : "Oh My Second Brain host operation complete.");
   for (const result of results) {
     lines.push(`- ${result.runtime} ${result.action}: ${result.skipped ? "skipped" : result.changed || dryRun ? "ok" : "no changes"}`);
     for (const message of result.messages) lines.push(`  ${message}`);

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -18,7 +18,7 @@ function textPayload(result: Awaited<ReturnType<Client["callTool"]>>): Record<st
   return JSON.parse(block.type === "text" ? block.text : "{}") as Record<string, unknown>;
 }
 
-describe("OMS MCP stdio server", () => {
+describe("Oh My Second Brain MCP stdio server", () => {
   it("exposes read/status tools and validates a fixture note", async () => {
     const transport = new StdioClientTransport({
       command: process.execPath,
@@ -103,7 +103,7 @@ describe("OMS MCP stdio server", () => {
       });
       expect(commit.isError).toBe(true);
       expect(commit.content[0]?.type === "text" ? commit.content[0].text : "").toContain(
-        "OMS MCP error",
+        "Oh My Second Brain MCP error",
       );
     } finally {
       await client.close();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -129,9 +129,9 @@ function conceptSummary(concept: Concept): Record<string, unknown> {
 export const omsMcpTools: Tool[] = [
   {
     name: "oms_graph_status",
-    title: "OMS graph/status",
+    title: "Oh My Second Brain graph/status",
     description:
-      "Read-only status for the active OMS ontology, graph/search cache phase, and gated write-tool posture.",
+      "Read-only status for the active Oh My Second Brain ontology, graph/search cache phase, and gated write-tool posture.",
     inputSchema: {
       type: "object",
       properties: {},
@@ -145,7 +145,7 @@ export const omsMcpTools: Tool[] = [
   },
   {
     name: "oms_graph_build",
-    title: "OMS graph build",
+    title: "Oh My Second Brain graph build",
     description:
       "Build the derived graph/search cache from markdown, frontmatter, folders, and wikilinks.",
     inputSchema: {
@@ -161,7 +161,7 @@ export const omsMcpTools: Tool[] = [
   },
   {
     name: "oms_list_concepts",
-    title: "OMS list concepts",
+    title: "Oh My Second Brain list concepts",
     description:
       "Read the active ontology concepts, frontmatter axes, folder bindings, and retrieval views.",
     inputSchema: {
@@ -177,7 +177,7 @@ export const omsMcpTools: Tool[] = [
   },
   {
     name: "oms_retrieve_by_axis",
-    title: "OMS retrieve by axis",
+    title: "Oh My Second Brain retrieve by axis",
     description:
       "Axis-first retrieval over the derived cache; optional lexical query only ranks inside the narrowed candidate set.",
     inputSchema: {
@@ -201,7 +201,7 @@ export const omsMcpTools: Tool[] = [
   },
   {
     name: "oms_lazy_load_note",
-    title: "OMS lazy-load note body",
+    title: "Oh My Second Brain lazy-load note body",
     description:
       "Load a selected note body only after axis/search narrowing has selected the note.",
     inputSchema: {
@@ -223,7 +223,7 @@ export const omsMcpTools: Tool[] = [
   },
   {
     name: "oms_validate_contract",
-    title: "OMS validate contract",
+    title: "Oh My Second Brain validate contract",
     description:
       "Read one vault note and validate its frontmatter against the active folder/concept contract.",
     inputSchema: {
@@ -245,7 +245,7 @@ export const omsMcpTools: Tool[] = [
   },
   {
     name: "oms_capture_prepare",
-    title: "OMS capture prepare",
+    title: "Oh My Second Brain capture prepare",
     description:
       "Plan a safe capture: choose folder/concept, surface missing fields, or route ambiguous input to inbox without writing.",
     inputSchema: {
@@ -266,7 +266,7 @@ export const omsMcpTools: Tool[] = [
   },
   {
     name: "oms_capture_commit",
-    title: "OMS capture commit",
+    title: "Oh My Second Brain capture commit",
     description:
       "Write or append a note only after vault path confinement and contract validation pass.",
     inputSchema: {
@@ -299,7 +299,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     {
       capabilities: { tools: {} },
       instructions:
-        "OMS exposes ontology/status/cache/retrieval tools and safe capture tools. Capture commit is gated by vault confinement and contract validation.",
+        "Oh My Second Brain exposes ontology/status/cache/retrieval tools and safe capture tools. Capture commit is gated by vault confinement and contract validation.",
     },
   );
 
@@ -501,9 +501,9 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       }
     }
 
-    return errorText(`Unknown OMS tool: ${request.params.name}`);
+    return errorText(`Unknown Oh My Second Brain tool: ${request.params.name}`);
     } catch (error) {
-      return errorText(`OMS MCP error: ${error instanceof Error ? error.message : String(error)}`);
+      return errorText(`Oh My Second Brain MCP error: ${error instanceof Error ? error.message : String(error)}`);
     }
   });
 

--- a/src/ontology/loader.ts
+++ b/src/ontology/loader.ts
@@ -4,7 +4,7 @@ import { parse as parseYaml } from "yaml";
 import type { Concept, Ontology, Taxonomy } from "./types.js";
 
 /**
- * Load a OMS ontology from a directory that contains:
+ * Load an Oh My Second Brain ontology from a directory that contains:
  *   <ontologyDir>/taxonomy.yaml
  *   <ontologyDir>/concepts/*.yaml
  *

--- a/src/ontology/types.ts
+++ b/src/ontology/types.ts
@@ -1,8 +1,8 @@
 /**
- * OMS convention format — the semantic ontology, adapted from ouroboros.
+ * Oh My Second Brain convention format — the semantic ontology, adapted from ouroboros.
  *
  * A vault's convention is declarative data the user owns (lives in `vault/.oms/`).
- * OMS ships defaults in `core/ontology/` and enforces whatever the user declares.
+ * Oh My Second Brain ships defaults in `core/ontology/` and enforces whatever the user declares.
  *
  * The format is deliberately semantic, not structural: every concept and folder
  * carries a declared `intent` so a host agent reads *why* knowledge lives somewhere,

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -50,11 +50,11 @@ describe("claude-code plugin DoD", () => {
     }
   });
 
-  it("the setup skill SKILL.md mentions 'npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz'", async () => {
+  it("the setup skill SKILL.md mentions 'npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz'", async () => {
     // The setup skill entry is "./skills/setup/" relative to the plugin root.
     const setupSkillPath = path.resolve(pluginRoot, "./skills/setup/SKILL.md");
     const content = await readFile(setupSkillPath, "utf-8");
-    expect(content).toContain("npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz");
+    expect(content).toContain("npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz");
   });
 });
 

--- a/src/setup.e2e.test.ts
+++ b/src/setup.e2e.test.ts
@@ -60,7 +60,7 @@ describe("runSetup --yes E2E", () => {
     expect(plan.pluginPath).toContain("adapters/claude-code");
     expect(plan.pluginInstallCommand).toContain("claude plugin install");
     expect(plan.mcpRegistrationCommand).toBe(
-      "claude mcp add oms -- npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.4/oms-0.1.4.tgz mcp --vault '/tmp/My Vault'",
+      "claude mcp add oms -- npx -y https://github.com/GoBeromsu/oms/releases/download/oms-v0.1.5/oms-0.1.5.tgz mcp --vault '/tmp/My Vault'",
     );
     expect(plan.mcpRuntimeStatus).toBe("read-status-runtime");
   });


### PR DESCRIPTION
## Summary
- Sets the human-facing project name to **Oh My Second Brain** while keeping `oms` as package/CLI/MCP/repo slug.
- Updates docs, adapter manifests/skills, packaged core guidance, CLI/MCP display text, and installer output.
- Bumps release metadata and GitHub release URLs to `oms-v0.1.5` / `oms-0.1.5.tgz`.

## Verification
- [x] npm run release:check
- [x] node dist/cli/oms.js --help
- [x] node dist/cli/oms.js install --runtime all --vault /tmp/Vault --dry-run
- [x] npm pack --json
- [x] unpacked tarball legacy lexa/lxa content scan

## Notes
`OMS_*` env vars and internal Codex managed MCP markers remain technical identifiers for compatibility; display name is Oh My Second Brain.
