### PR TITLE
feat(cli): split lint from doctor; aggregate doctor by frontmatter field

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ oms setup      Adopt an existing vault into the convention (writes .oms/taxonomy
 oms install    Install host adapters + MCP registration
 oms uninstall  Remove host adapters + MCP registration
 oms update     Check/apply a package update, then reconcile adapters
-oms doctor     Validate notes against the ontology (broken-link + orphan detection)
+oms doctor     Validate note frontmatter against the ontology (aggregated by field & concept)
+oms lint       Check vault link health: broken [[wikilinks]] + orphan notes
 oms semantic   Native markdown semantic index / search / get
 oms mcp        Start the stdio MCP server
 oms hook       Vault guard hooks (Claude Code pre/post tool-use)

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -10,6 +10,12 @@ import { resolveConcept } from "../ontology/resolver.js";
 import { parseNote } from "../conventions/frontmatter.js";
 import { validateFrontmatter } from "../conventions/validate.js";
 import { detectLinkIssues } from "../conventions/lint.js";
+import {
+  aggregateDoctor,
+  formatDoctorReport,
+  formatLintReport,
+  type NoteReport,
+} from "../conventions/report.js";
 import { runMcpServer } from "../mcp/server.js";
 import { runPreToolUse } from "../hook/pre-tool-use.js";
 import { runPostToolUse } from "../hook/post-tool-use.js";
@@ -577,10 +583,15 @@ export async function runSetup(opts: {
 }
 
 // ---------------------------------------------------------------------------
-// runDoctor
+// runDoctor — frontmatter convention validation, aggregated by field/concept
 // ---------------------------------------------------------------------------
 
-export async function runDoctor(opts: { vault: string }): Promise<number> {
+export async function runDoctor(opts: {
+  vault: string;
+  verbose?: boolean;
+  json?: boolean;
+  maxPerConcept?: number;
+}): Promise<number> {
   const { vault } = opts;
 
   // Doctor is non-blocking (onViolation: warn). It must ALWAYS exit 0 in v0,
@@ -602,15 +613,12 @@ export async function runDoctor(opts: { vault: string }): Promise<number> {
     const ontology = await loadOntology(ontologyDir);
 
     const skipDirs = new Set(["node_modules"]);
-    let totalNotes = 0;
-    let totalViolations = 0;
-    let notesWithViolations = 0;
+    const notes: NoteReport[] = [];
 
     for await (const relPath of walkMarkdown(vault, vault, skipDirs)) {
       const concept = resolveConcept(ontology, relPath);
       if (!concept) continue;
 
-      totalNotes++;
       const fullPath = path.join(vault, relPath);
       let raw: string;
       try {
@@ -622,54 +630,67 @@ export async function runDoctor(opts: { vault: string }): Promise<number> {
 
       const { frontmatter } = parseNote(raw);
       const result = validateFrontmatter(frontmatter, concept);
-
-      if (result.violations.length > 0) {
-        notesWithViolations++;
-        totalViolations += result.violations.length;
-        console.log(`\n  ${relPath} [concept: ${concept.concept}]`);
-        for (const v of result.violations) {
-          console.log(`    [${v.rule}] ${v.message}`);
-        }
-      }
+      notes.push({
+        notePath: relPath,
+        concept: concept.concept,
+        violations: result.violations,
+      });
     }
 
-    console.log(
-      `\nOh My Second Brain doctor: ${totalNotes} notes checked, ${notesWithViolations} with violations, ${totalViolations} total violations.`,
-    );
-    console.log("All violations are warnings (onViolation: warn). Exit 0.\n");
-
-    // Broken-link and orphan detection (C4 lint port).
-    try {
-      const lintResult = await detectLinkIssues(vault);
-      if (lintResult.brokenLinks.length > 0) {
-        console.log(`\n--- Broken wikilinks (${lintResult.brokenLinks.length}) ---`);
-        for (const { notePath, target } of lintResult.brokenLinks) {
-          console.log(`  [broken-link] ${notePath} -> [[${target}]]`);
-        }
-      } else {
-        console.log("Broken wikilinks: 0");
-      }
-
-      const orphanCount = lintResult.orphanPaths.length;
-      if (orphanCount > 0) {
-        console.log(`\n--- Orphan notes (no incoming links): ${orphanCount} ---`);
-        for (const p of lintResult.orphanPaths.slice(0, 20)) {
-          console.log(`  [orphan] ${p}`);
-        }
-        if (orphanCount > 20) {
-          console.log(`  ... and ${orphanCount - 20} more`);
-        }
-      } else {
-        console.log("Orphan notes: 0");
-      }
-    } catch (lintErr) {
-      console.warn("[oms] lint detection could not complete:", lintErr);
+    const aggregate = aggregateDoctor(notes);
+    if (opts.json) {
+      console.log(JSON.stringify(aggregate, null, 2));
+    } else {
+      console.log(
+        formatDoctorReport(aggregate, {
+          vault,
+          verbose: opts.verbose,
+          maxPerConcept: opts.maxPerConcept,
+          notes,
+        }),
+      );
     }
   } catch (err) {
     console.warn("[oms] doctor could not complete:", err);
   }
 
   // Always exit 0 in v0 (non-blocking, onViolation: warn).
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// runLint — link & structure hygiene (broken wikilinks, orphan notes)
+// ---------------------------------------------------------------------------
+
+export async function runLint(opts: {
+  vault: string;
+  verbose?: boolean;
+  json?: boolean;
+}): Promise<number> {
+  const { vault } = opts;
+
+  // Lint is non-blocking like doctor: surface findings, always exit 0.
+  try {
+    const result = await detectLinkIssues(vault);
+    if (opts.json) {
+      console.log(
+        JSON.stringify(
+          {
+            totalNotes: result.totalNotes,
+            brokenLinks: result.brokenLinks,
+            orphanPaths: result.orphanPaths,
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.log(formatLintReport(result, { vault, verbose: opts.verbose }));
+    }
+  } catch (err) {
+    console.warn("[oms] lint could not complete:", err);
+  }
+
   return 0;
 }
 
@@ -686,7 +707,8 @@ Usage:
   oh-my-second-brain install [--vault <path>] [--runtime <auto|all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
   oh-my-second-brain uninstall [--runtime <all|claude|codex|hermes>] [--dry-run] [--execute] [--yes]
   oh-my-second-brain update [--check] [--dry-run] [--yes] [--runtime <auto|all|claude|codex|hermes>] [--vault <path>]
-  oh-my-second-brain doctor [--vault <path>]
+  oh-my-second-brain doctor [--vault <path>] [--verbose] [--json] [--max <n>]
+  oh-my-second-brain lint [--vault <path>] [--verbose] [--json]
   oh-my-second-brain semantic <status|sync|query|search|vsearch|get|multi-get|collection> [options]
   oh-my-second-brain mcp [--vault <path>]
   oh-my-second-brain hook pre-tool-use [--vault <path>]
@@ -699,7 +721,8 @@ Commands:
   install  Install Oh My Second Brain host adapters and MCP registration.
   uninstall Remove Oh My Second Brain host adapters and MCP registration.
   update   Check for or apply an explicit package update, then refresh host adapters.
-  doctor   Validate vault notes against the active ontology (includes broken-link and orphan detection).
+  doctor   Validate vault frontmatter against the active ontology, aggregated by field and concept.
+  lint     Check vault link health: broken [[wikilinks]] and orphan notes.
   semantic Native markdown semantic index/search/get commands.
   mcp      Start the read/status MCP stdio server.
   hook     Vault guard hooks for Claude Code PreToolUse / PostToolUse events.
@@ -714,6 +737,9 @@ Options:
   --runtime <name> Select host runtime (default: auto for install, all for uninstall).
   --dry-run        Preview host config changes without writing files.
   --execute        Allow external host CLIs such as \`claude\` to run when available.
+  --verbose        doctor/lint: list every affected note instead of a summary.
+  --json           doctor/lint: emit machine-readable aggregation as JSON.
+  --max <n>        doctor --verbose: max notes listed per concept (default 50).
 `);
 }
 
@@ -732,6 +758,9 @@ async function main(): Promise<void> {
   let checkUpdate = false;
   let timeoutMs: number | undefined;
   let agentVault: string | undefined;
+  let verbose = false;
+  let json = false;
+  let maxPerConcept: number | undefined;
   const unknownFlags: string[] = [];
 
   for (let i = 1; i < argv.length; i++) {
@@ -778,6 +807,19 @@ async function main(): Promise<void> {
       dryRun = true;
     } else if (argv[i] === "--execute") {
       executeExternal = true;
+    } else if (argv[i] === "--verbose" || argv[i] === "-v") {
+      verbose = true;
+    } else if (argv[i] === "--json") {
+      json = true;
+    } else if (argv[i] === "--max" && argv[i + 1]) {
+      const parsed = Number.parseInt(argv[i + 1]!, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        console.error(`[oms] Unsupported --max value: ${argv[i + 1]!}`);
+        process.exitCode = 1;
+        return;
+      }
+      maxPerConcept = parsed;
+      i++;
     } else {
       unknownFlags.push(argv[i]!);
     }
@@ -847,7 +889,10 @@ async function main(): Promise<void> {
     });
     console.log(formatHostOperationResults(results, dryRun));
   } else if (command === "doctor") {
-    process.exitCode = await runDoctor({ vault });
+    process.exitCode = await runDoctor({ vault, verbose, json, maxPerConcept });
+    await maybePrintUpdateNotice();
+  } else if (command === "lint") {
+    process.exitCode = await runLint({ vault, verbose, json });
     await maybePrintUpdateNotice();
   } else if (isSemanticCliCommand(command)) {
     process.exitCode = await runSemanticCli({

--- a/src/conventions/report.test.ts
+++ b/src/conventions/report.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateDoctor,
+  formatDoctorReport,
+  formatLintReport,
+  type NoteReport,
+} from "./report.js";
+import type { VaultLintResult } from "./lint.js";
+
+// ---------------------------------------------------------------------------
+// aggregateDoctor
+// ---------------------------------------------------------------------------
+
+describe("aggregateDoctor", () => {
+  it("rolls up totals across all scanned notes", () => {
+    const notes: NoteReport[] = [
+      { notePath: "a.md", concept: "literature", violations: [] },
+      {
+        notePath: "b.md",
+        concept: "literature",
+        violations: [
+          { field: "title", rule: "required", message: "x" },
+          { field: "source-url", rule: "required", message: "y" },
+        ],
+      },
+      {
+        notePath: "c.md",
+        concept: "literature",
+        violations: [{ field: "title", rule: "required", message: "x" }],
+      },
+    ];
+
+    const agg = aggregateDoctor(notes);
+
+    expect(agg.totalNotes).toBe(3);
+    expect(agg.notesWithViolations).toBe(2);
+    expect(agg.totalViolations).toBe(3);
+  });
+
+  it("aggregates by frontmatter field: distinct notes vs total occurrences", () => {
+    const notes: NoteReport[] = [
+      {
+        notePath: "b.md",
+        concept: "literature",
+        violations: [
+          { field: "title", rule: "required", message: "x" },
+          { field: "source-url", rule: "required", message: "y" },
+        ],
+      },
+      {
+        notePath: "c.md",
+        concept: "literature",
+        violations: [{ field: "title", rule: "required", message: "x" }],
+      },
+    ];
+
+    const agg = aggregateDoctor(notes);
+
+    // title:required affects 2 notes (b, c) → notes:2, violations:2
+    const title = agg.fields.find((f) => f.field === "title");
+    expect(title).toMatchObject({
+      concept: "literature",
+      rule: "required",
+      notes: 2,
+      violations: 2,
+    });
+
+    // source-url:required affects 1 note → notes:1, violations:1
+    const sourceUrl = agg.fields.find((f) => f.field === "source-url");
+    expect(sourceUrl).toMatchObject({ notes: 1, violations: 1 });
+
+    // Most-violated field first.
+    expect(agg.fields[0]?.field).toBe("title");
+  });
+
+  it("counts a field once per note even with duplicate same-field violations", () => {
+    const notes: NoteReport[] = [
+      {
+        notePath: "b.md",
+        concept: "references",
+        violations: [
+          { field: "tags", rule: "type", message: "x" },
+          { field: "tags", rule: "type", message: "x again" },
+        ],
+      },
+    ];
+
+    const agg = aggregateDoctor(notes);
+    const tags = agg.fields.find((f) => f.field === "tags");
+    expect(tags).toMatchObject({ notes: 1, violations: 2 });
+  });
+
+  it("separates aggregation per concept", () => {
+    const notes: NoteReport[] = [
+      {
+        notePath: "lit.md",
+        concept: "literature",
+        violations: [{ field: "title", rule: "required", message: "x" }],
+      },
+      {
+        notePath: "ref.md",
+        concept: "references",
+        violations: [{ field: "title", rule: "required", message: "x" }],
+      },
+    ];
+
+    const agg = aggregateDoctor(notes);
+    expect(agg.concepts).toHaveLength(2);
+    // title:required appears once per concept as distinct rows.
+    expect(agg.fields.filter((f) => f.field === "title")).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDoctorReport
+// ---------------------------------------------------------------------------
+
+describe("formatDoctorReport", () => {
+  it("renders the per-field aggregation table when violations exist", () => {
+    const notes: NoteReport[] = [
+      {
+        notePath: "b.md",
+        concept: "literature",
+        violations: [{ field: "title", rule: "required", message: "x" }],
+      },
+    ];
+    const out = formatDoctorReport(aggregateDoctor(notes), { vault: "/v" });
+
+    expect(out).toContain("Violations by frontmatter field");
+    expect(out).toContain("Violations by concept");
+    expect(out).toContain("title");
+    expect(out).toContain("required");
+    // No per-note flood without --verbose.
+    expect(out).not.toContain("b.md");
+    expect(out).toContain("Run `oms doctor --verbose`");
+  });
+
+  it("lists affected notes only in verbose mode", () => {
+    const notes: NoteReport[] = [
+      {
+        notePath: "b.md",
+        concept: "literature",
+        violations: [{ field: "title", rule: "required", message: "x" }],
+      },
+    ];
+    const out = formatDoctorReport(aggregateDoctor(notes), {
+      vault: "/v",
+      verbose: true,
+      notes,
+    });
+    expect(out).toContain("Affected notes");
+    expect(out).toContain("b.md — title:required");
+  });
+
+  it("reports a clean bill of health when there are no violations", () => {
+    const notes: NoteReport[] = [
+      { notePath: "a.md", concept: "literature", violations: [] },
+    ];
+    const out = formatDoctorReport(aggregateDoctor(notes), { vault: "/v" });
+    expect(out).toContain("No frontmatter violations");
+    expect(out).not.toContain("Violations by frontmatter field");
+  });
+
+  it("handles an empty vault", () => {
+    const out = formatDoctorReport(aggregateDoctor([]), { vault: "/v" });
+    expect(out).toContain("No notes matched the active ontology");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLintReport
+// ---------------------------------------------------------------------------
+
+describe("formatLintReport", () => {
+  const result: VaultLintResult = {
+    totalNotes: 3,
+    brokenLinks: [
+      { notePath: "a.md", target: "Missing1" },
+      { notePath: "a.md", target: "Missing2" },
+      { notePath: "b.md", target: "Missing3" },
+    ],
+    orphanPaths: ["c.md"],
+  };
+
+  it("summarizes broken links by offending note, most first", () => {
+    const out = formatLintReport(result, { vault: "/v" });
+    expect(out).toContain("3 broken wikilink(s) across 2 note(s)");
+    expect(out).toContain("a.md (2)");
+    expect(out).toContain("[[Missing1]]");
+    // a.md (2 broken) should be listed before b.md (1 broken).
+    expect(out.indexOf("a.md")).toBeLessThan(out.indexOf("b.md"));
+  });
+
+  it("reports orphan notes", () => {
+    const out = formatLintReport(result, { vault: "/v" });
+    expect(out).toContain("Orphan notes (no incoming links): 1");
+    expect(out).toContain("c.md");
+  });
+
+  it("does not report frontmatter — that is doctor's job (MECE)", () => {
+    const out = formatLintReport(result, { vault: "/v" });
+    expect(out).not.toContain("frontmatter");
+    expect(out).not.toContain("concept");
+  });
+
+  it("gives a clean report when there are no link issues", () => {
+    const clean: VaultLintResult = {
+      totalNotes: 1,
+      brokenLinks: [],
+      orphanPaths: [],
+    };
+    const out = formatLintReport(clean, { vault: "/v" });
+    expect(out).toContain("Broken wikilinks: 0 ✓");
+    expect(out).toContain("Orphan notes: 0 ✓");
+  });
+});

--- a/src/conventions/report.ts
+++ b/src/conventions/report.ts
@@ -1,0 +1,362 @@
+import type { Violation } from "./validate.js";
+import type { VaultLintResult } from "./lint.js";
+
+// ---------------------------------------------------------------------------
+// Doctor: frontmatter convention aggregation
+// ---------------------------------------------------------------------------
+
+/** One scanned note and the violations found in its frontmatter (empty = clean). */
+export interface NoteReport {
+  notePath: string;
+  concept: string;
+  violations: readonly Violation[];
+}
+
+/** Aggregated counts for a single (field, rule) pair. */
+export interface FieldRuleAgg {
+  field: string;
+  rule: string;
+  /** Distinct notes that hit this field+rule at least once. */
+  notes: number;
+  /** Total occurrences of this field+rule across all notes. */
+  violations: number;
+}
+
+export interface ConceptAgg {
+  concept: string;
+  notes: number;
+  notesWithViolations: number;
+  violations: number;
+  /** Per (field, rule) breakdown, sorted by impact descending. */
+  fields: FieldRuleAgg[];
+}
+
+export interface DoctorAggregate {
+  totalNotes: number;
+  notesWithViolations: number;
+  totalViolations: number;
+  /** Per-concept breakdown, sorted by violation count descending. */
+  concepts: ConceptAgg[];
+  /** Flat per-frontmatter-field rollup across all concepts, most-violated first. */
+  fields: Array<FieldRuleAgg & { concept: string }>;
+}
+
+function fieldRuleKey(field: string, rule: string): string {
+  return `${field}\u0000${rule}`;
+}
+
+function sortFieldRule(a: FieldRuleAgg, b: FieldRuleAgg): number {
+  return (
+    b.notes - a.notes ||
+    b.violations - a.violations ||
+    a.field.localeCompare(b.field) ||
+    a.rule.localeCompare(b.rule)
+  );
+}
+
+/**
+ * Roll up per-note frontmatter violations into concept- and field-level
+ * aggregates. Every scanned note (clean or not) should be passed so that
+ * per-concept totals reflect coverage, not just failures.
+ */
+export function aggregateDoctor(notes: readonly NoteReport[]): DoctorAggregate {
+  interface MutConcept {
+    notes: number;
+    notesWithViolations: number;
+    violations: number;
+    fields: Map<string, FieldRuleAgg>;
+  }
+  const conceptMap = new Map<string, MutConcept>();
+  let totalNotes = 0;
+  let notesWithViolations = 0;
+  let totalViolations = 0;
+
+  for (const note of notes) {
+    totalNotes++;
+    let entry = conceptMap.get(note.concept);
+    if (!entry) {
+      entry = { notes: 0, notesWithViolations: 0, violations: 0, fields: new Map() };
+      conceptMap.set(note.concept, entry);
+    }
+    entry.notes++;
+    if (note.violations.length === 0) continue;
+
+    notesWithViolations++;
+    totalViolations += note.violations.length;
+    entry.notesWithViolations++;
+    entry.violations += note.violations.length;
+
+    // Count a note once per (field, rule) for `notes`, but every occurrence
+    // for `violations`.
+    const seenPairs = new Set<string>();
+    for (const v of note.violations) {
+      const key = fieldRuleKey(v.field, v.rule);
+      let fr = entry.fields.get(key);
+      if (!fr) {
+        fr = { field: v.field, rule: v.rule, notes: 0, violations: 0 };
+        entry.fields.set(key, fr);
+      }
+      fr.violations++;
+      if (!seenPairs.has(key)) {
+        seenPairs.add(key);
+        fr.notes++;
+      }
+    }
+  }
+
+  const concepts: ConceptAgg[] = [];
+  const fields: Array<FieldRuleAgg & { concept: string }> = [];
+  for (const [concept, entry] of conceptMap) {
+    const sortedFields = Array.from(entry.fields.values()).sort(sortFieldRule);
+    concepts.push({
+      concept,
+      notes: entry.notes,
+      notesWithViolations: entry.notesWithViolations,
+      violations: entry.violations,
+      fields: sortedFields,
+    });
+    for (const fr of sortedFields) fields.push({ ...fr, concept });
+  }
+  concepts.sort(
+    (a, b) => b.violations - a.violations || a.concept.localeCompare(b.concept),
+  );
+  fields.sort(
+    (a, b) =>
+      b.notes - a.notes ||
+      b.violations - a.violations ||
+      a.concept.localeCompare(b.concept) ||
+      a.field.localeCompare(b.field),
+  );
+
+  return { totalNotes, notesWithViolations, totalViolations, concepts, fields };
+}
+
+// ---------------------------------------------------------------------------
+// Table rendering
+// ---------------------------------------------------------------------------
+
+type Align = "left" | "right";
+
+function renderTable(
+  headers: readonly string[],
+  aligns: readonly Align[],
+  rows: readonly string[][],
+  indent = "  ",
+): string[] {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length), 0),
+  );
+  const renderRow = (cells: readonly string[]): string =>
+    (
+      indent +
+      cells
+        .map((c, i) =>
+          aligns[i] === "right"
+            ? (c ?? "").padStart(widths[i]!)
+            : (c ?? "").padEnd(widths[i]!),
+        )
+        .join("  ")
+    ).replace(/\s+$/, "");
+  return [renderRow(headers), ...rows.map(renderRow)];
+}
+
+// ---------------------------------------------------------------------------
+// Doctor formatting
+// ---------------------------------------------------------------------------
+
+export interface DoctorFormatOptions {
+  vault: string;
+  /** Append a per-note listing of every violation. */
+  verbose?: boolean;
+  /** Cap on notes listed per concept in verbose mode (default 50). */
+  maxPerConcept?: number;
+  /** Scanned notes — required for the verbose listing. */
+  notes?: readonly NoteReport[];
+}
+
+export function formatDoctorReport(
+  agg: DoctorAggregate,
+  opts: DoctorFormatOptions,
+): string {
+  const lines: string[] = [];
+  lines.push("Oh My Second Brain doctor — frontmatter convention check");
+  lines.push(`Vault: ${opts.vault}`);
+  lines.push("");
+
+  if (agg.totalNotes === 0) {
+    lines.push("No notes matched the active ontology (nothing to validate).");
+    lines.push("");
+    lines.push("All violations are warnings (onViolation: warn). Exit 0.");
+    return lines.join("\n");
+  }
+
+  lines.push(
+    `Scanned ${agg.totalNotes} notes across ${agg.concepts.length} concept(s).`,
+  );
+  lines.push(
+    `${agg.notesWithViolations} notes with violations · ${agg.totalViolations} total violations.`,
+  );
+
+  if (agg.totalViolations === 0) {
+    lines.push("");
+    lines.push("No frontmatter violations. ✓");
+    lines.push("");
+    lines.push("All violations are warnings (onViolation: warn). Exit 0.");
+    return lines.join("\n");
+  }
+
+  // Headline view: which frontmatter fields are systematically broken.
+  lines.push("");
+  lines.push("Violations by frontmatter field");
+  lines.push(
+    ...renderTable(
+      ["concept", "field", "rule", "notes", "violations"],
+      ["left", "left", "left", "right", "right"],
+      agg.fields.map((f) => [
+        f.concept,
+        f.field,
+        f.rule,
+        String(f.notes),
+        String(f.violations),
+      ]),
+    ),
+  );
+
+  // Per-concept rollup.
+  lines.push("");
+  lines.push("Violations by concept");
+  lines.push(
+    ...renderTable(
+      ["concept", "notes (viol/total)", "violations"],
+      ["left", "right", "right"],
+      agg.concepts
+        .filter((c) => c.violations > 0)
+        .map((c) => [
+          c.concept,
+          `${c.notesWithViolations}/${c.notes}`,
+          String(c.violations),
+        ]),
+    ),
+  );
+
+  if (opts.verbose && opts.notes) {
+    const max = opts.maxPerConcept ?? 50;
+    const byConcept = new Map<string, NoteReport[]>();
+    for (const n of opts.notes) {
+      if (n.violations.length === 0) continue;
+      const arr = byConcept.get(n.concept) ?? [];
+      arr.push(n);
+      byConcept.set(n.concept, arr);
+    }
+    lines.push("");
+    lines.push("Affected notes");
+    for (const c of agg.concepts) {
+      const arr = byConcept.get(c.concept);
+      if (!arr || arr.length === 0) continue;
+      lines.push("");
+      lines.push(`  [${c.concept}] ${arr.length} note(s)`);
+      for (const n of arr.slice(0, max)) {
+        const summary = n.violations.map((v) => `${v.field}:${v.rule}`).join(", ");
+        lines.push(`    ${n.notePath} — ${summary}`);
+      }
+      if (arr.length > max) {
+        lines.push(`    … and ${arr.length - max} more`);
+      }
+    }
+  }
+
+  lines.push("");
+  lines.push("All violations are warnings (onViolation: warn). Exit 0.");
+  if (!opts.verbose) {
+    lines.push("Run `oms doctor --verbose` to list affected notes.");
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Lint formatting (broken links + orphans)
+// ---------------------------------------------------------------------------
+
+export interface LintFormatOptions {
+  vault: string;
+  /** List every broken link and orphan instead of a capped summary. */
+  verbose?: boolean;
+  /** Max offending notes listed for broken links (default 20). */
+  maxBroken?: number;
+  /** Max orphan notes listed (default 20). */
+  maxOrphans?: number;
+}
+
+export function formatLintReport(
+  result: VaultLintResult,
+  opts: LintFormatOptions,
+): string {
+  const byNote = new Map<string, string[]>();
+  for (const { notePath, target } of result.brokenLinks) {
+    const arr = byNote.get(notePath) ?? [];
+    arr.push(target);
+    byNote.set(notePath, arr);
+  }
+  const offenders = Array.from(byNote.entries())
+    .map(([notePath, targets]) => ({ notePath, targets }))
+    .sort(
+      (a, b) =>
+        b.targets.length - a.targets.length ||
+        a.notePath.localeCompare(b.notePath),
+    );
+
+  const lines: string[] = [];
+  lines.push("Oh My Second Brain lint — link & structure check");
+  lines.push(`Vault: ${opts.vault}`);
+  lines.push("");
+  lines.push(`Scanned ${result.totalNotes} notes.`);
+  lines.push(
+    `${result.brokenLinks.length} broken wikilink(s) across ${offenders.length} note(s) · ${result.orphanPaths.length} orphan note(s).`,
+  );
+
+  if (result.brokenLinks.length > 0) {
+    lines.push("");
+    lines.push("Broken wikilinks — notes with the most dangling targets");
+    const maxNotes = opts.verbose ? offenders.length : opts.maxBroken ?? 20;
+    for (const o of offenders.slice(0, maxNotes)) {
+      lines.push(`  ${o.notePath} (${o.targets.length})`);
+      const targetMax = opts.verbose ? o.targets.length : 5;
+      for (const t of o.targets.slice(0, targetMax)) {
+        lines.push(`    -> [[${t}]]`);
+      }
+      if (o.targets.length > targetMax) {
+        lines.push(`    … and ${o.targets.length - targetMax} more`);
+      }
+    }
+    if (offenders.length > maxNotes) {
+      lines.push(
+        `  … and ${offenders.length - maxNotes} more note(s) with broken links`,
+      );
+    }
+  } else {
+    lines.push("");
+    lines.push("Broken wikilinks: 0 ✓");
+  }
+
+  if (result.orphanPaths.length > 0) {
+    lines.push("");
+    lines.push(`Orphan notes (no incoming links): ${result.orphanPaths.length}`);
+    const maxOrph = opts.verbose ? result.orphanPaths.length : opts.maxOrphans ?? 20;
+    for (const p of result.orphanPaths.slice(0, maxOrph)) {
+      lines.push(`  ${p}`);
+    }
+    if (result.orphanPaths.length > maxOrph) {
+      lines.push(`  … and ${result.orphanPaths.length - maxOrph} more`);
+    }
+  } else {
+    lines.push("");
+    lines.push("Orphan notes: 0 ✓");
+  }
+
+  lines.push("");
+  lines.push("Lint findings are warnings (non-blocking). Exit 0.");
+  if (!opts.verbose) {
+    lines.push("Run `oms lint --verbose` to list every finding.");
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## What

Splits the overloaded `oms doctor` into two MECE commands and makes `doctor` aggregate by frontmatter field instead of dumping every note.

### Roles (mutually exclusive, collectively exhaustive)

| command | question | checks |
|---|---|---|
| `oms doctor` | is each note internally well-formed per the convention? (intrinsic / per-note) | **frontmatter** — ontology `required` / `type` rules |
| `oms lint` | is the vault graph healthy? (relational / cross-note) | **links** — broken `[[wikilinks]]`, orphan notes |

`doctor` no longer runs link/orphan detection (`detectLinkIssues` removed from it); `lint` never touches frontmatter. No overlap, no gap.

## Why

- `doctor` doubled as a link linter, conflating two concerns.
- It printed one line per offending note (≈1.5MB / 14k lines on a real vault) and only a grand total — never a per-frontmatter-field rollup, so you couldn't see *which fields* were systematically broken.

## After (real vault)

```
Violations by frontmatter field
  concept     field          rule      notes  violations
  literature  source-url     required    375         375
  literature  title          required    266         266
  permanent   tags           required    159         159
  literature  author         type         38          38
```

## Changes

- `src/conventions/report.ts` (new) — pure aggregation/formatting: `aggregateDoctor`, `formatDoctorReport`, `formatLintReport`.
- `src/cli/oms.ts` — rewrite `runDoctor` (aggregated), add `runLint`, `lint` routing, `--verbose` / `--json` / `--max` flags, usage text.
- `src/conventions/report.test.ts` (new) — 13 unit tests (aggregation math, MECE separation, empty/clean cases).
- `README.md` — CLI reference updated.

Flags: default = capped summary; `--verbose` lists every note; `--json` emits machine-readable aggregation; `--max <n>` caps verbose per-concept listing.

## Verification

- `npm run lint` (tsc) ✅ · `npm run build` ✅
- `npx vitest run` → 629 passed, 11 skipped (pre-existing golden parity skips) ✅
- Ran `doctor` + `lint` (incl. `--json`) against a real ~19k-note vault ✅

Both commands remain non-blocking (exit 0), preserving `onViolation: warn`.