### PR TITLE
refactor(install): drop dead agent-vault (OMS_AGENT_VAULT) support

### DIFF
--- a/adapters/claude-code/hooks/oms-guard.mjs
+++ b/adapters/claude-code/hooks/oms-guard.mjs
@@ -8,7 +8,6 @@
  *
  * Configuration (env vars set by the settings.json hook definition):
  *   OMS_VAULT        — primary vault path (e.g. /Users/…/Ataraxia)
- *   OMS_AGENT_VAULT  — agent vault path  (e.g. /Users/…/agent)
  *   OMS_GUARD        — set to "off" to bypass all checks
  *
  * Fail-open: any error (oms crash, timeout, invalid JSON) → {"continue": true}.
@@ -74,7 +73,6 @@ async function main() {
 
   const vaultPaths = [
     process.env.OMS_VAULT,
-    process.env.OMS_AGENT_VAULT,
   ].filter(Boolean);
 
   // No vaults configured → pass through.

--- a/adapters/claude-code/hooks/oms-post-guard.mjs
+++ b/adapters/claude-code/hooks/oms-post-guard.mjs
@@ -8,7 +8,6 @@
  *
  * Configuration (env vars set by the settings.json hook definition):
  *   OMS_VAULT        — primary vault path
- *   OMS_AGENT_VAULT  — agent vault path
  *
  * Fail-open: any error → silent return (PostToolUse hooks are advisory).
  */
@@ -63,7 +62,6 @@ async function readStdin(timeoutMs = 5000) {
 async function main() {
   const vaultPaths = [
     process.env.OMS_VAULT,
-    process.env.OMS_AGENT_VAULT,
   ].filter(Boolean);
 
   if (vaultPaths.length === 0) return;

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -731,7 +731,6 @@ async function main(): Promise<void> {
   let executeExternal = false;
   let checkUpdate = false;
   let timeoutMs: number | undefined;
-  let agentVault: string | undefined;
   const unknownFlags: string[] = [];
 
   for (let i = 1; i < argv.length; i++) {
@@ -771,9 +770,6 @@ async function main(): Promise<void> {
         return;
       }
       i++;
-    } else if (argv[i] === "--agent-vault" && argv[i + 1]) {
-      agentVault = path.resolve(argv[i + 1]!);
-      i++;
     } else if (argv[i] === "--dry-run") {
       dryRun = true;
     } else if (argv[i] === "--execute") {
@@ -797,7 +793,6 @@ async function main(): Promise<void> {
       action: command,
       runtime: selectedRuntime,
       vault,
-      agentVault,
       dryRun,
       executeExternal,
       yes,

--- a/src/install/hosts.test.ts
+++ b/src/install/hosts.test.ts
@@ -88,15 +88,10 @@ describe("Claude Code hook wiring helpers", () => {
   });
 
   it("buildGuardCommandString includes OMS_VAULT and guard bin", () => {
-    const cmd = buildGuardCommandString("/Users/testuser/Vault", undefined, "/Users/testuser", "oms-guard");
+    const cmd = buildGuardCommandString("/Users/testuser/Vault", "/Users/testuser", "oms-guard");
     expect(cmd).toContain("OMS_VAULT=");
     expect(cmd).toContain("oms-guard");
     expect(cmd).not.toContain("OMS_AGENT_VAULT");
-  });
-
-  it("buildGuardCommandString includes OMS_AGENT_VAULT when agentVault provided", () => {
-    const cmd = buildGuardCommandString("/Users/testuser/Vault", "/Users/testuser/RawVault", "/Users/testuser", "oms-guard");
-    expect(cmd).toContain("OMS_AGENT_VAULT=");
   });
 
   it("isOmsHookEntry detects marker in hook command", () => {

--- a/src/install/hosts.ts
+++ b/src/install/hosts.ts
@@ -13,8 +13,6 @@ export interface HostOperationOptions {
   action: HostAction;
   runtime: RuntimeSelection;
   vault: string;
-  /** Optional second vault path (e.g. agent/raw vault). Emitted as OMS_AGENT_VAULT. */
-  agentVault?: string;
   packageSpec?: string;
   dryRun?: boolean;
   executeExternal?: boolean;
@@ -142,14 +140,10 @@ export function toShellVaultPath(absPath: string, homeDir: string): string {
 /** Build the shell command string for a guard binary entry. */
 export function buildGuardCommandString(
   vault: string,
-  agentVault: string | undefined,
   homeDir: string,
   guardBin: string,
 ): string {
   const parts: string[] = [`OMS_VAULT=${toShellVaultPath(vault, homeDir)}`];
-  if (agentVault) {
-    parts.push(`OMS_AGENT_VAULT=${toShellVaultPath(agentVault, homeDir)}`);
-  }
   parts.push(guardBin);
   return parts.join(" ");
 }
@@ -203,7 +197,7 @@ async function readSettingsJsonSafe(settingsPath: string): Promise<SettingsReadR
  * Returns a human-readable message and whether the file was changed.
  */
 export async function upsertClaudeHooks(
-  options: Pick<HostOperationOptions, "vault" | "agentVault" | "dryRun" | "homeDir">,
+  options: Pick<HostOperationOptions, "vault" | "dryRun" | "homeDir">,
   claudeDir: string,
 ): Promise<{ changed: boolean; messages: string[] }> {
   const settingsPath = path.join(claudeDir, "settings.json");
@@ -212,8 +206,8 @@ export async function upsertClaudeHooks(
   const messages: string[] = [];
 
   if (corrupt) {
-    const preCmd = buildGuardCommandString(options.vault, options.agentVault, homeDir, GUARD_MARKER);
-    const postCmd = buildGuardCommandString(options.vault, options.agentVault, homeDir, POST_GUARD_MARKER);
+    const preCmd = buildGuardCommandString(options.vault, homeDir, GUARD_MARKER);
+    const postCmd = buildGuardCommandString(options.vault, homeDir, POST_GUARD_MARKER);
     messages.push(
       `WARNING: ${settingsPath} is not valid JSON — hook wiring skipped to avoid data loss.`,
       `Manual step: add these entries to ${settingsPath}:`,
@@ -230,8 +224,8 @@ export async function upsertClaudeHooks(
     : {};
   let changed = false;
 
-  const preCmd = buildGuardCommandString(options.vault, options.agentVault, homeDir, GUARD_MARKER);
-  const postCmd = buildGuardCommandString(options.vault, options.agentVault, homeDir, POST_GUARD_MARKER);
+  const preCmd = buildGuardCommandString(options.vault, homeDir, GUARD_MARKER);
+  const postCmd = buildGuardCommandString(options.vault, homeDir, POST_GUARD_MARKER);
 
   // PreToolUse
   const preArr = Array.isArray(hooks["PreToolUse"]) ? [...(hooks["PreToolUse"] as unknown[])] : [];


### PR DESCRIPTION
## Why

The second **agent vault** was fully absorbed into the single Ataraxia vault on 2026-06-13 (**ADR-001**, single-vault regime). `OMS_AGENT_VAULT` / `agentVault` / `--agent-vault` is now dead code — there is one vault, and AI vs. user content is distinguished by **zones + `created_by` frontmatter**, not by a vault boundary.

This stacks on **#31** (`feat/claude-hook-install`), which introduced the second-vault wiring; it targets that branch so the dead code never reaches `main`.

## What

Removes (leaving `OMS_AGENT_RUNTIME` — the host runtime, e.g. `codex` — **untouched**):

- `HostOperationOptions.agentVault` field (`src/install/hosts.ts`)
- `agentVault` param + `OMS_AGENT_VAULT` emission in `buildGuardCommandString`
- `"agentVault"` from the `upsertClaudeHooks` `Pick<>` and all 4 call sites
- `--agent-vault` CLI arg parsing (`src/cli/oms.ts`)
- `process.env.OMS_AGENT_VAULT` from both guard hooks' `vaultPaths` arrays (`oms-guard.mjs`, `oms-post-guard.mjs`) + their doc comments

`hosts.test.ts`: drops the OMS_AGENT_VAULT-emission test; **keeps** the `not.toContain("OMS_AGENT_VAULT")` assertion as a regression guard.

## Verification

- `npx vitest run src/install/hosts.test.ts` → **13/13 pass**
- `grep -rI "agentVault\|OMS_AGENT_VAULT\|--agent-vault" src adapters` (excluding `OMS_AGENT_RUNTIME`) → **0 hits** (only the intentional `not.toContain` assertion)
- `OMS_AGENT_RUNTIME` references → unchanged

> ⚠️ **Pre-existing, out-of-scope:** the `feat/claude-hook-install` tip does not `tsc`-build on its own — `oms.ts:35` imports `./semantic.js` (committed in `22e65f5`) but no `semantic.*` source is committed yet (it's separate in-flight WIP). That `TS2307` is present with **and without** this diff; this PR neither causes nor fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)