### PR TITLE
refactor(conventions): single vault-walk SSOT for doctor + lint

### DIFF
--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -16,6 +16,7 @@ import {
   formatLintReport,
   type NoteReport,
 } from "../conventions/report.js";
+import { walkVaultMarkdown, mapWithConcurrency } from "../conventions/vault-walk.js";
 import { runMcpServer } from "../mcp/server.js";
 import { runPreToolUse } from "../hook/pre-tool-use.js";
 import { runPostToolUse } from "../hook/post-tool-use.js";
@@ -323,30 +324,6 @@ function printClaudeInstallPlan(plan: ClaudeInstallPlan): void {
   );
 }
 
-/** Walk a directory recursively, yielding relative paths for all .md files. */
-async function* walkMarkdown(
-  dir: string,
-  base: string,
-  skipDirs: Set<string>,
-): AsyncGenerator<string> {
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-  for (const entry of entries) {
-    if (entry.name.startsWith(".")) continue;
-    if (skipDirs.has(entry.name)) continue;
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      yield* walkMarkdown(full, base, skipDirs);
-    } else if (entry.isFile() && entry.name.endsWith(".md")) {
-      yield path.relative(base, full).replace(/\\/g, "/");
-    }
-  }
-}
-
 // ---------------------------------------------------------------------------
 // runSetup
 // ---------------------------------------------------------------------------
