### PR TITLE
chore: ignore node_modules symlink; document git-sync workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies & build output
-node_modules/
+# 'node_modules' (no trailing slash) so worktree symlinks are ignored too
+node_modules
 dist/
 *.tsbuildinfo
 coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,14 @@ CI pipeline order: **build first, then test**. A broken build blocks the test ru
 
 ---
 
+## Git workflow
+
+- **Sync with mainline before you branch.** Start every task with `git fetch origin && git switch -c <branch> origin/main` (or `git pull --rebase` on a tracking branch). This repo is frequently developed in **detached-HEAD worktrees that lag behind `main`**; branching off a stale HEAD risks rebuilding on retired code (e.g., a module that was deleted on `main`).
+- **Rebase on mainline drift.** If `main` advances mid-task, `git rebase origin/main` before opening the PR.
+- **Worktree caveat:** when `main` is checked out in another worktree, skip `gh pr merge --delete-branch` — the local branch-delete step fails with `'main' is already used by worktree`. Merge, then delete branches manually (`git push origin --delete <branch>`).
+
+---
+
 ## CRITICAL: NodeNext Import Extensions
 
 **tsconfig uses `moduleResolution: NodeNext`.**


### PR DESCRIPTION
Repo-hygiene follow-ups from the doctor/lint split session.

## node_modules (정석 fix)
This worktree's `node_modules` is a **symlink** to the main checkout. `.gitignore` had `node_modules/` (trailing slash = directory-only), which does **not** match a symlink — so `node_modules` showed up as untracked and was at risk of being staged by `git add .`. Dropping the trailing slash (`node_modules`) ignores the name regardless of dir/symlink. Verified: `git check-ignore` now matches and it no longer appears in `git status`.

## Git workflow (AGENTS.md)
Codifies the lesson from this session: this repo is often developed in detached-HEAD worktrees that lag `main`, and the previous PR was nearly based on a stale HEAD (2 commits behind, incl. a retired module).

- Fetch + branch off `origin/main` before starting.
- Rebase on mainline drift.
- Worktree caveat: skip `gh pr merge --delete-branch` when `main` is checked out in another worktree.

No source/build changes (docs + gitignore only).