### PR TITLE
refactor(engine): single sqlite-vec semantic store with explicit embedding config

### DIFF
--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -130,10 +130,12 @@ async function mcpSmoke(packageRoot, vault) {
   // StdioClientTransport sandboxes the child env to a safe default subset, so the
   // embedding-model path must be forwarded explicitly or the child is always
   // model-less regardless of this process's env -- which would desync it from the
-  // hasModel gate below. Forward only the local OMS_MODEL_PATH (no remote Upstage
-  // network from an artifact smoke), matching src/mcp/semantic-server.test.ts.
+  // hasModel gate below. Forward the canonical OMS_EMBEDDING_PROVIDER +
+  // OMS_EMBEDDING_MODEL pair (ADR-007: explicit config, no auto-detect),
+  // matching src/mcp/semantic-server.test.ts.
   const childEnv = { ...getDefaultEnvironment() };
-  if (process.env.OMS_MODEL_PATH) childEnv.OMS_MODEL_PATH = process.env.OMS_MODEL_PATH;
+  if (process.env.OMS_EMBEDDING_PROVIDER) childEnv.OMS_EMBEDDING_PROVIDER = process.env.OMS_EMBEDDING_PROVIDER;
+  if (process.env.OMS_EMBEDDING_MODEL) childEnv.OMS_EMBEDDING_MODEL = process.env.OMS_EMBEDDING_MODEL;
   const transport = new StdioClientTransport({
     command: process.execPath,
     args: [cli, "mcp", "--vault", vault],
@@ -202,11 +204,11 @@ async function mcpSmoke(packageRoot, vault) {
     // real results; without one (the default CI runner) we assert the op
     // *refuses to falsely succeed* -- which itself proves it routed to the
     // engine, not the legacy hash store. Mirrors src/mcp/semantic-server.test.ts.
-    // Gate on the local model path only, mirroring semantic-server.test.ts: the
-    // smoke forwards OMS_MODEL_PATH to the child but deliberately leaves the remote
-    // Upstage path out (no network in CI), so gating on UPSTAGE_API_KEY here would
-    // desync the runner gate from the forwarded child env.
-    const hasModel = Boolean(process.env.OMS_MODEL_PATH);
+    // Gate on the canonical embedding pair, mirroring semantic-server.test.ts: the
+    // smoke forwards OMS_EMBEDDING_PROVIDER + OMS_EMBEDDING_MODEL to the child, so the
+    // runner gate must key off the same pair to stay in sync with the forwarded child
+    // env (ADR-007: explicit config, no auto-detect).
+    const hasModel = Boolean(process.env.OMS_EMBEDDING_PROVIDER && process.env.OMS_EMBEDDING_MODEL);
     const textOf = (res) => (res.content?.[0]?.type === "text" ? res.content[0].text : "");
     const syncCall = { name: "oms_sync_embeddings", arguments: { collection: "vault" } };
     const queryCall = {
@@ -237,7 +239,7 @@ async function mcpSmoke(packageRoot, vault) {
     } else {
       // sync gives the strong routing proof: the ADR-007 loud guard naming the model env.
       const sync = await callGuarded(syncCall);
-      if (!sync.guarded || !/OMS_MODEL_PATH|UPSTAGE_API_KEY/.test(sync.text)) {
+      if (!sync.guarded || !/OMS_EMBEDDING_PROVIDER|OMS_EMBEDDING_MODEL/.test(sync.text)) {
         fail("MCP semantic sync did not loud-guard the missing embedding model (ADR-007)");
       }
       // query must likewise refuse to falsely succeed without a model/store.

--- a/src/engine/assemble.test.ts
+++ b/src/engine/assemble.test.ts
@@ -9,8 +9,8 @@
  * another temp dir. Both are cleaned up in afterAll.
  *
  * Assertions:
- *   1. assembleEngine() WITHOUT modelPath (no UPSTAGE_API_KEY) → THROWS.
- *   2. assembleEngine() WITH real modelPath → adapter constructed.
+ *   1. assembleEngine() WITHOUT embedding provider/model → THROWS.
+ *   2. assembleEngine() WITH provider=gguf + real model path → adapter constructed.
  *   3. syncVault() → syncs fixture, stores real 768d embeddings.
  *   4. vec0 stored dimension == 768 (proven via sqlite_master DDL).
  *   5. semantic query via adapter → astronomy doc ranks #1 for astronomy query.
@@ -129,35 +129,35 @@ function readVec0Dimension(dbPath: string): number | null {
 // ---------------------------------------------------------------------------
 
 describe("assembleEngine — strict guard (no model needed)", () => {
-  it("THROWS when no modelPath and no UPSTAGE_API_KEY", () => {
+  it("THROWS asking for OMS_EMBEDDING_PROVIDER when no provider/model configured", () => {
     const saved = process.env["UPSTAGE_API_KEY"];
     delete process.env["UPSTAGE_API_KEY"];
     try {
       expect(() =>
         assembleEngine({ vault: "/tmp/fake-vault" }),
-      ).toThrow("OMS_MODEL_PATH");
+      ).toThrow("OMS_EMBEDDING_PROVIDER");
     } finally {
       if (saved !== undefined) process.env["UPSTAGE_API_KEY"] = saved;
     }
   });
 
-  it("error message mentions hash-projection to explain what was avoided", () => {
+  it("THROWS asking for OMS_EMBEDDING_MODEL when provider is set but model is missing", () => {
     const saved = process.env["UPSTAGE_API_KEY"];
     delete process.env["UPSTAGE_API_KEY"];
     try {
       expect(() =>
-        assembleEngine({ vault: "/tmp/fake-vault" }),
-      ).toThrow("hash-projection");
+        assembleEngine({ vault: "/tmp/fake-vault", embeddingProvider: "gguf" }),
+      ).toThrow("OMS_EMBEDDING_MODEL");
     } finally {
       if (saved !== undefined) process.env["UPSTAGE_API_KEY"] = saved;
     }
   });
 
-  it("requireRealEmbeddingProvider THROWS when no modelPath and no UPSTAGE_API_KEY", () => {
+  it("requireRealEmbeddingProvider THROWS when no provider/model configured", () => {
     const saved = process.env["UPSTAGE_API_KEY"];
     delete process.env["UPSTAGE_API_KEY"];
     try {
-      expect(() => requireRealEmbeddingProvider({})).toThrow("OMS_MODEL_PATH");
+      expect(() => requireRealEmbeddingProvider({})).toThrow("OMS_EMBEDDING_PROVIDER");
     } finally {
       if (saved !== undefined) process.env["UPSTAGE_API_KEY"] = saved;
     }
@@ -168,8 +168,8 @@ describe("assembleEngine — strict guard (no model needed)", () => {
 // Stub-wiring test — adapter construction with fake provider (always runs)
 // ---------------------------------------------------------------------------
 
-describe("assembleEngine — stub-wiring via UPSTAGE_API_KEY shim", () => {
-  it("constructs adapter when UPSTAGE_API_KEY is set (does not call API)", () => {
+describe("assembleEngine — stub-wiring via explicit Upstage config", () => {
+  it("constructs adapter when provider=upstage + model + key are set (does not call API)", () => {
     let tmpVault = "";
     let tmpDb = "";
     const saved = process.env["UPSTAGE_API_KEY"];
@@ -180,7 +180,12 @@ describe("assembleEngine — stub-wiring via UPSTAGE_API_KEY shim", () => {
         "stub.sqlite",
       );
       process.env["UPSTAGE_API_KEY"] = "stub-key-for-construction-test";
-      const engine = assembleEngine({ vault: tmpVault, dbPath: tmpDb });
+      const engine = assembleEngine({
+        vault: tmpVault,
+        dbPath: tmpDb,
+        embeddingProvider: "upstage",
+        embeddingModel: "solar-embedding-1-large",
+      });
       expect(engine.adapter).toBeDefined();
       expect(engine.provider.model).toContain("upstage");
       // No embed() called — dispose is safe
@@ -217,7 +222,8 @@ describe.skipIf(!SMOKE_ENABLED)(
       () => {
         engine = assembleEngine({
           vault: fixtureVault,
-          modelPath: MODEL_PATH,
+          embeddingProvider: "gguf",
+          embeddingModel: MODEL_PATH,
           dbPath: fixtureDb,
         });
         expect(engine.provider.dimensions).toBe(768);

--- a/src/engine/assemble.ts
+++ b/src/engine/assemble.ts
@@ -1,22 +1,17 @@
 /**
  * Assemble — production wiring for the OMS engine.
  *
- * Constructs a ready McpEngineAdapter from a minimal config object, wiring:
- *   - EmbeddingProvider via the STRICT factory (requireRealEmbeddingProvider)
- *     so missing model → loud throw, never silent hash-projection fallback.
- *   - EngineStore via openEngineStore(dbPath, provider.dimensions) — dimensions
- *     come from the provider itself, never hardcoded, so native-dim-in == stored-dim-out.
- *   - DispatcherDeps assembled from store + embed + optional tuning knobs.
- *   - McpEngineAdapter constructed with those deps.
+ * This module owns the construction of the engine's McpEngineAdapter and its
+ * injected backend dependencies.
  *
- * All 10 MCP ops are live on the adapter (retrieve_by_axis / retrieve_context
- * are wired to the engine C2 graph + node index as of the task #5 swap).
- *
- * R18: NO runtime import from src/search.
+ * RALPLAN constraints (approved):
+ * - No silent fallback for vec/HyDE.
+ * - Explicit embedding configuration: OMS_EMBEDDING_PROVIDER + OMS_EMBEDDING_MODEL.
+ * - Lex-only semantic queries must remain usable without embedding configuration.
  */
 
 import { requireRealEmbeddingProvider } from "./embed/provider.js";
-import { openEngineStore } from "./embed/store.js";
+import { openEngineStore, openEngineStoreCore } from "./embed/store.js";
 import { syncEngineStore } from "./embed/sync.js";
 import { McpEngineAdapter } from "./mcp/facade.js";
 import { makeDeferredProvider, makeDeferredStore } from "./embed/deferred.js";
@@ -28,24 +23,18 @@ import type { EmbeddingProvider } from "./types.js";
 // Public config type
 // ---------------------------------------------------------------------------
 
-/** Configuration for assembleEngine(). */
+/** Configuration for assembleEngine() / assembleCoreSemanticEngine(). */
 export interface AssembleConfig {
-  /**
-   * Absolute path to the Obsidian vault root.
-   * Used as the default dbPath parent and as vault root for syncEngineStore().
-   */
+  /** Absolute path to the vault root. */
   vault: string;
 
-  /**
-   * Absolute path to the GGUF model file.
-   * When absent AND UPSTAGE_API_KEY is unset, assembleEngine() throws.
-   */
-  modelPath?: string;
+  /** Optional explicit embedding provider id (OMS_EMBEDDING_PROVIDER). */
+  embeddingProvider?: string;
 
-  /**
-   * Absolute path to the SQLite engine store database file.
-   * Default: <vault>/.oms/engine-store.sqlite
-   */
+  /** Optional explicit embedding model/id/path (OMS_EMBEDDING_MODEL). */
+  embeddingModel?: string;
+
+  /** Absolute path to the SQLite engine store database file. Default: <vault>/.oms/engine-store.sqlite */
   dbPath?: string;
 
   /** RRF smoothing constant passed to DispatcherDeps (default 60). */
@@ -59,41 +48,23 @@ export interface AssembleConfig {
 // Assembled engine handle
 // ---------------------------------------------------------------------------
 
-/**
- * The assembled engine: the MCP adapter plus the underlying primitives
- * exposed for testing (smoke tests, task #8 wiring) and for syncVault().
- */
 export interface AssembledEngine {
-  /** The ready McpEngineAdapter wired to real store + embed. */
   adapter: McpEngineAdapter;
-  /** The underlying DispatcherDeps (store + embed + tuning). */
   deps: DispatcherDeps;
-  /** Direct reference to the EngineStore (EngineStore ⊃ VectorStore). */
   store: EngineStore;
-  /** Direct reference to the EmbeddingProvider. */
   provider: EmbeddingProvider;
-  /**
-   * Sync the vault (or a sub-path) into the store using the assembled provider.
-   * Delegates to syncEngineStore() with the same modelPath / dbPath / vault.
-   * Returns sync counters.
-   */
   syncVault(opts?: SyncVaultOptions): Promise<SyncVaultResult>;
-  /**
-   * Release resources: disposes the embedding provider and closes the store.
-   * Call this when the engine is no longer needed (e.g. after a sync script).
-   */
   dispose(): Promise<void>;
 }
 
-/** Options for AssembledEngine.syncVault(). */
 export interface SyncVaultOptions {
-  /** Vault-relative sub-path to sync (default: entire vault). */
   collectionPath?: string;
-  /** When false, stores chunks without embedding (scan-only mode). Default true. */
+  /** Default true. */
   embed?: boolean;
+  /** When true, allows destructive vector rebuild on mismatch. Default false. */
+  force?: boolean;
 }
 
-/** Counters returned by AssembledEngine.syncVault(). */
 export interface SyncVaultResult {
   scanned: number;
   added: number;
@@ -104,47 +75,37 @@ export interface SyncVaultResult {
 }
 
 // ---------------------------------------------------------------------------
-// Public factory
+// Public factories
 // ---------------------------------------------------------------------------
 
 /**
- * Assemble a production-ready McpEngineAdapter from config.
+ * Assemble a semantic-capable engine with a REAL embedding provider.
  *
- * Resolution order for the embedding provider (strict — no hash-projection):
- *   1. UPSTAGE_API_KEY env var → Upstage Solar (4096d).
- *   2. config.modelPath → GGUF / node-llama-cpp (768d EmbeddingGemma-300M).
- *   3. Neither → throws (OMS_MODEL_PATH / missing GGUF model mentioned in message).
- *
- * The store is opened with provider.dimensions so the vec0 DDL bakes in the
- * correct dimension count (768 for GGUF, 4096 for Upstage) — native-dim-in == stored-dim-out.
- *
- * @param config - Vault path, optional modelPath, optional dbPath and tuning knobs.
- * @returns An AssembledEngine with adapter, deps, store, provider, syncVault, dispose.
- * @throws {Error} When no real embedding provider is available (strict guard).
+ * This is the production semantic engine. It requires explicit embedding
+ * configuration and never fabricates vectors.
  */
 export function assembleEngine(config: AssembleConfig): AssembledEngine {
   const vault = config.vault;
   const dbPath = config.dbPath ?? `${vault}/.oms/engine-store.sqlite`;
 
-  // Strict: throws if no real provider is available (Step 0 guard)
-  const provider = requireRealEmbeddingProvider({ modelPath: config.modelPath });
+  const provider = requireRealEmbeddingProvider({
+    provider: config.embeddingProvider,
+    model: config.embeddingModel,
+  });
 
-  // Open store with provider.dimensions — never a hardcoded number
-  // This is the critical invariant: native-dim-in == stored-dim-out
   const store = openEngineStore(dbPath, provider.dimensions);
 
-  // Build DispatcherDeps per dispatcher.ts:111
   const deps: DispatcherDeps = {
     store,
     embed: provider,
     ...(config.rrfK !== undefined ? { rrfK: config.rrfK } : {}),
     ...(config.graphDepth !== undefined ? { graphDepth: config.graphDepth } : {}),
-    // graphTraverse, hydeGenerator, provenanceMap: not wired here (C2 / M2+)
   };
 
-  // Thread the resolved model path so adapter.syncEmbeddings (MCP sync, no
-  // per-call modelPath) reaches the real provider — see McpEngineAdapter ctor.
-  const adapter = new McpEngineAdapter(deps, vault, config.modelPath);
+  const adapter = new McpEngineAdapter(deps, vault, {
+    embeddingProvider: config.embeddingProvider,
+    embeddingModel: config.embeddingModel,
+  });
 
   return {
     adapter,
@@ -153,16 +114,14 @@ export function assembleEngine(config: AssembleConfig): AssembledEngine {
     provider,
 
     async syncVault(opts: SyncVaultOptions = {}): Promise<SyncVaultResult> {
-      // syncEngineStore opens its own provider+store internally, but we already
-      // have a live provider. To avoid double-loading the model we call
-      // syncEngineStore with modelPath so it can short-circuit via its own lazy
-      // load — the GGUF pool deduplicates via loadPromise within the same process.
       const result = await syncEngineStore({
         vault,
         dbPath,
-        modelPath: config.modelPath,
-        embed: opts.embed,
         collectionPath: opts.collectionPath,
+        embed: opts.embed,
+        force: opts.force,
+        embeddingProvider: config.embeddingProvider,
+        embeddingModel: config.embeddingModel,
       });
       return {
         scanned: result.scanned,
@@ -181,26 +140,68 @@ export function assembleEngine(config: AssembleConfig): AssembledEngine {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Graph-only factory (Option-1 swap)
-// ---------------------------------------------------------------------------
+/**
+ * Assemble a CORE-ONLY semantic engine.
+ *
+ * This engine opens the sqlite store in core-only mode and wires a deferred
+ * embedder. It enables lex-only semantic operations without embedding config.
+ * vec/HyDE operations will fail (embed() throws; vecAvailable is false).
+ */
+export function assembleCoreSemanticEngine(config: AssembleConfig): AssembledEngine {
+  const vault = config.vault;
+  const dbPath = config.dbPath ?? `${vault}/.oms/engine-store.sqlite`;
+
+  const provider = makeDeferredProvider();
+  const store = openEngineStoreCore(dbPath);
+
+  const deps: DispatcherDeps = {
+    store,
+    embed: provider,
+    ...(config.rrfK !== undefined ? { rrfK: config.rrfK } : {}),
+    ...(config.graphDepth !== undefined ? { graphDepth: config.graphDepth } : {}),
+  };
+
+  const adapter = new McpEngineAdapter(deps, vault, {
+    embeddingProvider: config.embeddingProvider,
+    embeddingModel: config.embeddingModel,
+  });
+
+  return {
+    adapter,
+    deps,
+    store,
+    provider,
+
+    async syncVault(opts: SyncVaultOptions = {}): Promise<SyncVaultResult> {
+      const result = await syncEngineStore({
+        vault,
+        dbPath,
+        collectionPath: opts.collectionPath,
+        embed: opts.embed,
+        force: opts.force,
+        embeddingProvider: config.embeddingProvider,
+        embeddingModel: config.embeddingModel,
+      });
+      return {
+        scanned: result.scanned,
+        added: result.added,
+        updated: result.updated,
+        skipped: result.skipped,
+        available: result.available,
+        reason: result.reason,
+      };
+    },
+
+    async dispose(): Promise<void> {
+      await provider.dispose().catch(() => undefined);
+      store.close();
+    },
+  };
+}
 
 /**
- * Assemble a GRAPH-ONLY engine: a McpEngineAdapter whose graph ops (build,
- * status, axis-first retrieval) run model-free off the filesystem, with
- * deferred (throw-on-use) embedding provider + store standing in for the
- * semantic layer.
- *
- * Used by the MCP server's Option-1 swap: the engine owns axis-first retrieval
- * immediately (no model required), while semantic retrieval stays on the
- * src/search layer until the engine reaches output parity. Unlike
- * assembleEngine(), this NEVER opens a SQLite store and NEVER loads a model, so
- * it is side-effect-free and safe to call on every server boot (R2 stateless).
- * The deferred primitives are LOUD GUARDS (ADR-007): any accidental semantic
- * call throws rather than fabricating vectors.
- *
- * @param config - Vault path (+ optional rrfK/graphDepth; modelPath/dbPath ignored).
- * @returns An AssembledEngine whose adapter serves graph ops; semantic ops throw.
+ * Assemble a GRAPH-ONLY engine: graph ops run model-free; semantic store/embed
+ * are throw-on-use guards.
  */
 export function assembleGraphOnlyEngine(config: AssembleConfig): AssembledEngine {
   const vault = config.vault;
@@ -223,8 +224,6 @@ export function assembleGraphOnlyEngine(config: AssembleConfig): AssembledEngine
     provider,
 
     async syncVault(): Promise<SyncVaultResult> {
-      // Graph-only: vault embedding-sync requires a real provider. Report
-      // unavailable rather than throwing so callers can degrade gracefully.
       return {
         scanned: 0,
         added: 0,
@@ -232,8 +231,7 @@ export function assembleGraphOnlyEngine(config: AssembleConfig): AssembledEngine
         skipped: 0,
         available: false,
         reason:
-          "graph-only engine: vault sync requires a real embedding provider " +
-          "(set OMS_MODEL_PATH or UPSTAGE_API_KEY).",
+          "graph-only engine: embedding sync requires an explicit embedding provider/model.",
       };
     },
 

--- a/src/engine/embed/deferred.ts
+++ b/src/engine/embed/deferred.ts
@@ -38,9 +38,9 @@ export function makeDeferredProvider(): EmbeddingProvider {
     embed(_text: string): Promise<Float32Array> {
       return Promise.reject(
         new Error(
-          `${GRAPH_ONLY}: embedding provider unavailable. Set OMS_MODEL_PATH or ` +
-            `UPSTAGE_API_KEY for engine semantic ops; semantic retrieval otherwise ` +
-            `stays on the src/search layer.`,
+          `${GRAPH_ONLY}: embedding provider unavailable. Configure embeddings via ` +
+            `OMS_EMBEDDING_PROVIDER + OMS_EMBEDDING_MODEL (and provider auth env vars, ` +
+            `e.g. UPSTAGE_API_KEY) for engine semantic ops.`,
         ),
       );
     },
@@ -66,6 +66,10 @@ export function makeDeferredStore(): EngineStore {
     );
   };
   return {
+    capabilities: () => ({ vecAvailable: false }),
+    upsertLex: () => unavailable(),
+    readEmbeddingIdentity: () => unavailable(),
+    writeEmbeddingIdentity: () => unavailable(),
     upsert: () => unavailable(),
     queryVec: () => unavailable(),
     queryLex: () => unavailable(),

--- a/src/engine/embed/identity.ts
+++ b/src/engine/embed/identity.ts
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto";
+import { ENGINE_EMBED_META_VERSION, type EmbeddingIdentity } from "./store.js";
+
+export function fingerprintEmbeddingIdentity(input: {
+  provider: string;
+  model: string;
+  dimensions: number;
+}): string {
+  const raw = [ENGINE_EMBED_META_VERSION, input.provider, input.model, String(input.dimensions)].join("\u0000");
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+export function makeEmbeddingIdentity(input: {
+  provider: string;
+  model: string;
+  dimensions: number;
+}): EmbeddingIdentity {
+  return {
+    provider: input.provider,
+    model: input.model,
+    dimensions: input.dimensions,
+    fingerprint: fingerprintEmbeddingIdentity(input),
+  };
+}
+
+export function embeddingIdentityEqual(a: EmbeddingIdentity, b: EmbeddingIdentity): boolean {
+  return (
+    a.provider === b.provider &&
+    a.model === b.model &&
+    a.dimensions === b.dimensions &&
+    a.fingerprint === b.fingerprint
+  );
+}

--- a/src/engine/embed/provider.test.ts
+++ b/src/engine/embed/provider.test.ts
@@ -66,10 +66,10 @@ describe("createHashProjectionProvider", () => {
 // ---------------------------------------------------------------------------
 
 describe("requireRealEmbeddingProvider — GGUF path", () => {
-  it("returns GGUF provider when modelPath is provided", () => {
+  it("returns GGUF provider when provider=gguf + model are provided", () => {
     const saved = process.env["UPSTAGE_API_KEY"];
     delete process.env["UPSTAGE_API_KEY"];
-    const p = requireRealEmbeddingProvider({ modelPath: "/fake/model.gguf" });
+    const p = requireRealEmbeddingProvider({ provider: "gguf", model: "/fake/model.gguf" });
     expect(p.model).toMatch(/^node-llama-cpp:/);
     expect(p.dimensions).toBe(GGUF_EMBEDDING_DIMENSIONS);
     if (saved !== undefined) process.env["UPSTAGE_API_KEY"] = saved;
@@ -91,10 +91,6 @@ describe("requireRealEmbeddingProvider — GGUF path", () => {
 });
 
 // ---------------------------------------------------------------------------
-// GGUF provider with real model (skipped unless OMS_MODEL_PATH is set)
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // requireRealEmbeddingProvider — strict production factory
 // ---------------------------------------------------------------------------
 
@@ -109,31 +105,54 @@ describe("requireRealEmbeddingProvider — strict guard", () => {
     }
   });
 
-  it("THROWS with OMS_MODEL_PATH message when no modelPath and no UPSTAGE_API_KEY", () => {
+  it("THROWS asking for OMS_EMBEDDING_PROVIDER when no provider is configured", () => {
     savedUpstage = process.env["UPSTAGE_API_KEY"];
     delete process.env["UPSTAGE_API_KEY"];
-    expect(() => requireRealEmbeddingProvider({})).toThrow("OMS_MODEL_PATH");
+    expect(() => requireRealEmbeddingProvider({})).toThrow("OMS_EMBEDDING_PROVIDER");
   });
 
-  it("THROWS mentioning 'hash-projection' to make the guard rationale clear", () => {
+  it("THROWS asking for OMS_EMBEDDING_MODEL when provider is set but model is missing", () => {
     savedUpstage = process.env["UPSTAGE_API_KEY"];
     delete process.env["UPSTAGE_API_KEY"];
-    expect(() => requireRealEmbeddingProvider()).toThrow("hash-projection");
+    expect(() => requireRealEmbeddingProvider({ provider: "gguf" })).toThrow("OMS_EMBEDDING_MODEL");
   });
 
-  it("returns GGUF provider (dimensions===768) when modelPath is given", () => {
+  it("returns GGUF provider (dimensions===768) when provider=gguf + model are given", () => {
     savedUpstage = process.env["UPSTAGE_API_KEY"];
     delete process.env["UPSTAGE_API_KEY"];
-    const p = requireRealEmbeddingProvider({ modelPath: "/fake/model.gguf" });
+    const p = requireRealEmbeddingProvider({ provider: "gguf", model: "/fake/model.gguf" });
     expect(p.model).toMatch(/^node-llama-cpp:/);
     expect(p.dimensions).toBe(768);
   });
 
-  it("does NOT throw when UPSTAGE_API_KEY is set (Upstage path)", () => {
+  it("does NOT auto-detect Upstage from UPSTAGE_API_KEY — provider must be explicit", () => {
     savedUpstage = process.env["UPSTAGE_API_KEY"];
     process.env["UPSTAGE_API_KEY"] = "test-key-123";
-    const p = requireRealEmbeddingProvider({});
+    // Key present but no OMS_EMBEDDING_PROVIDER → still throws (no key-based auto-detect).
+    expect(() => requireRealEmbeddingProvider({})).toThrow("OMS_EMBEDDING_PROVIDER");
+  });
+
+  it("returns Upstage provider when provider=upstage + model + UPSTAGE_API_KEY are set", () => {
+    savedUpstage = process.env["UPSTAGE_API_KEY"];
+    process.env["UPSTAGE_API_KEY"] = "test-key-123";
+    const p = requireRealEmbeddingProvider({ provider: "upstage", model: "solar-embedding-1-large" });
     expect(p.model).toContain("upstage");
+  });
+
+  it("THROWS for provider=upstage when UPSTAGE_API_KEY is missing", () => {
+    savedUpstage = process.env["UPSTAGE_API_KEY"];
+    delete process.env["UPSTAGE_API_KEY"];
+    expect(() =>
+      requireRealEmbeddingProvider({ provider: "upstage", model: "solar-embedding-1-large" }),
+    ).toThrow("UPSTAGE_API_KEY");
+  });
+
+  it("THROWS for an unsupported provider id", () => {
+    savedUpstage = process.env["UPSTAGE_API_KEY"];
+    delete process.env["UPSTAGE_API_KEY"];
+    expect(() =>
+      requireRealEmbeddingProvider({ provider: "cohere", model: "embed-v3" }),
+    ).toThrow("unsupported");
   });
 });
 

--- a/src/engine/embed/provider.ts
+++ b/src/engine/embed/provider.ts
@@ -216,7 +216,7 @@ export function createGGUFEmbeddingProvider(
 
 const UPSTAGE_DIMENSIONS = 4096;
 const UPSTAGE_API_URL = "https://api.upstage.ai/v1/embeddings";
-const UPSTAGE_MODEL = "embedding-passage";
+// No default model: OMS config must supply OMS_EMBEDDING_MODEL explicitly.
 
 interface UpstageEmbeddingResponse {
   data: Array<{ embedding: number[]; index: number }>;
@@ -229,9 +229,9 @@ interface UpstageEmbeddingResponse {
  * when UPSTAGE_API_KEY is set in the environment; never use by default.
  * The API key MUST come from env — never hardcoded (R4 secrets-via-env).
  */
-export function createUpstageProvider(apiKey: string): EmbeddingProvider {
+export function createUpstageProvider(apiKey: string, model: string): EmbeddingProvider {
   return {
-    model: "upstage-embedding-passage:4096d",
+    model: `upstage:${model}`,
     dimensions: UPSTAGE_DIMENSIONS,
 
     async embed(text: string): Promise<Float32Array> {
@@ -249,7 +249,7 @@ export function createUpstageProvider(apiKey: string): EmbeddingProvider {
             "Content-Type": "application/json",
             Authorization: `Bearer ${apiKey}`,
           },
-          body: JSON.stringify({ input, model: UPSTAGE_MODEL }),
+          body: JSON.stringify({ input, model }),
         });
         if (response.ok) {
           const json = (await response.json()) as UpstageEmbeddingResponse;
@@ -284,13 +284,17 @@ export function createUpstageProvider(apiKey: string): EmbeddingProvider {
 }
 
 // ---------------------------------------------------------------------------
-// Production factory — strict, fails loud when no real model is available
+// Production factory — strict, explicit, no auto-detect
 // ---------------------------------------------------------------------------
 
-/** Options for the production embedding factory. */
+export type EmbeddingProviderKind = "gguf" | "upstage";
+
+/** Options for the production embedding factory (explicit provider + model). */
 export interface EmbeddingProviderOptions {
-  /** Absolute path to a GGUF model file (enables real 768d embeddings). */
-  modelPath?: string;
+  /** Provider id selected by OMS_EMBEDDING_PROVIDER. */
+  provider?: EmbeddingProviderKind | string;
+  /** Provider-specific model identifier selected by OMS_EMBEDDING_MODEL. */
+  model?: string;
 }
 
 /** Alias kept for callers that import StrictEmbeddingProviderOptions by name. */
@@ -299,34 +303,48 @@ export type StrictEmbeddingProviderOptions = EmbeddingProviderOptions;
 /**
  * Resolve a REAL embedding provider or throw.
  *
- * This is the ONE production factory for the OMS engine.  It NEVER falls back
- * to a fake/stub embedder — missing configuration is a loud error, not a
- * silent corruption.
+ * This is the ONE production factory for the OMS engine. It NEVER falls back to
+ * a fake/stub embedder and it NEVER auto-selects a provider based on env key
+ * presence (UPSTAGE_API_KEY, etc.). Provider selection is explicit.
  *
- * Resolution order:
- *   1. UPSTAGE_API_KEY env var set → Upstage Solar (4096d).
- *   2. opts.modelPath provided → GGUF / node-llama-cpp (768d, EmbeddingGemma-300M).
- *   3. Neither available → throws with a clear message mentioning OMS_MODEL_PATH.
- *
- * @throws {Error} When neither UPSTAGE_API_KEY nor modelPath is available.
+ * @throws {Error} When provider/model are missing or unsupported, or when
+ *                 provider-specific auth is missing.
  */
 export function requireRealEmbeddingProvider(
   opts: StrictEmbeddingProviderOptions = {},
 ): EmbeddingProvider {
-  const upstageKey = process.env["UPSTAGE_API_KEY"];
-  if (upstageKey) {
-    return createUpstageProvider(upstageKey);
+  const providerRaw = (opts.provider ?? "").toString().trim();
+  const model = (opts.model ?? "").toString().trim();
+
+  if (!providerRaw) {
+    throw new Error(
+      "OMS embedding provider is not configured. Set OMS_EMBEDDING_PROVIDER " +
+        "(e.g. gguf or upstage) and OMS_EMBEDDING_MODEL, then rerun sync.",
+    );
   }
-  if (opts.modelPath) {
-    return createGGUFEmbeddingProvider(opts.modelPath);
+  if (!model) {
+    throw new Error(
+      `OMS embedding model is not configured for provider "${providerRaw}". ` +
+        "Set OMS_EMBEDDING_MODEL and rerun sync.",
+    );
   }
+
+  if (providerRaw === "gguf") {
+    return createGGUFEmbeddingProvider(model);
+  }
+
+  if (providerRaw === "upstage") {
+    const upstageKey = process.env["UPSTAGE_API_KEY"];
+    if (!upstageKey) {
+      throw new Error(
+        "OMS embedding provider is configured as upstage but UPSTAGE_API_KEY is missing.",
+      );
+    }
+    return createUpstageProvider(upstageKey, model);
+  }
+
   throw new Error(
-    "OMS production path requires a real embedding model but none is configured. " +
-    "Set OMS_MODEL_PATH to the absolute path of the GGUF model file " +
-    "(e.g. /path/to/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf) " +
-    "or set UPSTAGE_API_KEY for the Upstage Solar API. " +
-    "The hash-projection fallback (model id 'hash-projection:dim=64') is NOT " +
-    "permitted on the production assemble path — it would silently produce " +
-    "fake embeddings and corrupt the vault index.",
+    `OMS embedding provider "${providerRaw}" is unsupported. ` +
+      "Supported providers: gguf, upstage.",
   );
 }

--- a/src/engine/embed/store.ts
+++ b/src/engine/embed/store.ts
@@ -1,8 +1,10 @@
 /**
- * SQLite-backed VectorStore: sqlite-vec ANN + FTS5 BM25.
+ * SQLite-backed EngineStore: FTS5 lexical search + sqlite-vec ANN.
  *
- * Schema is isolated under `engine_chunk_*` tables to coexist with the
- * existing src/search layer in the same SQLite file if needed.
+ * RALPLAN constraints (approved):
+ * - Core schema (meta + FTS + engine_meta) MUST exist even when sqlite-vec is unavailable.
+ * - vec/HyDE MUST NOT silently degrade to empty hits; vector usage must fail loudly.
+ * - A core-only open path must exist for lex-only operation without embedding config.
  */
 
 import { mkdirSync } from "node:fs";
@@ -12,44 +14,71 @@ import * as sqliteVec from "sqlite-vec";
 import type { Chunk, ScoredHit, VectorStore } from "../types.js";
 
 // ---------------------------------------------------------------------------
-// Extended store interface (superset of VectorStore — dispatcher-safe)
+// Public types
 // ---------------------------------------------------------------------------
 
+export type SqliteVecLoader = (db: Database.Database) => void;
+
+export const DEFAULT_SQLITE_VEC_LOADER: SqliteVecLoader = (db) => sqliteVec.load(db);
+
+export interface EngineStoreCapabilities {
+  readonly vecAvailable: boolean;
+}
+
+export interface EmbeddingIdentity {
+  readonly provider: string;
+  readonly model: string;
+  readonly dimensions: number;
+  readonly fingerprint: string;
+}
+
 /**
- * Extended VectorStore returned by openEngineStore().
+ * Extended VectorStore returned by openEngineStore()/openEngineStoreCore().
  *
- * Adds two helpers needed by the vault→store sync layer without disturbing
- * the VectorStore interface consumed by the retrieval dispatcher.
  * EngineStore satisfies VectorStore everywhere (structural subtype).
  */
 export interface EngineStore extends VectorStore {
+  /** Capability snapshot for this store handle. */
+  capabilities(): EngineStoreCapabilities;
+
+  /** Upsert chunks into meta+FTS only (no vectors). */
+  upsertLex(rows: ReadonlyArray<Chunk>): void;
+
+  /** Read stored embedding identity (null when none is recorded). */
+  readEmbeddingIdentity(): EmbeddingIdentity | null;
+
+  /** Overwrite stored embedding identity and updated_at. */
+  writeEmbeddingIdentity(identity: EmbeddingIdentity): void;
+
   /**
-   * Return a Map from chunk ordinal → stored SHA-256 for all chunks of
-   * `docPath`.  Used by syncEngineStore() to skip re-embedding unchanged chunks.
+   * Return a Map from chunk ordinal → stored SHA-256 for all chunks of `docPath`.
+   * Used by syncEngineStore() to skip reprocessing unchanged chunks.
    */
   getShas(docPath: string): Map<number, string>;
-  /**
-   * Delete all chunks (meta + vec + FTS) for `docPath`.
-   * Useful when a document is deleted from the vault.
-   */
+
+  /** Delete all chunks (meta + vec + FTS) for `docPath`. */
   clearDocument(docPath: string): void;
-  /**
-   * Return every distinct `doc_path` currently stored.
-   * Used by the cleanup op to diff stored docs against live vault paths.
-   */
+
+  /** Return every distinct `doc_path` currently stored. */
   listDocPaths(): string[];
 }
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const ENGINE_EMBED_META_VERSION = "oms-embed-meta-v1";
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** Pack a Float32Array as a raw-bytes Buffer for sqlite-vec MATCH queries. */
+/** Pack a Float32Array as raw-bytes Buffer for sqlite-vec MATCH queries. */
 function vecBuf(vector: Float32Array): Buffer {
   return Buffer.from(vector.buffer, vector.byteOffset, vector.byteLength);
 }
 
-/** Simple tokeniser for FTS5 query building — mirrors the search layer approach. */
+/** Simple tokeniser for FTS5 query building — mirrors the legacy search layer. */
 function makeFtsQuery(text: string): string {
   const terms = text
     .toLowerCase()
@@ -61,14 +90,29 @@ function makeFtsQuery(text: string): string {
   return terms.map((t) => `${t.replace(/"/g, "")}*`).join(" OR ");
 }
 
-// ---------------------------------------------------------------------------
-// Schema bootstrap
-// ---------------------------------------------------------------------------
-
-function ensureSchema(db: Database.Database, dimensions: number): boolean {
+function ensureCoreSchema(db: Database.Database): void {
   db.pragma("journal_mode = WAL");
 
-  // Core metadata table (non-virtual, owns the canonical rowid)
+  // (1) engine_meta — single-row embedding identity metadata
+  // updated_at is initialised at schema creation and updated again only when
+  // writeEmbeddingIdentity() is called.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS engine_meta (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      embedding_provider TEXT,
+      embedding_model TEXT,
+      embedding_dimensions INTEGER,
+      embedding_fingerprint TEXT,
+      embedding_schema_version TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
+
+  db.prepare(
+    "INSERT OR IGNORE INTO engine_meta (id, embedding_schema_version, updated_at) VALUES (1, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+  ).run(ENGINE_EMBED_META_VERSION);
+
+  // (2) engine_chunk_meta + engine_chunk_fts
   db.exec(`
     CREATE TABLE IF NOT EXISTS engine_chunk_meta (
       rowid  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -78,137 +122,82 @@ function ensureSchema(db: Database.Database, dimensions: number): boolean {
       sha      TEXT NOT NULL,
       UNIQUE(doc_path, ordinal)
     );
+
     CREATE VIRTUAL TABLE IF NOT EXISTS engine_chunk_fts USING fts5(
       doc_path UNINDEXED,
       ordinal  UNINDEXED,
       text
     );
   `);
+}
 
-  // vec0 virtual table — dimension count must be baked into the DDL
-  const vecExists = (
-    db
-      .prepare(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='engine_chunk_vec'",
-      )
-      .get() as { name: string } | undefined
-  ) !== undefined;
+function vecTableExists(db: Database.Database): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='engine_chunk_vec'")
+    .get() as { name: string } | undefined;
+  return row !== undefined;
+}
 
-  let vectorAvailable = false;
-  if (!vecExists) {
-    try {
-      db.exec(
-        `CREATE VIRTUAL TABLE engine_chunk_vec USING vec0(embedding float[${dimensions}]);`,
-      );
-      vectorAvailable = true;
-    } catch {
-      // sqlite-vec unavailable — ANN queries will return empty lists
-    }
-  } else {
-    vectorAvailable = true;
-  }
-
-  return vectorAvailable;
+function createVecTable(db: Database.Database, dimensions: number): void {
+  db.exec(
+    `CREATE VIRTUAL TABLE engine_chunk_vec USING vec0(embedding float[${dimensions}]);`,
+  );
 }
 
 // ---------------------------------------------------------------------------
-// Row-level types for better-sqlite3 prepared statements
-// ---------------------------------------------------------------------------
-
-interface MetaRow {
-  readonly rowid: number;
-  readonly doc_path: string;
-  readonly ordinal: number;
-  readonly text: string;
-  readonly sha: string;
-}
-
-interface LexRow {
-  readonly rowid: number;
-  readonly doc_path: string;
-  readonly ordinal: number;
-  readonly rank: number;
-}
-
-// ---------------------------------------------------------------------------
-// Public factory
+// Public factories
 // ---------------------------------------------------------------------------
 
 /**
- * Open (or create) an engine store at `dbPath`.
+ * Open (or create) an engine store at `dbPath` in CORE-ONLY mode.
  *
- * Returns an EngineStore (superset of VectorStore) which is directly usable
- * as DispatcherDeps.store without any cast.
- *
- * `dimensions` must match the embedding model's output width.
- * The vec0 virtual table DDL bakes in this value — opening with a different
- * dimension on an existing DB is a no-op (the existing table is reused as-is).
- *
- * @param dbPath     - Absolute path to the SQLite database file.
- * @param dimensions - Embedding vector width (must match EmbeddingProvider.dimensions).
+ * Core-only mode:
+ * - creates core schema (meta + FTS + engine_meta)
+ * - does NOT create vec0
+ * - queryVec() throws
+ * - upsert() throws
  */
-export function openEngineStore(dbPath: string, dimensions: number): EngineStore {
-  // Ensure parent directory exists
+export function openEngineStoreCore(dbPath: string): EngineStore {
   mkdirSync(path.dirname(dbPath), { recursive: true });
-
   const db = new Database(dbPath);
 
-  // Load sqlite-vec extension
-  let vecLoaded = false;
+  ensureCoreSchema(db);
+  // Optional: load sqlite-vec so lex-only sync can delete stale vectors for
+  // modified chunks (prevents silent cross-model reuse on later vec queries).
+  let stmtDeleteVec: ReturnType<Database.Database["prepare"]> | null = null;
+  let stmtClearDocVec: ReturnType<Database.Database["prepare"]> | null = null;
   try {
-    sqliteVec.load(db);
-    vecLoaded = true;
+    DEFAULT_SQLITE_VEC_LOADER(db);
+    if (vecTableExists(db)) {
+      stmtDeleteVec = db.prepare<[bigint]>("DELETE FROM engine_chunk_vec WHERE rowid = ?");
+      stmtClearDocVec = db.prepare<[string]>(
+        "DELETE FROM engine_chunk_vec WHERE rowid IN (SELECT rowid FROM engine_chunk_meta WHERE doc_path = ?)",
+      );
+    }
   } catch {
-    // Native extension unavailable — queryVec will always return []
+    // sqlite-vec unavailable or vec table absent — core-only mode still works.
   }
 
-  const vectorAvailable = vecLoaded && ensureSchema(db, dimensions);
-
-  // ---------------------------------------------------------------------------
-  // Prepared statements
-  // ---------------------------------------------------------------------------
-
-  const stmtGetMeta = db.prepare<[string, number], MetaRow>(
+  // Prepared statements — core only
+  const stmtGetMeta = db.prepare<[string, number], { rowid: number; doc_path: string; ordinal: number; text: string; sha: string }>(
     "SELECT rowid, doc_path, ordinal, text, sha FROM engine_chunk_meta WHERE doc_path = ? AND ordinal = ?",
   );
-
   const stmtInsertMeta = db.prepare<[string, number, string, string]>(
     "INSERT INTO engine_chunk_meta (doc_path, ordinal, text, sha) VALUES (?, ?, ?, ?)",
   );
-
   const stmtUpdateMeta = db.prepare<[string, string, string, number]>(
     "UPDATE engine_chunk_meta SET text = ?, sha = ? WHERE doc_path = ? AND ordinal = ?",
   );
 
-  const stmtDeleteVec = vectorAvailable
-    ? db.prepare<[bigint]>("DELETE FROM engine_chunk_vec WHERE rowid = ?")
-    : null;
-
-  const stmtInsertVec = vectorAvailable
-    ? db.prepare<[bigint, Buffer]>("INSERT INTO engine_chunk_vec(rowid, embedding) VALUES (?, ?)")
-    : null;
-
   const stmtDeleteFts = db.prepare<[bigint]>(
     "DELETE FROM engine_chunk_fts WHERE rowid = ?",
   );
-
   const stmtInsertFts = db.prepare<[bigint, string, number, string]>(
     "INSERT INTO engine_chunk_fts(rowid, doc_path, ordinal, text) VALUES (?, ?, ?, ?)",
   );
 
-  // queryVec: JOIN directly avoids a second lookup round-trip
-  const stmtQueryVec = vectorAvailable
-    ? db.prepare<[Buffer, number], { doc_path: string; ordinal: number; distance: number }>(
-        `SELECT m.doc_path, m.ordinal, v.distance
-         FROM engine_chunk_vec v
-         JOIN engine_chunk_meta m ON m.rowid = v.rowid
-         WHERE v.embedding MATCH ? AND k = ?
-         ORDER BY v.distance`,
-      )
-    : null;
-
-  const stmtQueryLex = db.prepare<[string, number], LexRow>(
-    `SELECT m.rowid, m.doc_path, m.ordinal, bm25(engine_chunk_fts) AS rank
+  const stmtQueryLex = db.prepare<[string, number], { doc_path: string; ordinal: number; rank: number }>(
+    `SELECT m.doc_path, m.ordinal, bm25(engine_chunk_fts) AS rank
      FROM engine_chunk_fts
      JOIN engine_chunk_meta m ON m.rowid = engine_chunk_fts.rowid
      WHERE engine_chunk_fts MATCH ?
@@ -216,17 +205,10 @@ export function openEngineStore(dbPath: string, dimensions: number): EngineStore
      LIMIT ?`,
   );
 
-  // getShas: read stored ordinal→sha pairs for a document (used by sync layer)
   const stmtGetShas = db.prepare<[string], { ordinal: number; sha: string }>(
     "SELECT ordinal, sha FROM engine_chunk_meta WHERE doc_path = ?",
   );
 
-  // clearDocument: delete all chunks for a document across all three tables
-  const stmtClearDocVec = vectorAvailable
-    ? db.prepare<[string]>(
-        "DELETE FROM engine_chunk_vec WHERE rowid IN (SELECT rowid FROM engine_chunk_meta WHERE doc_path = ?)",
-      )
-    : null;
   const stmtClearDocFts = db.prepare<[string]>(
     "DELETE FROM engine_chunk_fts WHERE rowid IN (SELECT rowid FROM engine_chunk_meta WHERE doc_path = ?)",
   );
@@ -234,10 +216,39 @@ export function openEngineStore(dbPath: string, dimensions: number): EngineStore
     "DELETE FROM engine_chunk_meta WHERE doc_path = ?",
   );
 
-  // listDocPaths: distinct documents currently present (used by cleanup diff)
   const stmtListDocPaths = db.prepare<[], { doc_path: string }>(
     "SELECT DISTINCT doc_path FROM engine_chunk_meta",
   );
+
+  const stmtReadIdentity = db.prepare<[], {
+    embedding_provider: string | null;
+    embedding_model: string | null;
+    embedding_dimensions: number | null;
+    embedding_fingerprint: string | null;
+  }>(
+    "SELECT embedding_provider, embedding_model, embedding_dimensions, embedding_fingerprint FROM engine_meta WHERE id = 1",
+  );
+
+  const stmtWriteIdentity = db.prepare<[string, string, number, string]>(
+    "UPDATE engine_meta SET embedding_provider = ?, embedding_model = ?, embedding_dimensions = ?, embedding_fingerprint = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = 1",
+  );
+
+  const doUpsertLex = db.transaction((rows: ReadonlyArray<Chunk>) => {
+    for (const row of rows) {
+      const existing = stmtGetMeta.get(row.docPath, row.ordinal);
+      if (existing) {
+        const id = BigInt(existing.rowid);
+        stmtDeleteVec?.run(id);
+        stmtDeleteFts.run(id);
+        stmtUpdateMeta.run(row.text, row.sha, row.docPath, row.ordinal);
+        stmtInsertFts.run(id, row.docPath, row.ordinal, row.text);
+      } else {
+        const info = stmtInsertMeta.run(row.docPath, row.ordinal, row.text, row.sha);
+        const id = BigInt(info.lastInsertRowid);
+        stmtInsertFts.run(id, row.docPath, row.ordinal, row.text);
+      }
+    }
+  });
 
   const doClearDocument = db.transaction((docPath: string) => {
     stmtClearDocVec?.run(docPath);
@@ -245,72 +256,33 @@ export function openEngineStore(dbPath: string, dimensions: number): EngineStore
     stmtClearDocMeta.run(docPath);
   });
 
-  // ---------------------------------------------------------------------------
-  // Upsert transaction
-  // ---------------------------------------------------------------------------
-
-  const doUpsert = db.transaction(
-    (rows: ReadonlyArray<Chunk & { vector: Float32Array }>) => {
-      for (const row of rows) {
-        const existing = stmtGetMeta.get(row.docPath, row.ordinal);
-
-        if (existing !== undefined) {
-          // Delete old vec + FTS entries keyed by rowid (sqlite-vec requires BigInt)
-          const existingId = BigInt(existing.rowid);
-          stmtDeleteVec?.run(existingId);
-          stmtDeleteFts.run(existingId);
-          // Update meta (rowid unchanged)
-          stmtUpdateMeta.run(row.text, row.sha, row.docPath, row.ordinal);
-          // Re-insert vec + FTS with the same rowid
-          if (stmtInsertVec) stmtInsertVec.run(existingId, vecBuf(row.vector));
-          stmtInsertFts.run(existingId, row.docPath, row.ordinal, row.text);
-        } else {
-          // Fresh insert — sqlite-vec vec0 requires BigInt rowid (mirrors search layer)
-          const info = stmtInsertMeta.run(row.docPath, row.ordinal, row.text, row.sha);
-          const rowid = BigInt(info.lastInsertRowid);
-          if (stmtInsertVec) stmtInsertVec.run(rowid, vecBuf(row.vector));
-          stmtInsertFts.run(rowid, row.docPath, row.ordinal, row.text);
-        }
-      }
-    },
-  );
-
-  // ---------------------------------------------------------------------------
-  // VectorStore implementation
-  // ---------------------------------------------------------------------------
-
   return {
-    upsert(rows: ReadonlyArray<Chunk & { vector: Float32Array }>): void {
-      doUpsert(rows);
+    capabilities(): EngineStoreCapabilities {
+      return { vecAvailable: false };
     },
 
-    queryVec(vec: Float32Array, k: number): ScoredHit[] {
-      if (!stmtQueryVec) return [];
-      const buf = vecBuf(vec);
-      let rows: Array<{ doc_path: string; ordinal: number; distance: number }>;
-      try {
-        rows = stmtQueryVec.all(buf, k);
-      } catch {
-        return [];
-      }
-      return rows.map((r): ScoredHit => ({
-        docPath: r.doc_path,
-        chunkOrdinal: r.ordinal,
-        // Convert L2 distance to score: closer = higher
-        score: 1 / (1 + Math.max(0, r.distance)),
-      }));
+    upsertLex(rows: ReadonlyArray<Chunk>): void {
+      doUpsertLex(rows);
+    },
+
+    // VectorStore
+    upsert(): void {
+      throw new Error("EngineStore(core-only): vector upsert is unavailable.");
+    },
+
+    queryVec(): ScoredHit[] {
+      throw new Error("EngineStore(core-only): vector queries are unavailable.");
     },
 
     queryLex(text: string, k: number): ScoredHit[] {
       const ftsQ = makeFtsQuery(text);
       if (!ftsQ) return [];
-      let rows: LexRow[];
+      let rows: Array<{ doc_path: string; ordinal: number; rank: number }>;
       try {
         rows = stmtQueryLex.all(ftsQ, k);
       } catch {
         return [];
       }
-      // BM25 rank is negative (lower = better); map to 1-based position score
       return rows.map((r, index): ScoredHit => ({
         docPath: r.doc_path,
         chunkOrdinal: r.ordinal,
@@ -323,6 +295,283 @@ export function openEngineStore(dbPath: string, dimensions: number): EngineStore
       db.close();
     },
 
+    // EngineStore extensions
+    readEmbeddingIdentity(): EmbeddingIdentity | null {
+      const row = stmtReadIdentity.get();
+      if (!row) return null;
+      if (
+        !row.embedding_provider ||
+        !row.embedding_model ||
+        row.embedding_dimensions === null ||
+        !row.embedding_fingerprint
+      ) {
+        return null;
+      }
+      return {
+        provider: row.embedding_provider,
+        model: row.embedding_model,
+        dimensions: row.embedding_dimensions,
+        fingerprint: row.embedding_fingerprint,
+      };
+    },
+
+    writeEmbeddingIdentity(identity: EmbeddingIdentity): void {
+      stmtWriteIdentity.run(identity.provider, identity.model, identity.dimensions, identity.fingerprint);
+    },
+
+    getShas(docPath: string): Map<number, string> {
+      const rows = stmtGetShas.all(docPath);
+      const out = new Map<number, string>();
+      for (const r of rows) out.set(r.ordinal, r.sha);
+      return out;
+    },
+
+    clearDocument(docPath: string): void {
+      doClearDocument(docPath);
+    },
+
+    listDocPaths(): string[] {
+      return stmtListDocPaths.all().map((r) => r.doc_path);
+    },
+  };
+}
+
+/**
+ * Open (or create) an engine store at `dbPath` with vector capability.
+ *
+ * Vector-capable mode still guarantees core schema exists even when sqlite-vec
+ * cannot be loaded, but in that case vecAvailable=false and vector operations
+ * throw.
+ */
+export function openEngineStore(
+  dbPath: string,
+  dimensions: number,
+  opts: { readonly sqliteVecLoader?: SqliteVecLoader } = {},
+): EngineStore {
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+
+  ensureCoreSchema(db);
+
+  const sqliteVecLoader = opts.sqliteVecLoader ?? DEFAULT_SQLITE_VEC_LOADER;
+  let vecLoaded = false;
+  try {
+    sqliteVecLoader(db);
+    vecLoaded = true;
+  } catch {
+    vecLoaded = false;
+  }
+
+  // Create vec table only when the extension is loaded.
+  let vecAvailable = false;
+  if (vecLoaded) {
+    if (!vecTableExists(db)) {
+      try {
+        createVecTable(db, dimensions);
+        vecAvailable = true;
+      } catch {
+        vecAvailable = false;
+      }
+    } else {
+      vecAvailable = true;
+    }
+  }
+
+  // Prepared statements (core)
+  const stmtGetMeta = db.prepare<[string, number], { rowid: number; doc_path: string; ordinal: number; text: string; sha: string }>(
+    "SELECT rowid, doc_path, ordinal, text, sha FROM engine_chunk_meta WHERE doc_path = ? AND ordinal = ?",
+  );
+  const stmtInsertMeta = db.prepare<[string, number, string, string]>(
+    "INSERT INTO engine_chunk_meta (doc_path, ordinal, text, sha) VALUES (?, ?, ?, ?)",
+  );
+  const stmtUpdateMeta = db.prepare<[string, string, string, number]>(
+    "UPDATE engine_chunk_meta SET text = ?, sha = ? WHERE doc_path = ? AND ordinal = ?",
+  );
+
+  const stmtDeleteFts = db.prepare<[bigint]>(
+    "DELETE FROM engine_chunk_fts WHERE rowid = ?",
+  );
+  const stmtInsertFts = db.prepare<[bigint, string, number, string]>(
+    "INSERT INTO engine_chunk_fts(rowid, doc_path, ordinal, text) VALUES (?, ?, ?, ?)",
+  );
+
+  const stmtQueryLex = db.prepare<[string, number], { doc_path: string; ordinal: number; rank: number }>(
+    `SELECT m.doc_path, m.ordinal, bm25(engine_chunk_fts) AS rank
+     FROM engine_chunk_fts
+     JOIN engine_chunk_meta m ON m.rowid = engine_chunk_fts.rowid
+     WHERE engine_chunk_fts MATCH ?
+     ORDER BY rank
+     LIMIT ?`,
+  );
+
+  const stmtGetShas = db.prepare<[string], { ordinal: number; sha: string }>(
+    "SELECT ordinal, sha FROM engine_chunk_meta WHERE doc_path = ?",
+  );
+
+  const stmtClearDocFts = db.prepare<[string]>(
+    "DELETE FROM engine_chunk_fts WHERE rowid IN (SELECT rowid FROM engine_chunk_meta WHERE doc_path = ?)",
+  );
+  const stmtClearDocMeta = db.prepare<[string]>(
+    "DELETE FROM engine_chunk_meta WHERE doc_path = ?",
+  );
+
+  const stmtListDocPaths = db.prepare<[], { doc_path: string }>(
+    "SELECT DISTINCT doc_path FROM engine_chunk_meta",
+  );
+
+  const stmtReadIdentity = db.prepare<[], {
+    embedding_provider: string | null;
+    embedding_model: string | null;
+    embedding_dimensions: number | null;
+    embedding_fingerprint: string | null;
+  }>(
+    "SELECT embedding_provider, embedding_model, embedding_dimensions, embedding_fingerprint FROM engine_meta WHERE id = 1",
+  );
+
+  const stmtWriteIdentity = db.prepare<[string, string, number, string]>(
+    "UPDATE engine_meta SET embedding_provider = ?, embedding_model = ?, embedding_dimensions = ?, embedding_fingerprint = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = 1",
+  );
+
+  // Prepared statements (vec)
+  const stmtDeleteVec = vecAvailable
+    ? db.prepare<[bigint]>("DELETE FROM engine_chunk_vec WHERE rowid = ?")
+    : null;
+  const stmtInsertVec = vecAvailable
+    ? db.prepare<[bigint, Buffer]>("INSERT INTO engine_chunk_vec(rowid, embedding) VALUES (?, ?)")
+    : null;
+
+  const stmtQueryVec = vecAvailable
+    ? db.prepare<[Buffer, number], { doc_path: string; ordinal: number; distance: number }>(
+        `SELECT m.doc_path, m.ordinal, v.distance
+         FROM engine_chunk_vec v
+         JOIN engine_chunk_meta m ON m.rowid = v.rowid
+         WHERE v.embedding MATCH ? AND k = ?
+         ORDER BY v.distance`,
+      )
+    : null;
+
+  const stmtClearDocVec = vecAvailable
+    ? db.prepare<[string]>(
+        "DELETE FROM engine_chunk_vec WHERE rowid IN (SELECT rowid FROM engine_chunk_meta WHERE doc_path = ?)",
+      )
+    : null;
+
+  const doClearDocument = db.transaction((docPath: string) => {
+    stmtClearDocVec?.run(docPath);
+    stmtClearDocFts.run(docPath);
+    stmtClearDocMeta.run(docPath);
+  });
+
+  const doUpsertLex = db.transaction((rows: ReadonlyArray<Chunk>) => {
+    for (const row of rows) {
+      const existing = stmtGetMeta.get(row.docPath, row.ordinal);
+      if (existing) {
+        const id = BigInt(existing.rowid);
+        stmtDeleteFts.run(id);
+        stmtUpdateMeta.run(row.text, row.sha, row.docPath, row.ordinal);
+        stmtInsertFts.run(id, row.docPath, row.ordinal, row.text);
+      } else {
+        const info = stmtInsertMeta.run(row.docPath, row.ordinal, row.text, row.sha);
+        const id = BigInt(info.lastInsertRowid);
+        stmtInsertFts.run(id, row.docPath, row.ordinal, row.text);
+      }
+    }
+  });
+
+  const doUpsert = db.transaction((rows: ReadonlyArray<Chunk & { vector: Float32Array }>) => {
+    if (!vecAvailable || !stmtInsertVec || !stmtDeleteVec) {
+      throw new Error("EngineStore: vector layer unavailable (sqlite-vec not loaded).");
+    }
+    for (const row of rows) {
+      const existing = stmtGetMeta.get(row.docPath, row.ordinal);
+      if (existing) {
+        const id = BigInt(existing.rowid);
+        stmtDeleteVec.run(id);
+        stmtDeleteFts.run(id);
+        stmtUpdateMeta.run(row.text, row.sha, row.docPath, row.ordinal);
+        stmtInsertVec.run(id, vecBuf(row.vector));
+        stmtInsertFts.run(id, row.docPath, row.ordinal, row.text);
+      } else {
+        const info = stmtInsertMeta.run(row.docPath, row.ordinal, row.text, row.sha);
+        const id = BigInt(info.lastInsertRowid);
+        stmtInsertVec.run(id, vecBuf(row.vector));
+        stmtInsertFts.run(id, row.docPath, row.ordinal, row.text);
+      }
+    }
+  });
+
+  return {
+    capabilities(): EngineStoreCapabilities {
+      return { vecAvailable };
+    },
+
+    upsertLex(rows: ReadonlyArray<Chunk>): void {
+      doUpsertLex(rows);
+    },
+
+    readEmbeddingIdentity(): EmbeddingIdentity | null {
+      const row = stmtReadIdentity.get();
+      if (!row) return null;
+      if (
+        !row.embedding_provider ||
+        !row.embedding_model ||
+        row.embedding_dimensions === null ||
+        !row.embedding_fingerprint
+      ) {
+        return null;
+      }
+      return {
+        provider: row.embedding_provider,
+        model: row.embedding_model,
+        dimensions: row.embedding_dimensions,
+        fingerprint: row.embedding_fingerprint,
+      };
+    },
+
+    writeEmbeddingIdentity(identity: EmbeddingIdentity): void {
+      stmtWriteIdentity.run(identity.provider, identity.model, identity.dimensions, identity.fingerprint);
+    },
+
+    // VectorStore
+    upsert(rows: ReadonlyArray<Chunk & { vector: Float32Array }>): void {
+      doUpsert(rows);
+    },
+
+    queryVec(vec: Float32Array, k: number): ScoredHit[] {
+      if (!stmtQueryVec) {
+        throw new Error("EngineStore: vector queries are unavailable (sqlite-vec not loaded).");
+      }
+      const buf = vecBuf(vec);
+      const rows = stmtQueryVec.all(buf, k);
+      return rows.map((r): ScoredHit => ({
+        docPath: r.doc_path,
+        chunkOrdinal: r.ordinal,
+        score: 1 / (1 + Math.max(0, r.distance)),
+      }));
+    },
+
+    queryLex(text: string, k: number): ScoredHit[] {
+      const ftsQ = makeFtsQuery(text);
+      if (!ftsQ) return [];
+      let rows: Array<{ doc_path: string; ordinal: number; rank: number }>;
+      try {
+        rows = stmtQueryLex.all(ftsQ, k);
+      } catch {
+        return [];
+      }
+      return rows.map((r, index): ScoredHit => ({
+        docPath: r.doc_path,
+        chunkOrdinal: r.ordinal,
+        score: 1 / (1 + index),
+      }));
+    },
+
+    close(): void {
+      db.pragma("wal_checkpoint(PASSIVE)");
+      db.close();
+    },
+
+    // EngineStore extensions
     getShas(docPath: string): Map<number, string> {
       const rows = stmtGetShas.all(docPath);
       const out = new Map<number, string>();

--- a/src/engine/embed/sync.test.ts
+++ b/src/engine/embed/sync.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Engine semantic contract tests (RALPLAN: OMS semantic engine cleanup).
+ *
+ * Proves the locked contract WITHOUT loading a real embedding model:
+ *   1. embed=false is a lex-only sync — no vectors, no identity, provenance warning.
+ *   2. Core-only store supports lexical search but throws on vector ops.
+ *   3. sqlite-vec unavailability is deterministic (injected throwing loader):
+ *      core schema + lex stay usable; vec ops throw (no silent empty hits).
+ *   4. Fingerprint mismatch fails fast by default (structured stored+configured
+ *      identity) and rebuilds destructively + overwrites identity only with force.
+ *   5. The core semantic engine answers lex-only queries but fails fast on a
+ *      vec/HyDE request when no real embedding provider is configured.
+ *
+ * GGUF model loading never happens here: providers are lazy, so an empty vault
+ * (zero embed() calls) and the deferred provider keep every assertion offline.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { syncEngineStore } from "./sync.js";
+import { openEngineStore, openEngineStoreCore } from "./store.js";
+import { makeEmbeddingIdentity } from "./identity.js";
+import type { Chunk } from "../types.js";
+import { assembleCoreSemanticEngine } from "../assemble.js";
+
+let vault: string;
+let dbDir: string;
+let dbPath: string;
+
+function writeDoc(rel: string, content: string): void {
+  const full = path.join(vault, rel);
+  mkdirSync(path.dirname(full), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+}
+
+function lexChunk(docPath: string, text: string): Chunk {
+  return { docPath, ordinal: 0, text, headingPath: [], sha: `${docPath}:0` };
+}
+
+beforeEach(() => {
+  vault = mkdtempSync(path.join(tmpdir(), "oms-sync-vault-"));
+  dbDir = mkdtempSync(path.join(tmpdir(), "oms-sync-db-"));
+  dbPath = path.join(dbDir, "engine-store.sqlite");
+});
+
+afterEach(() => {
+  rmSync(vault, { recursive: true, force: true });
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// (1) embed=false → lex-only sync
+// ---------------------------------------------------------------------------
+
+describe("syncEngineStore — embed=false (lex-only)", () => {
+  it("indexes lexically, writes no embedding identity, and emits a provenance warning", async () => {
+    writeDoc("notes/alpha.md", "# Alpha\nretrieval augmented generation over a knowledge graph");
+
+    const result = await syncEngineStore({ vault, dbPath, embed: false });
+
+    expect(result.available).toBe(true);
+    expect(result.added).toBeGreaterThan(0);
+    expect(result.warnings?.some((w) => /embed=false/i.test(w))).toBe(true);
+
+    const store = openEngineStoreCore(dbPath);
+    try {
+      // embed=false MUST NOT record embedding identity.
+      expect(store.readEmbeddingIdentity()).toBeNull();
+      const hits = store.queryLex("retrieval augmented", 5);
+      expect(hits.map((h) => h.docPath)).toContain("notes/alpha.md");
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) core-only store vec gating
+// ---------------------------------------------------------------------------
+
+describe("openEngineStoreCore — vec gating", () => {
+  it("supports lexical search but throws on vector upsert/query", () => {
+    const store = openEngineStoreCore(dbPath);
+    try {
+      expect(store.capabilities().vecAvailable).toBe(false);
+      store.upsertLex([lexChunk("a.md", "graph neural networks and embeddings")]);
+      expect(store.queryLex("graph neural", 5).map((h) => h.docPath)).toContain("a.md");
+      expect(() => store.queryVec(new Float32Array(8), 5)).toThrow();
+      expect(() => store.upsert([])).toThrow();
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3) sqlite-vec unavailability is deterministic (injected loader throws)
+// ---------------------------------------------------------------------------
+
+describe("openEngineStore — sqlite-vec unavailable (injected loader)", () => {
+  it("keeps core schema + lex usable while vector ops throw (no silent empty hits)", () => {
+    const store = openEngineStore(dbPath, 768, {
+      sqliteVecLoader: () => {
+        throw new Error("sqlite-vec extension unavailable");
+      },
+    });
+    try {
+      expect(store.capabilities().vecAvailable).toBe(false);
+      store.upsertLex([lexChunk("b.md", "semantic readiness rules and fingerprints")]);
+      expect(store.queryLex("semantic readiness", 5).map((h) => h.docPath)).toContain("b.md");
+      // Vector usage must fail loudly, never degrade to an empty result.
+      expect(() => store.queryVec(new Float32Array(768), 5)).toThrow();
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (4) fingerprint mismatch: fail fast by default, force-only destructive rebuild
+// ---------------------------------------------------------------------------
+
+describe("syncEngineStore — fingerprint mismatch policy", () => {
+  function seedIdentity(model: string): void {
+    const seeded = openEngineStore(dbPath, 768);
+    try {
+      seeded.writeEmbeddingIdentity(
+        makeEmbeddingIdentity({ provider: "gguf", model, dimensions: 768 }),
+      );
+    } finally {
+      seeded.close();
+    }
+  }
+
+  it("fails fast and reports stored+configured identity when identity differs (no force)", async () => {
+    seedIdentity("old-model");
+
+    // Empty vault → zero embed() calls → the lazy GGUF provider never loads a model.
+    const result = await syncEngineStore({
+      vault,
+      dbPath,
+      embed: true,
+      embeddingProvider: "gguf",
+      embeddingModel: "new-model",
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/mismatch/i);
+    expect(result.storedIdentity?.model).toBe("old-model");
+    expect(result.configuredIdentity?.model).toBe("new-model");
+  });
+
+  it("rebuilds destructively and overwrites identity only when force=true", async () => {
+    seedIdentity("old-model");
+
+    const result = await syncEngineStore({
+      vault,
+      dbPath,
+      embed: true,
+      force: true,
+      embeddingProvider: "gguf",
+      embeddingModel: "new-model",
+    });
+    expect(result.available).toBe(true);
+
+    const store = openEngineStore(dbPath, 768);
+    try {
+      const identity = store.readEmbeddingIdentity();
+      expect(identity?.provider).toBe("gguf");
+      expect(identity?.model).toBe("new-model");
+      // vec0 was dropped + recreated, so vectors remain queryable post-rebuild.
+      expect(store.capabilities().vecAvailable).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (5) core semantic engine: lex usable, vec/HyDE fails fast without embeddings
+// ---------------------------------------------------------------------------
+
+describe("assembleCoreSemanticEngine — lex usable, vec fails fast", () => {
+  it("answers lex-only queries but fails fast on a vec request without embeddings", async () => {
+    writeDoc("notes/topic.md", "# Topic\nknowledge graph retrieval and semantic search notes");
+
+    // Populate the lexical index without embeddings (lex/graph stay usable).
+    const sync = await syncEngineStore({ vault, dbPath, embed: false });
+    expect(sync.available).toBe(true);
+
+    const engine = assembleCoreSemanticEngine({ vault, dbPath });
+    try {
+      const lex = await engine.adapter.semanticQuery({ query: "knowledge graph", lex: "knowledge graph" });
+      expect(lex.available).toBe(true);
+      if (lex.available) {
+        expect(lex.hits.map((h) => h.path)).toContain("notes/topic.md");
+      }
+
+      const vec = await engine.adapter.semanticQuery({ query: "knowledge graph", vec: "knowledge graph" });
+      expect(vec.available).toBe(false);
+      if (!vec.available) {
+        expect(vec.reason).toMatch(/OMS_EMBEDDING_PROVIDER|embedding provider/i);
+      }
+    } finally {
+      await engine.dispose();
+    }
+  });
+});

--- a/src/engine/embed/sync.ts
+++ b/src/engine/embed/sync.ts
@@ -1,28 +1,22 @@
 /**
  * Vault → engine store synchronisation.
  *
- * Ports the vault-scan + embed + upsert pipeline from
- * src/search/semantic-sync.ts::syncSemanticEmbeddingStore() and
- * src/search/semantic-index-build.ts::buildSemanticIndex() into the engine.
- *
- * Key differences from the search layer:
- *   - Operates on chunks (chunker.ts), not whole documents.
- *   - SHA-256 incremental diff at chunk level: only re-embeds changed chunks.
- *   - Stores into the sqlite-vec EngineStore (not the JSON/SQLite search index).
- *   - No runtime import from src/search (R18 hard constraint).
- *
- * SHA-256 incremental pattern ported idea-only from qmd (tobi, MIT) —
- * see ACKNOWLEDGMENTS.md M1 section.
+ * RALPLAN constraints (approved):
+ * - vec/HyDE require sqlite-vec + real embeddings; no fake/hash fallback.
+ * - embed=false is a lex-only sync: it MUST NOT fabricate vectors.
+ * - Fingerprint mismatch fails fast by default; destructive rebuild only with explicit force.
  */
 
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import Database from "better-sqlite3";
 import { chunkDocument } from "./chunker.js";
 import { requireRealEmbeddingProvider } from "./provider.js";
-import { openEngineStore } from "./store.js";
+import { DEFAULT_SQLITE_VEC_LOADER, openEngineStore, openEngineStoreCore } from "./store.js";
+import { makeEmbeddingIdentity } from "./identity.js";
 import type { EmbeddingProvider } from "../types.js";
 import type { ChunkerOptions, Chunk } from "../types.js";
-import type { EngineStore } from "./store.js";
+import type { EmbeddingIdentity, EngineStore } from "./store.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -33,26 +27,18 @@ export interface EngineSyncOptions {
   vault: string;
   /** Logical collection name stored in the index (default: "vault"). */
   collection?: string;
-  /**
-   * Vault-relative sub-path to sync (default: entire vault).
-   * Must not escape the vault root.
-   */
+  /** Vault-relative sub-path to sync (default: entire vault). */
   collectionPath?: string;
-  /**
-   * Absolute path to the SQLite engine store database file.
-   * Default: <vault>/.oms/engine-store.sqlite
-   */
+  /** Absolute path to the SQLite engine store database file. Default: <vault>/.oms/engine-store.sqlite */
   dbPath?: string;
-  /**
-   * Absolute path to the GGUF model file.
-   * Required unless UPSTAGE_API_KEY is set; omitting both causes a loud throw.
-   */
-  modelPath?: string;
-  /**
-   * When false, chunks are stored in the DB but not embedded (scan-only mode).
-   * Default: true.
-   */
+  /** When false, updates lexical index only (no vectors). Default: true. */
   embed?: boolean;
+  /** Allow destructive rebuild when embedding identity mismatches. Default: false. */
+  force?: boolean;
+  /** Explicit embedding provider id (OMS_EMBEDDING_PROVIDER). */
+  embeddingProvider?: string;
+  /** Explicit embedding model/id/path (OMS_EMBEDDING_MODEL). */
+  embeddingModel?: string;
   /** Chunker overrides (maxTokens, overlapRatio). */
   chunkerOpts?: Partial<ChunkerOptions>;
 }
@@ -60,17 +46,22 @@ export interface EngineSyncOptions {
 export interface EngineSyncResult {
   available: boolean;
   reason?: string;
+  warnings?: string[];
+
   collection: string;
   dbPath: string;
+
   scanned: number;
   added: number;
   updated: number;
-  /** Chunks skipped because their SHA-256 matched the stored value. */
   skipped: number;
+
+  storedIdentity?: EmbeddingIdentity;
+  configuredIdentity?: EmbeddingIdentity;
 }
 
 // ---------------------------------------------------------------------------
-// Internal vault walker (ported from semantic-index-build.ts, idea-only)
+// Internal vault walker
 // ---------------------------------------------------------------------------
 
 const SKIP_DIRS = new Set(["node_modules", ".git", ".oms"]);
@@ -94,7 +85,39 @@ export async function* walkMarkdown(dir: string, base: string): AsyncGenerator<s
 }
 
 // ---------------------------------------------------------------------------
-// Per-document incremental sync helper
+// Identity helpers
+// ---------------------------------------------------------------------------
+function dbHasAnyChunks(dbPath: string): boolean {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db.prepare("SELECT rowid FROM engine_chunk_meta LIMIT 1").get() as { rowid: number } | undefined;
+    return row !== undefined;
+  } finally {
+    db.close();
+  }
+}
+
+function formatMismatchReason(args: {
+  stored?: EmbeddingIdentity;
+  configured?: EmbeddingIdentity;
+  forceFlagName: string;
+}): string {
+  const stored = args.stored;
+  const cfg = args.configured;
+  const storedText = stored
+    ? `stored=${stored.provider}/${stored.model} dim=${stored.dimensions} fp=${stored.fingerprint.slice(0, 12)}`
+    : "stored=<none>";
+  const cfgText = cfg
+    ? `configured=${cfg.provider}/${cfg.model} dim=${cfg.dimensions} fp=${cfg.fingerprint.slice(0, 12)}`
+    : "configured=<none>";
+  return (
+    `Embedding identity mismatch (${storedText}; ${cfgText}). ` +
+    `Rebuild vectors with ${args.forceFlagName}.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-document sync
 // ---------------------------------------------------------------------------
 
 interface SyncCounters {
@@ -104,141 +127,286 @@ interface SyncCounters {
   skipped: number;
 }
 
-async function syncDocument(
-  relPath: string,
-  vault: string,
-  store: EngineStore,
-  provider: EmbeddingProvider,
-  shouldEmbed: boolean,
-  chunkerOpts: Partial<ChunkerOptions> | undefined,
-  counters: SyncCounters,
-): Promise<void> {
+async function syncDocument(opts: {
+  relPath: string;
+  vault: string;
+  store: EngineStore;
+  provider: EmbeddingProvider | null;
+  shouldEmbed: boolean;
+  chunkerOpts: Partial<ChunkerOptions> | undefined;
+  counters: SyncCounters;
+  rebuildAllVectors: boolean;
+}): Promise<void> {
   let content: string;
   try {
-    content = await readFile(path.join(vault, relPath), "utf-8");
+    content = await readFile(path.join(opts.vault, opts.relPath), "utf-8");
   } catch {
-    return; // unreadable file — skip silently
+    return;
   }
 
-  counters.scanned++;
-  const chunks: Chunk[] = chunkDocument(relPath, content, chunkerOpts);
+  opts.counters.scanned++;
+  const chunks: Chunk[] = chunkDocument(opts.relPath, content, opts.chunkerOpts);
+  const storedShas = opts.store.getShas(opts.relPath);
 
-  // SHA-256 incremental diff: read stored shas for this document
-  const storedShas = store.getShas(relPath);
+  const chunkCountChanged = storedShas.size !== chunks.length;
+  const fullRewrite = opts.rebuildAllVectors || chunkCountChanged;
+
+  if (!opts.shouldEmbed) {
+    // Lex-only: update meta+FTS only.
+    // When the chunk-count changes we clear and reinsert to avoid orphaned extra chunks.
+    if (fullRewrite) {
+      opts.store.clearDocument(opts.relPath);
+      opts.store.upsertLex(chunks);
+      opts.counters.added += chunks.length;
+      return;
+    }
+
+    const toUpsert: Chunk[] = [];
+    for (const chunk of chunks) {
+      const storedSha = storedShas.get(chunk.ordinal);
+      if (storedSha === chunk.sha) {
+        opts.counters.skipped++;
+        continue;
+      }
+      toUpsert.push(chunk);
+      if (storedSha === undefined) opts.counters.added++;
+      else opts.counters.updated++;
+    }
+    if (toUpsert.length > 0) opts.store.upsertLex(toUpsert);
+    return;
+  }
+
+  if (!opts.provider) {
+    throw new Error("Internal error: shouldEmbed=true but provider is null.");
+  }
+
+  // Vector path
+  if (fullRewrite) {
+    opts.store.clearDocument(opts.relPath);
+    const toUpsert: Array<Chunk & { vector: Float32Array }> = [];
+    for (const chunk of chunks) {
+      const vector = await opts.provider.embed(chunk.text);
+      toUpsert.push({ ...chunk, vector });
+      opts.counters.added++;
+    }
+    if (toUpsert.length > 0) opts.store.upsert(toUpsert);
+    return;
+  }
 
   const toUpsert: Array<Chunk & { vector: Float32Array }> = [];
-
   for (const chunk of chunks) {
     const storedSha = storedShas.get(chunk.ordinal);
     if (storedSha === chunk.sha) {
-      // Chunk text is unchanged — skip embedding (SHA-256 incremental pattern, qmd MIT)
-      counters.skipped++;
+      opts.counters.skipped++;
       continue;
     }
-
-    let vector: Float32Array;
-    if (shouldEmbed) {
-      vector = await provider.embed(chunk.text);
-    } else {
-      // embed=false: store a zero vector as placeholder (test/scan-only mode)
-      vector = new Float32Array(provider.dimensions);
-    }
-
+    const vector = await opts.provider.embed(chunk.text);
     toUpsert.push({ ...chunk, vector });
-    if (storedSha === undefined) {
-      counters.added++;
-    } else {
-      counters.updated++;
-    }
+    if (storedSha === undefined) opts.counters.added++;
+    else opts.counters.updated++;
   }
-
-  if (toUpsert.length > 0) {
-    store.upsert(toUpsert);
-  }
+  if (toUpsert.length > 0) opts.store.upsert(toUpsert);
 }
 
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
 
-/**
- * Scan the vault (or a sub-collection), chunk every markdown file, and
- * upsert changed chunks into the engine SQLite store.
- *
- * Unchanged chunks (SHA-256 match) are skipped — embedding is not called for
- * them, keeping incremental re-sync cheap.
- *
- * Requires a real embedding provider: set OMS_MODEL_PATH (GGUF) or
- * UPSTAGE_API_KEY (Upstage Solar). Omitting both causes a loud throw so that
- * the vault index is never silently populated with fake embeddings.
- *
- * The GGUF model is lazy-loaded on the first embed() call and unloaded after
- * 5 minutes of inactivity.
- *
- * @param opts - Sync configuration.
- * @returns Counters describing what was scanned / added / updated / skipped.
- */
-export async function syncEngineStore(
-  opts: EngineSyncOptions,
-): Promise<EngineSyncResult> {
+export async function syncEngineStore(opts: EngineSyncOptions): Promise<EngineSyncResult> {
   const vault = path.resolve(opts.vault);
   const collection = opts.collection ?? "vault";
-  const collectionRoot = opts.collectionPath
-    ? path.resolve(vault, opts.collectionPath)
-    : vault;
-  const dbPath =
-    opts.dbPath ?? path.join(vault, ".oms", "engine-store.sqlite");
+  const collectionRoot = opts.collectionPath ? path.resolve(vault, opts.collectionPath) : vault;
+  const dbPath = opts.dbPath ?? path.join(vault, ".oms", "engine-store.sqlite");
   const shouldEmbed = opts.embed !== false;
+  const force = opts.force === true;
+
+  const warnings: string[] = [];
 
   let provider: EmbeddingProvider | null = null;
   let store: EngineStore | null = null;
 
+  let storedIdentity: EmbeddingIdentity | undefined;
+  let configuredIdentity: EmbeddingIdentity | undefined;
+
   try {
-    provider = requireRealEmbeddingProvider({ modelPath: opts.modelPath });
+    if (!shouldEmbed) {
+      // Lex-only path: no embedding provider required.
+      store = openEngineStoreCore(dbPath);
+      warnings.push("embed=false: lexical index updated; no vectors generated");
+
+      const counters: SyncCounters = { scanned: 0, added: 0, updated: 0, skipped: 0 };
+      for await (const relPath of walkMarkdown(collectionRoot, vault)) {
+        await syncDocument({
+          relPath,
+          vault,
+          store,
+          provider: null,
+          shouldEmbed: false,
+          chunkerOpts: opts.chunkerOpts,
+          counters,
+          rebuildAllVectors: false,
+        });
+      }
+
+      return {
+        available: true,
+        warnings,
+        collection,
+        dbPath,
+        scanned: counters.scanned,
+        added: counters.added,
+        updated: counters.updated,
+        skipped: counters.skipped,
+      };
+    }
+
+    const embeddingProvider = (opts.embeddingProvider ?? "").trim();
+    const embeddingModel = (opts.embeddingModel ?? "").trim();
+
+    provider = requireRealEmbeddingProvider({ provider: embeddingProvider, model: embeddingModel });
+    configuredIdentity = makeEmbeddingIdentity({
+      provider: embeddingProvider,
+      model: embeddingModel,
+      dimensions: provider.dimensions,
+    });
+
+    // Vector-capable open.
     store = openEngineStore(dbPath, provider.dimensions);
+    if (!store.capabilities().vecAvailable) {
+      warnings.push("Vector layer unavailable: sqlite-vec not loaded");
+      return {
+        available: false,
+        reason: "Vector layer unavailable: sqlite-vec not loaded.",
+        warnings,
+        collection,
+        dbPath,
+        scanned: 0,
+        added: 0,
+        updated: 0,
+        skipped: 0,
+        configuredIdentity,
+      };
+    }
 
-    const counters: SyncCounters = {
-      scanned: 0,
-      added: 0,
-      updated: 0,
-      skipped: 0,
-    };
+    storedIdentity = store.readEmbeddingIdentity() ?? undefined;
 
+    // If there are indexed chunks on disk but no stored identity, treat as mismatch.
+    const hasStoredChunks = dbHasAnyChunks(dbPath);
+    const missingStoredIdentity = storedIdentity === undefined;
+
+    const mismatch =
+      (storedIdentity !== undefined &&
+        (storedIdentity.provider !== configuredIdentity.provider ||
+          storedIdentity.model !== configuredIdentity.model ||
+          storedIdentity.dimensions !== configuredIdentity.dimensions ||
+          storedIdentity.fingerprint !== configuredIdentity.fingerprint)) ||
+      (missingStoredIdentity && hasStoredChunks);
+    if (mismatch && !force) {
+      return {
+        available: false,
+        reason: formatMismatchReason({
+          stored: storedIdentity,
+          configured: configuredIdentity,
+          forceFlagName: "--force/force:true",
+        }),
+        warnings,
+        collection,
+        dbPath,
+        scanned: 0,
+        added: 0,
+        updated: 0,
+        skipped: 0,
+        storedIdentity,
+        configuredIdentity,
+      };
+    }
+
+    // On force mismatch: destructive rebuild of the vec0 table.
+    let rebuildAllVectors = false;
+    if (mismatch && force) {
+      // Close the live store handle before mutating the vec0 table.
+      store.close();
+      store = null;
+
+      const db = new Database(dbPath);
+      try {
+        DEFAULT_SQLITE_VEC_LOADER(db);
+        db.exec("DROP TABLE IF EXISTS engine_chunk_vec;");
+        db.exec(
+          `CREATE VIRTUAL TABLE engine_chunk_vec USING vec0(embedding float[${provider.dimensions}]);`,
+        );
+        rebuildAllVectors = true;
+      } finally {
+        db.close();
+      }
+
+      // Re-open so prepared statements reflect the rebuilt vec table.
+      store = openEngineStore(dbPath, provider.dimensions);
+      if (!store.capabilities().vecAvailable) {
+        warnings.push("Vector layer unavailable: sqlite-vec not loaded");
+        return {
+          available: false,
+          reason: "Vector layer unavailable: sqlite-vec not loaded.",
+          warnings,
+          collection,
+          dbPath,
+          scanned: 0,
+          added: 0,
+          updated: 0,
+          skipped: 0,
+          configuredIdentity,
+        };
+      }
+    }
+
+    if (!store) {
+      throw new Error("Internal error: engine store is null after preparation.");
+    }
+    const counters: SyncCounters = { scanned: 0, added: 0, updated: 0, skipped: 0 };
     for await (const relPath of walkMarkdown(collectionRoot, vault)) {
-      await syncDocument(
+      await syncDocument({
         relPath,
         vault,
         store,
         provider,
-        shouldEmbed,
-        opts.chunkerOpts,
+        shouldEmbed: true,
+        chunkerOpts: opts.chunkerOpts,
         counters,
-      );
+        rebuildAllVectors,
+      });
     }
+
+    // Persist configured embedding identity only after a successful embed=true sync.
+    store.writeEmbeddingIdentity(configuredIdentity);
 
     return {
       available: true,
+      warnings,
       collection,
       dbPath,
       scanned: counters.scanned,
       added: counters.added,
       updated: counters.updated,
       skipped: counters.skipped,
+      storedIdentity,
+      configuredIdentity,
     };
-  } catch (err: unknown) {
+  } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     return {
       available: false,
       reason,
+      warnings,
       collection,
       dbPath,
       scanned: 0,
       added: 0,
       updated: 0,
       skipped: 0,
+      storedIdentity,
+      configuredIdentity,
     };
   } finally {
-    // Always dispose provider and close store — no resource leaks
     await provider?.dispose().catch(() => undefined);
     store?.close();
   }

--- a/src/engine/mcp/facade.ts
+++ b/src/engine/mcp/facade.ts
@@ -283,16 +283,14 @@ export class McpEngineAdapter {
    * @param vaultPath - Absolute vault root, used by graph / sync / cleanup /
    *                    retrieve ops that are vault-scoped. Required so tsc
    *                    enforces it at every construction site (RISK-4).
-   * @param modelPath - Server-configured GGUF path (OMS_MODEL_PATH, resolved by
-   *                    assembleEngine). Threaded into syncEmbeddings so a sync
-   *                    triggered through the MCP surface — which carries no
-   *                    per-call modelPath — still reaches the real provider
-   *                    instead of tripping the ADR-007 model-less guard.
+   * @param config    - Optional embedding identity config (provider/model).
+   *                    This is used to enforce mismatch policy and to thread
+   *                    identity into syncEmbeddings when the call omits it.
    */
   constructor(
     private readonly deps: DispatcherDeps,
     private readonly vaultPath: string,
-    private readonly modelPath?: string,
+    private readonly config?: { readonly embeddingProvider?: string; readonly embeddingModel?: string },
   ) {}
 
   // -------------------------------------------------------------------------
@@ -361,12 +359,14 @@ export class McpEngineAdapter {
         vault: opts.vault,
         collection: opts.collection,
         collectionPath: opts.collectionPath,
-        // Fall back to the server-configured model (OMS_MODEL_PATH) when the MCP
-        // call omits an explicit modelPath — otherwise syncEngineStore builds a
-        // model-less provider and the ADR-007 guard rejects the sync. Mirrors
-        // AssembledEngine.syncVault, which threads config.modelPath the same way.
-        modelPath: opts.modelPath ?? this.modelPath,
+        // Embedding identity is owned by the assemble-time canonical config
+        // (OMS_EMBEDDING_PROVIDER / OMS_EMBEDDING_MODEL) threaded into the
+        // adapter; the MCP call no longer carries modelPath. syncEngineStore
+        // resolves the real provider and fails fast (ADR-007) if it is missing.
+        embeddingProvider: this.config?.embeddingProvider,
+        embeddingModel: this.config?.embeddingModel,
         embed: opts.embed ?? true,
+        force: opts.force ?? false,
       });
       if (!syncResult.available) {
         return syncResultUnavailable(syncResult.reason ?? "sync unavailable", opts);

--- a/src/engine/tracer.ts
+++ b/src/engine/tracer.ts
@@ -106,7 +106,10 @@ export async function runTracer(
   const files = await resolveFiles(vaultPath, config.files);
 
   // ── Step 2: create embed provider + store ─────────────────────────────────
-  const embedProvider = requireRealEmbeddingProvider({ modelPath: config.modelPath });
+  const embedProvider = requireRealEmbeddingProvider({
+    provider: config.embeddingProvider,
+    model: config.embeddingModel,
+  });
   await mkdir(path.dirname(config.dbPath), { recursive: true });
   const store = openEngineStore(config.dbPath, config.embeddingDimensions);
 
@@ -198,7 +201,8 @@ export function makeTracerConfig(overrides: Partial<TracerConfig> = {}): TracerC
     vaultPath,
     dbPath: overrides.dbPath ?? path.join(vaultPath, ".oms", "cache", "engine", "engine.db"),
     embeddingDimensions: overrides.embeddingDimensions ?? 768,
-    modelPath: overrides.modelPath ?? process.env["OMS_MODEL_PATH"],
+    embeddingProvider: overrides.embeddingProvider ?? process.env["OMS_EMBEDDING_PROVIDER"],
+    embeddingModel: overrides.embeddingModel ?? process.env["OMS_EMBEDDING_MODEL"],
     files: overrides.files,
     cacheDir: overrides.cacheDir,
     topK: overrides.topK ?? 10,

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -18,11 +18,16 @@ export interface EngineConfig {
   /** Dimensionality of raw embeddings produced by the chosen model. Default 768. */
   embeddingDimensions: number;
   /**
-   * Optional path to a GGUF model file.
+   * Explicit embedding provider id (OMS_EMBEDDING_PROVIDER), e.g. "gguf" or "upstage".
    * Required on the strict production path (requireRealEmbeddingProvider);
-   * omitting it without UPSTAGE_API_KEY causes a loud throw.
+   * omitting it (and OMS_EMBEDDING_MODEL) causes a loud throw — no auto-detect.
    */
-  modelPath?: string;
+  embeddingProvider?: string;
+  /**
+   * Explicit embedding model/path/id (OMS_EMBEDDING_MODEL): a GGUF file path for
+   * the "gguf" provider, or a remote model id for API providers like "upstage".
+   */
+  embeddingModel?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/semantic-server.test.ts
+++ b/src/mcp/semantic-server.test.ts
@@ -20,12 +20,16 @@ function textPayload(result: Awaited<ReturnType<Client["callTool"]>>): Record<st
 describe("Oh My Second Brain MCP semantic stdio server", () => {
   it("runs typed semantic search and document rehydration through read-only MCP tools", async () => {
     // The clean swap routes oms_sync_embeddings / oms_semantic_query through the
-    // native engine, which REQUIRES a real embedding model (ADR-007). With
-    // OMS_MODEL_PATH set we assert real engine results end-to-end through stdio;
-    // without it we assert the loud guard — a positive routing proof, since the
-    // legacy src/search hash path would have returned available:true instead.
-    const modelPath = process.env["OMS_MODEL_PATH"];
-    const hasModel = typeof modelPath === "string" && modelPath.length > 0;
+    // native engine, which REQUIRES an explicitly configured embedding provider
+    // (ADR-007). With OMS_EMBEDDING_PROVIDER + OMS_EMBEDDING_MODEL set we assert
+    // real engine results end-to-end through stdio; without them we assert the
+    // loud guard — a positive routing proof, since the legacy src/search hash
+    // path would have returned available:true instead.
+    const embeddingProvider = process.env["OMS_EMBEDDING_PROVIDER"];
+    const embeddingModel = process.env["OMS_EMBEDDING_MODEL"];
+    const hasModel =
+      typeof embeddingProvider === "string" && embeddingProvider.length > 0 &&
+      typeof embeddingModel === "string" && embeddingModel.length > 0;
     const tmpVault = await mkdtemp(path.join(tmpdir(), "oms-mcp-semantic-"));
     await mkdir(path.join(tmpVault, "references"), { recursive: true });
     await writeFile(
@@ -57,9 +61,15 @@ Index note for graph neighborhoods and semantic lookup.
       cwd: repoRoot,
       stderr: "pipe",
       // StdioClientTransport sandboxes the child env to a safe default subset,
-      // so OMS_MODEL_PATH must be forwarded explicitly for the engine path.
-      ...(hasModel && modelPath
-        ? { env: { ...getDefaultEnvironment(), OMS_MODEL_PATH: modelPath } }
+      // so the canonical embedding config must be forwarded for the engine path.
+      ...(hasModel
+        ? {
+            env: {
+              ...getDefaultEnvironment(),
+              OMS_EMBEDDING_PROVIDER: embeddingProvider!,
+              OMS_EMBEDDING_MODEL: embeddingModel!,
+            },
+          }
         : {}),
     });
     const client = new Client({ name: "oms-test-client", version: "0.0.0" });
@@ -114,12 +124,13 @@ Index note for graph neighborhoods and semantic lookup.
           expect.objectContaining({ path: "references/Agent Retrieval.md" }),
         );
       } else {
-        // Loud-guard path: engine assembly throws without a model → isError
-        // envelope mentioning OMS_MODEL_PATH (ADR-007). Reaching this branch
-        // proves the op routed to the engine, not the legacy hash store.
+        // Loud-guard path: engine assembly throws without explicit embedding
+        // config → isError envelope naming the canonical keys (ADR-007).
+        // Reaching this branch proves the op routed to the engine, not the
+        // legacy hash store.
         expect(syncRaw.isError).toBe(true);
         const syncText = syncRaw.content[0]?.type === "text" ? syncRaw.content[0].text : "";
-        expect(syncText).toMatch(/OMS_MODEL_PATH|UPSTAGE_API_KEY/);
+        expect(syncText).toMatch(/OMS_EMBEDDING_PROVIDER|OMS_EMBEDDING_MODEL/);
         const queryRaw = await client.callTool(queryCall);
         expect(queryRaw.isError).toBe(true);
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -341,26 +341,32 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
   // Native engine — semantic layer (lazy): assembled on the FIRST semantic op,
   // not at boot, so boot stays stateless (R2). assembleEngine opens the engine
   // SQLite store on construction and loads the embedding model on first embed().
-  // Golden-set parity is verified (engine >= 1.7x the src/search baseline recall@10
-  // on every query type), so the engine now owns semantic query/status/sync/
-  // collections/contexts/cleanup. Requires a real model: OMS_MODEL_PATH (GGUF) or
-  // UPSTAGE_API_KEY — absent both, assembleEngine throws a loud, actionable error
-  // (ADR-007: no hash/fake fallback) that surfaces via the dispatch catch below.
+  // Embedding selection is canonical and explicit: OMS_EMBEDDING_PROVIDER
+  // (e.g. gguf | upstage) + OMS_EMBEDDING_MODEL (path or model id). Absent
+  // either, assembleEngine throws a loud, actionable error (ADR-007: no
+  // hash/fake fallback, no auto-detect) that surfaces via the dispatch catch.
   let semanticEngine: AssembledEngine | null = null;
   const getSemanticEngine = (): AssembledEngine => {
     if (semanticEngine === null) {
-      const modelPath = process.env["OMS_MODEL_PATH"];
-      semanticEngine = assembleEngine({ vault, ...(modelPath ? { modelPath } : {}) });
+      semanticEngine = assembleEngine({
+        vault,
+        ...(process.env["OMS_EMBEDDING_PROVIDER"]
+          ? { embeddingProvider: process.env["OMS_EMBEDDING_PROVIDER"] }
+          : {}),
+        ...(process.env["OMS_EMBEDDING_MODEL"]
+          ? { embeddingModel: process.env["OMS_EMBEDDING_MODEL"] }
+          : {}),
+      });
     }
     return semanticEngine;
   };
 
-  // A real embedding model is configured iff one of these is set (ADR-007). The
-  // engine's model-OPTIONAL surface (document reads, retrieve_context's semantic
-  // leg, ReadResource) keys off this to decide engine vs src/search WITHOUT
-  // triggering an assembly throw on a model-less host.
+  // A real embedding provider is configured iff the canonical pair is set
+  // (ADR-007). The engine's model-OPTIONAL surface (document reads,
+  // retrieve_context's semantic leg, ReadResource) keys off this to decide
+  // engine vs src/search WITHOUT triggering an assembly throw on a model-less host.
   const hasEmbeddingModel = (): boolean =>
-    Boolean(process.env["OMS_MODEL_PATH"] ?? process.env["UPSTAGE_API_KEY"]);
+    Boolean(process.env["OMS_EMBEDDING_PROVIDER"] && process.env["OMS_EMBEDDING_MODEL"]);
 
   // Lenient adapter resolver for those model-optional paths: returns the engine
   // adapter only when a model is configured AND assembly succeeds, else null so

--- a/test/golden-set/golden.test.ts
+++ b/test/golden-set/golden.test.ts
@@ -128,12 +128,14 @@ describe("golden harness — fail-loud behaviour (unit)", () => {
   it(
     "(b) engine throw propagates; runEngine does not swallow errors as []",
     async () => {
-      // Strip real-model env vars so requireRealEmbeddingProvider throws.
+      // Strip embedding-config env vars so requireRealEmbeddingProvider throws.
       // This verifies that the try/catch that used to return [] is gone.
       const savedUpstage = process.env["UPSTAGE_API_KEY"];
-      const savedModel = process.env["OMS_MODEL_PATH"];
+      const savedProvider = process.env["OMS_EMBEDDING_PROVIDER"];
+      const savedModel = process.env["OMS_EMBEDDING_MODEL"];
       delete process.env["UPSTAGE_API_KEY"];
-      delete process.env["OMS_MODEL_PATH"];
+      delete process.env["OMS_EMBEDDING_PROVIDER"];
+      delete process.env["OMS_EMBEDDING_MODEL"];
 
       try {
         const q: GoldenQuery = {
@@ -143,18 +145,18 @@ describe("golden harness — fail-loud behaviour (unit)", () => {
           expectedNotes: [],
           curated: true,
         };
-        // modelPath: undefined + no UPSTAGE_API_KEY → requireRealEmbeddingProvider throws
+        // No provider/model configured + no UPSTAGE_API_KEY → requireRealEmbeddingProvider throws
         const config = makeTracerConfig({
           vaultPath: "/nonexistent",
           dbPath: "/tmp/oms-golden-failsafe-b-do-not-use.db",
           embeddingDimensions: 768,
-          modelPath: undefined,
         });
         await expect(runEngine(q, config, [])).rejects.toThrow();
       } finally {
         // Restore env regardless of test outcome
         if (savedUpstage !== undefined) process.env["UPSTAGE_API_KEY"] = savedUpstage;
-        if (savedModel !== undefined) process.env["OMS_MODEL_PATH"] = savedModel;
+        if (savedProvider !== undefined) process.env["OMS_EMBEDDING_PROVIDER"] = savedProvider;
+        if (savedModel !== undefined) process.env["OMS_EMBEDDING_MODEL"] = savedModel;
       }
     },
   );


### PR DESCRIPTION
## Summary

Converges OMS semantic retrieval on a single sqlite-vec **engine store** with
strict, explicit embedding configuration and fail-fast readiness. The engine's
legacy model-path knob and key-based provider auto-detection are removed; lex/graph
retrieval stays usable without any embedding configuration.

Implements the approved RALPLAN
(`.gjc/plans/ralplan/2026-06-17-1919-0201/stage-11-final.md`) and the locked spec
(`.gjc/specs/deep-interview-oms-semantic-engine-cleanup.md`) at the **engine
layer**.

## What changed

- **provider** (`src/engine/embed/provider.ts`): `requireRealEmbeddingProvider`
  requires explicit `OMS_EMBEDDING_PROVIDER` (`gguf` | `upstage`) **and**
  `OMS_EMBEDDING_MODEL`. No `UPSTAGE_API_KEY`-based auto-detect; no
  `OMS_MODEL_PATH` alias. Unsupported providers and missing provider auth throw
  actionable errors.
- **store** (`src/engine/embed/store.ts`): core schema (`engine_chunk_meta`,
  `engine_chunk_fts`, `engine_meta`) is always created; `engine_chunk_vec` (vec0)
  is conditional. Adds `openEngineStoreCore`, an injectable sqlite-vec loader, a
  `vecAvailable` capability, and on-disk embedding identity
  (provider/model/dimensions/fingerprint). `queryVec` throws when vec is
  unavailable — **no silent empty-hit fallback**. Fixes a missing `else` branch
  that re-declared the rowid binding in the core `upsertLex`.
- **identity** (`src/engine/embed/identity.ts`, new): deterministic fingerprint
  over `{schemaVersion, provider, model, dimensions}` + identity builders.
- **sync** (`src/engine/embed/sync.ts`): `embed=false` is a lex-only sync (no
  vectors, provenance warning, no identity written). Fingerprint mismatch
  **fails fast by default** with structured `storedIdentity` + `configuredIdentity`;
  destructive vec rebuild happens **only with explicit `force`**.
- **wiring** (`assemble.ts`, `mcp/facade.ts`, `tracer.ts`, `types.ts`,
  `mcp/server.ts`): thread the canonical provider/model identity end to end; the
  MCP server reads `OMS_EMBEDDING_PROVIDER` / `OMS_EMBEDDING_MODEL`.

## Tests

- Migrated `provider.test.ts` and `assemble.test.ts` to the explicit-config API
  and error messages.
- New `src/engine/embed/sync.test.ts` proves the locked contract **without a real
  model** (lazy providers + empty vault keep it offline):
  1. `embed=false` lex-only sync — no vectors, no identity, provenance warning.
  2. Core-only store supports lex but throws on vector ops.
  3. Injected throwing sqlite-vec loader → core schema + lex stay usable, vec ops
     throw (no silent empty hits).
  4. Fingerprint mismatch fails fast (structured stored+configured identity);
     `force` rebuilds destructively and overwrites identity.
  5. Core semantic engine answers lex-only queries but fails fast on a vec request
     without embeddings.
- Updated `semantic-server.test.ts` and `golden.test.ts` for the canonical config.

## Verification

```
npm run lint   # tsc --noEmit            → exit 0
npm run build  # tsc                      → exit 0
npm test       # vitest run              → 631 passed | 11 skipped, exit 0
```

## Acceptance criteria (spec)

- [x] Provider selection uses `OMS_EMBEDDING_PROVIDER` + `OMS_EMBEDDING_MODEL`
  only; provider required and explicit (no key auto-detect, no `OMS_MODEL_PATH`).
- [x] DB metadata records resolved provider/model/dimension/fingerprint and is
  surfaced in sync errors (stored vs configured).
- [x] Fingerprint mismatch fails fast by default; rebuild only with explicit force.
- [x] Graph/lex retrieval remains usable without semantic configuration.
- [x] Test coverage added for mismatch detection + fail-fast + force rebuild.
- [x] `npm run lint && npm run build && npm test` pass.
- [~] Single engine store is the SSOT and the engine's production path has **no
  hash/fake fallback** (the hash projector is test-only). Full deletion of the
  legacy `src/search` semantic implementation is **deferred** (see below).

## Deferred to a follow-up PR (intentional)

Plan phases **0 / 4 / 5** — removing `storage`/`modelPath` from the MCP/CLI tool
schemas, rebasing `src/cli/semantic-http.ts`, and **deleting the legacy
`src/search/semantic-*` modules** — are intentionally out of scope here. That work
rewrites the CLI semantic surface, the morning-retrieve layer, and guts the
golden-set **parity harness** (whose baseline is `src/search`), so it is a
separate concern. Bundling it would break the mandatory green verification gate
and violate the repo's "one concern per PR" rule (AGENTS.md). This PR delivers the
engine contract; the legacy teardown lands next.

Per request: **do not merge.**