@@ -612,30 +589,35 @@ export async function runDoctor(opts: {
 
     const ontology = await loadOntology(ontologyDir);
 
-    const skipDirs = new Set(["node_modules"]);
-    const notes: NoteReport[] = [];
-
-    for await (const relPath of walkMarkdown(vault, vault, skipDirs)) {
+    // Enumerate concept-matched notes first, then read + validate in parallel
+    // (reading note contents dominates wall time on large vaults).
+    const candidates: { relPath: string; concept: Concept }[] = [];
+    for await (const relPath of walkVaultMarkdown(vault)) {
       const concept = resolveConcept(ontology, relPath);
-      if (!concept) continue;
-
-      const fullPath = path.join(vault, relPath);
-      let raw: string;
-      try {
-        raw = await readFile(fullPath, "utf-8");
-      } catch {
-        console.warn(`[oms] Could not read ${relPath}`);
-        continue;
-      }
-
-      const { frontmatter } = parseNote(raw);
-      const result = validateFrontmatter(frontmatter, concept);
-      notes.push({
-        notePath: relPath,
-        concept: concept.concept,
-        violations: result.violations,
-      });
+      if (concept) candidates.push({ relPath, concept });
     }
+
+    const scanned = await mapWithConcurrency(
+      candidates,
+      64,
+      async ({ relPath, concept }): Promise<NoteReport | null> => {
+        try {
+          const raw = await readFile(path.join(vault, relPath), "utf-8");
+          const { frontmatter } = parseNote(raw);
+          return {
+            notePath: relPath,
+            concept: concept.concept,
+            violations: validateFrontmatter(frontmatter, concept).violations,
+          };
+        } catch {
+          console.warn(`[oms] Could not read ${relPath}`);
+          return null;
+        }
+      },
+    );
+    const notes: NoteReport[] = scanned.filter(
+      (n): n is NoteReport => n !== null,
+    );
 
     const aggregate = aggregateDoctor(notes);
     if (opts.json) {

--- a/src/conventions/lint.ts
+++ b/src/conventions/lint.ts
@@ -1,12 +1,7 @@
-import { readFile, readdir } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { parseNote } from "./frontmatter.js";
-
-// Folders skipped during vault walks (same set as graph/cache.ts).
-const SKIP_DIRS = new Set([
-  ".oms", ".obsidian", ".trash", ".git", ".claude",
-  "_archive", "node_modules",
-]);
+import { walkVaultMarkdown, mapWithConcurrency } from "./vault-walk.js";
 
 export interface BrokenLink {
   notePath: string;
@@ -20,23 +15,7 @@ export interface VaultLintResult {
   totalNotes: number;
 }
 
-async function* walkMarkdown(dir: string, base: string): AsyncGenerator<string> {
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-  for (const entry of entries) {
-    if (entry.name.startsWith(".") || SKIP_DIRS.has(entry.name)) continue;
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      yield* walkMarkdown(full, base);
-    } else if (entry.isFile() && entry.name.endsWith(".md")) {
-      yield path.relative(base, full).replace(/\\/g, "/");
-    }
-  }
-}
+
 
 const WIKILINK_RE = /\[\[([^\]|#\n]+?)(?:[#|][^\]]*?)?\]\]/g;
 
@@ -74,7 +53,7 @@ function buildNoteIndex(notePaths: readonly string[]): Map<string, string> {
  */
 export async function detectLinkIssues(vault: string): Promise<VaultLintResult> {
   const allPaths: string[] = [];
-  for await (const p of walkMarkdown(vault, vault)) {
+  for await (const p of walkVaultMarkdown(vault)) {
     allPaths.push(p);
   }
 
@@ -82,15 +61,19 @@ export async function detectLinkIssues(vault: string): Promise<VaultLintResult> 
   const brokenLinks: BrokenLink[] = [];
   const incomingCount = new Map<string, number>(allPaths.map((p) => [p, 0]));
 
-  for (const notePath of allPaths) {
-    let raw: string;
+  // Read + extract links in parallel (I/O-bound), then resolve sequentially in
+  // path order so brokenLinks ordering stays deterministic.
+  const perNote = await mapWithConcurrency(allPaths, 64, async (notePath) => {
     try {
-      raw = await readFile(path.join(vault, notePath), "utf-8");
+      const raw = await readFile(path.join(vault, notePath), "utf-8");
+      return { notePath, targets: extractWikilinks(parseNote(raw).body) };
     } catch {
-      continue;
+      return { notePath, targets: [] as string[] };
     }
-    const { body } = parseNote(raw);
-    for (const target of extractWikilinks(body)) {
+  });
+
+  for (const { notePath, targets } of perNote) {
+    for (const target of targets) {
       const resolved = noteIndex.get(target.toLowerCase());
       if (resolved === undefined) {
         brokenLinks.push({ notePath, target });

--- a/src/conventions/vault-walk.test.ts
+++ b/src/conventions/vault-walk.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  VAULT_SKIP_DIRS,
+  walkVaultMarkdown,
+  mapWithConcurrency,
+} from "./vault-walk.js";
+
+async function makeVault(
+  files: Record<string, string>,
+): Promise<{ vaultPath: string; cleanup: () => Promise<void> }> {
+  const vaultPath = await mkdtemp(path.join(os.tmpdir(), "oms-walk-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(vaultPath, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, content);
+  }
+  return { vaultPath, cleanup: () => rm(vaultPath, { recursive: true, force: true }) };
+}
+
+async function collect(gen: AsyncGenerator<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const p of gen) out.push(p);
+  return out.sort();
+}
+
+describe("walkVaultMarkdown", () => {
+  it("yields nested markdown as POSIX relative paths", async () => {
+    const { vaultPath, cleanup } = await makeVault({
+      "a.md": "x",
+      "sub/b.md": "x",
+      "sub/deep/c.md": "x",
+      "not-a-note.txt": "x",
+    });
+    try {
+      expect(await collect(walkVaultMarkdown(vaultPath))).toEqual([
+        "a.md",
+        "sub/b.md",
+        "sub/deep/c.md",
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips VAULT_SKIP_DIRS and dotfiles by default", async () => {
+    const files: Record<string, string> = { "keep.md": "x" };
+    for (const dir of VAULT_SKIP_DIRS) files[`${dir}/buried.md`] = "x";
+    files[".hidden/secret.md"] = "x";
+    const { vaultPath, cleanup } = await makeVault(files);
+    try {
+      expect(await collect(walkVaultMarkdown(vaultPath))).toEqual(["keep.md"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("matches .md case-insensitively", async () => {
+    const { vaultPath, cleanup } = await makeVault({ "Upper.MD": "x", "lower.md": "x" });
+    try {
+      expect(await collect(walkVaultMarkdown(vaultPath))).toEqual(["Upper.MD", "lower.md"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("honors a custom skip set", async () => {
+    const { vaultPath, cleanup } = await makeVault({
+      "keep.md": "x",
+      "node_modules/dep.md": "x",
+      "_archive/old.md": "x",
+    });
+    try {
+      // Only skip node_modules → _archive is now included.
+      const result = await collect(
+        walkVaultMarkdown(vaultPath, { skip: new Set(["node_modules"]) }),
+      );
+      expect(result).toEqual(["_archive/old.md", "keep.md"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("can include dotfile dirs when skipDotfiles is false", async () => {
+    const { vaultPath, cleanup } = await makeVault({
+      "keep.md": "x",
+      ".obsidian-notes/n.md": "x",
+    });
+    try {
+      const result = await collect(
+        walkVaultMarkdown(vaultPath, { skip: new Set(), skipDotfiles: false }),
+      );
+      expect(result).toEqual([".obsidian-notes/n.md", "keep.md"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns nothing for a missing directory instead of throwing", async () => {
+    expect(await collect(walkVaultMarkdown("/no/such/vault/xyz"))).toEqual([]);
+  });
+});
+
+describe("mapWithConcurrency", () => {
+  it("preserves input order regardless of completion order", async () => {
+    const items = [50, 10, 30, 0, 20];
+    const result = await mapWithConcurrency(items, 3, async (n) => {
+      await new Promise((r) => setTimeout(r, n));
+      return n * 2;
+    });
+    expect(result).toEqual([100, 20, 60, 0, 40]);
+  });
+
+  it("handles an empty list", async () => {
+    expect(await mapWithConcurrency([], 8, async () => 1)).toEqual([]);
+  });
+
+  it("processes every item with limit greater than length", async () => {
+    const result = await mapWithConcurrency([1, 2, 3], 64, async (n) => n + 1);
+    expect(result).toEqual([2, 3, 4]);
+  });
+
+  it("never runs more than `limit` tasks at once", async () => {
+    let active = 0;
+    let peak = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    await mapWithConcurrency(items, 4, async (n) => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+      return n;
+    });
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(1);
+  });
+});

--- a/src/conventions/vault-walk.ts
+++ b/src/conventions/vault-walk.ts
@@ -1,0 +1,104 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Single source of truth for "what counts as a vault note to scan".
+ *
+ * Folders that are tooling/system/cache, never user notes. Every full-vault
+ * walk (doctor, lint, …) should skip the same set so subsystems agree on the
+ * note universe instead of each maintaining its own divergent list.
+ *
+ * NOTE: the engine/semantic lane (graph build, embedding sync) historically
+ * uses its own narrower policies for indexing reasons and is intentionally
+ * NOT migrated onto this default yet — converging it changes index contents
+ * and is a separate decision.
+ */
+export const VAULT_SKIP_DIRS: ReadonlySet<string> = new Set([
+  ".oms",
+  ".obsidian",
+  ".trash",
+  ".git",
+  ".claude",
+  "_archive",
+  "node_modules",
+]);
+
+export interface WalkOptions {
+  /** Directory names to skip entirely. Default: {@link VAULT_SKIP_DIRS}. */
+  skip?: ReadonlySet<string>;
+  /** Skip any entry whose name starts with ".". Default: true. */
+  skipDotfiles?: boolean;
+  /** Base directory relative paths are computed against. Default: `root`. */
+  base?: string;
+}
+
+async function* walk(
+  dir: string,
+  base: string,
+  skip: ReadonlySet<string>,
+  skipDotfiles: boolean,
+): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const name = entry.name;
+    if (skip.has(name)) continue;
+    if (skipDotfiles && name.startsWith(".")) continue;
+    const full = path.join(dir, name);
+    if (entry.isDirectory()) {
+      yield* walk(full, base, skip, skipDotfiles);
+    } else if (entry.isFile() && name.toLowerCase().endsWith(".md")) {
+      yield path.relative(base, full).replace(/\\/g, "/");
+    }
+  }
+}
+
+/**
+ * Recursively walk a vault, yielding POSIX-style relative paths for every
+ * markdown note, skipping {@link VAULT_SKIP_DIRS} (and dotfiles) by default.
+ *
+ * Streaming generator: paths are produced as the tree is traversed, so memory
+ * stays flat regardless of vault size.
+ */
+export function walkVaultMarkdown(
+  root: string,
+  opts: WalkOptions = {},
+): AsyncGenerator<string> {
+  return walk(
+    root,
+    opts.base ?? root,
+    opts.skip ?? VAULT_SKIP_DIRS,
+    opts.skipDotfiles ?? true,
+  );
+}
+
+/**
+ * Map over `items` with bounded concurrency, preserving input order in the
+ * returned array.
+ *
+ * The hot cost of a vault walk is reading note *contents* (≈95% of wall time
+ * on a large vault), not enumerating paths. Reading in parallel is the only
+ * optimization that materially helps; the directory scan is already cheap.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]!, i);
+    }
+  };
+  await Promise.all(Array.from({ length: workerCount }, worker));
+  return results;
+}


### PR DESCRIPTION
## Problem
Each full-vault scan reimplemented `walkMarkdown` — **7 copies**, with **5 different `SKIP_DIRS` sets**, plus inconsistent dotfile and `.md`-casing handling. doctor skipped only `{node_modules}`; lint skipped `{.oms,.obsidian,.trash,.git,.claude,_archive,node_modules}`. Result: the two commands disagreed on "what is a vault note," which is the root cause of the doctor-vs-lint scan-count gap flagged in #36.

## Change
New `src/conventions/vault-walk.ts` — single source of truth for the convention/CLI lane:
- `VAULT_SKIP_DIRS` — canonical skip policy.
- `walkVaultMarkdown(root, opts?)` — one streaming recursive walker (overridable `skip`, `skipDotfiles`, case-insensitive `.md`).
- `mapWithConcurrency(items, limit, fn)` — order-preserving bounded-parallel mapper.

Migrated `lint.detectLinkIssues` and `doctor` onto it, and switched their content reads to **parallel** (concurrency 64).

## Why parallel, not bash
Measured on the real ~19k-note vault: directory enumeration is ~84 ms (≈ `find`'s ~70 ms — Node `readdir` is the same `getdents` syscall). Reading note **contents** is ~95% of wall time (1.78 s serial → 0.78 s parallel). So shelling out to `find` would save <3%; concurrent reads give ~2x. The scan was never the bottleneck.

## Behavior verification (current vault state, apples-to-apples)
- Same skip set → **identical** 14,529 concept-matched notes (refactor is behavior-preserving).
- Canonical skip → drops **exactly 23** notes, **all under `_archive/`** — the intended consistency fix (doctor now ignores archived notes, like lint already did).

## Scope
Convention/CLI lane only (doctor, lint). The engine/graph/setup walkers keep their own intentional indexing policies (semantic store / graph build) and are a documented follow-up — per AGENTS.md "small diffs, one concern per PR."

## Tests
- `src/conventions/vault-walk.test.ts` (new, 10 cases): skip policy, dotfiles, custom skip, case-insensitive `.md`, missing dir, and `mapWithConcurrency` order/empty/limit/peak-concurrency.
- `npm run lint` ✅ · `npm run build` ✅ · `npx vitest run` → **639 passed, 11 skipped** ✅