### PR TITLE
feat: audit port onto new harness + qmd-compatible bridge (ADR-009)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ after editing imports.
 - **No `any` without justification.** Add a comment explaining why if you must use it.
 - **Test new logic paths.** Any new branch in `src/` should have a corresponding vitest case.
 - **Backward-compatible config changes only.** If a config shape changes, provide a migration path.
+- **qmd-compatible interface is a product contract.** CLI/MCP aliases (`query`, `search`, `vsearch`, `get`, `multi-get`/`multi_get`) and `qmd://` resource semantics require ADR-009 review plus adapter parity updates when changed.
 - Run `npm run lint && npm run build && npm test` before opening a PR and confirm all pass.
 
 ---

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -46,6 +46,7 @@ A **field** is one frontmatter key — the smallest unit of convention. Each fie
 | `intent`   | Semantic purpose: *what this field is FOR.* |
 | `normalize` | Optional: `kebab`, `lower`, or `trim` — applied at validation. |
 | `immutable` | Advisory: once written, should not change (v0: no-op, forward-compat). |
+| `enum` | Optional closed vocabulary for string fields; values outside it are lint violations. |
 
 Users grow their convention field-by-field. There is no mandatory field list.
 
@@ -77,7 +78,7 @@ folders:
     concept: inbox
 ```
 
-A folder may bind to one concept, multiple concepts (list), or `null` (not yet assigned).
+A folder may bind to one concept, multiple concepts (list), or `null` (not yet assigned). A folder binding may set `agentWritable: true`; paired with `routingLawStrict: true`, notes in that folder must carry `created_by`. Top-level `exclude` entries are vault-relative globs skipped by audit/lint scans.
 
 ---
 
@@ -105,6 +106,7 @@ Oh My Second Brain enforces what the user declared; it does not touch anything e
 ## Quick Reference for Host Agents
 
 - To understand a note: look up its folder in the taxonomy → read the `concept.intent`.
-- To validate frontmatter: load the concept's `fields`; check `required` + `type`.
+- To validate frontmatter: load the concept's `fields`; check `required`, `type`, and any `enum`.
 - To retrieve knowledge: apply the relevant `lens` to surface the fields that matter.
+- To audit a vault: honor taxonomy `exclude` globs and routing-law flags.
 - When in doubt, preserve: `additionalProperties: preserve` means unknown keys are safe.

--- a/core/skills/compile/SKILL.md
+++ b/core/skills/compile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: compile
 version: 0.1.0
-description: Stateless per-concept compile worker — takes a concept name, source materials, and graph context; returns a synthesized Markdown page body with SHA-incremental skip, nashsu 2-step CoT, atomicstrata 2-phase separation, lucasastorian cascade backlinks, and provenance-weighted synthesis context.
+description: Stateless per-concept compile worker — takes a concept name, source materials, and graph context; returns a synthesized Markdown page body with SHA-incremental skip, 2-step analysis-draft/synthesis-output separation, atomicstrata 2-phase separation, lucasastorian cascade backlinks, and provenance-weighted synthesis context.
 trigger: /compile
 tags: [compile, wiki, synthesis, sha, incremental, second-brain, oms]
 ---

--- a/docs/decisions/ADR-009-qmd-compatible-global-collection-bridge.md
+++ b/docs/decisions/ADR-009-qmd-compatible-global-collection-bridge.md
@@ -1,0 +1,119 @@
+---
+slug: ADR-009-qmd-compatible-global-collection-bridge
+title: "qmd-호환 전역 컬렉션 브릿지 — link 기반 vault 해석과 product interface 계약"
+status: Accepted
+date: 2026-07-05
+created_by: gjc
+deciders: [beomsu]
+relates_to:
+  - ./ADR-004-config-secrets-access-topology.md
+  - ./ADR-008-note-identity-real-path-ssot-no-slug.md
+  - ../exec-plan/active/self-owned-second-brain/deep-interview-record.md
+---
+
+# ADR-009: qmd-호환 전역 컬렉션 브릿지 — link 기반 vault 해석과 product interface 계약
+
+## Status
+
+Accepted
+
+## Context
+
+OMS는 knowledge-management 엔진이고, 여러 외부 repo·host adapter에서 같은 Obsidian vault를 질의해야 한다. qmd는 사용자가 검증한 "어느 작업 폴더에서든 collection을 질의하는" 인터페이스 기준선이다. 다만 OMS는 qmd 런타임에 의존하지 않고, qmd의 좋은 product surface만 자체 엔진 위에 흡수한다.
+
+이미 선행 ADR이 두 축을 고정했다.
+
+- [ADR-004](./ADR-004-config-secrets-access-topology.md)는 config/secrets/access topology를 분리하고, repo별 `.oms`는 설정 저장소가 아니라 pointer/권한 선언만 담당한다고 정했다.
+- [ADR-008](./ADR-008-note-identity-real-path-ssot-no-slug.md)은 qmd식 slug를 canonical identity로 도입하지 않고, document identity의 SSOT를 vault-relative real path로 유지한다고 정했다.
+
+2026-07-05 deep-interview(`di-20260705-harness-skill-governance`)는 이 결정을 실행 기준으로 재확인했다.
+
+- Established Fact #3 / Round 1: oms-query-bridge는 tobi/qmd 인터페이스 패턴을 채택한다 — 단일 엔진 위 CLI+MCP, 분산 흐름 통합.
+- Established Fact #17 / Round 7: bridge 수용 기준은 **link 기반, upstream 그대로**이며 신규 query 엔진을 개발하지 않는다.
+- Established Fact #18 / Round 7: `oms link`는 프로젝트 host convention 파일(`AGENTS.md` 등)에 사용법을 자동 기입한다. `oms install`의 전역 안내는 사용자 레벨 host rules(`~/.codex/rules/oms.md` 등)가 담당한다.
+- Non-Goal #1: qmd 전역 collection registry 신규 개발은 비목표다. link 기반으로 충분하며 필요 시 후속 결정으로 분리한다.
+- Acceptance Criteria §oms-query-bridge: vault 밖 외부 repo에서 `oms link --vault <vault>` 1회 후 `oms query/search/get`과 MCP query/get이 그 vault로 동작해야 한다.
+
+따라서 "qmd와 비슷하게 보이는 표면"이 단순한 우발적 alias인지, 아니면 사용자·adapter가 의존해도 되는 공식 product interface인지 명시해야 한다.
+
+## Decision
+
+### D1 — Vault 해석은 link 기반 `resolveEffectiveVault` 경로가 공식이다
+
+OMS가 명시적 `--vault` 없이 vault를 해석할 때의 공식 순서는 다음이다.
+
+1. **vault `.oms/`**: 현재 작업 디렉터리가 vault 자체이고 `.oms/concepts/` 또는 `.oms/taxonomy.yaml`을 가진 경우 그 디렉터리를 vault로 본다.
+2. **bridge `.oms/links.yaml`**: 외부 repo의 `.oms/links.yaml`이 `vault`와 선택적 `scope`를 선언하면, 해당 vault와 scope를 사용한다.
+3. **`OMS_VAULT`**: local vault/bridge가 없으면 환경변수 vault를 사용한다.
+4. **`cwd` fallback**: 아무 단서도 없으면 현재 작업 디렉터리를 vault로 취급한다.
+
+이 순서는 `resolveEffectiveVault`의 product contract다. qmd식 전역 collection registry를 별도로 만들지 않는다. 외부 repo는 `oms link --vault <vault>`로 bridge를 생성하고, bridge는 config/secrets를 복제하지 않으며 vault real path와 scope만 가진다.
+
+### D2 — qmd-호환 CLI/MCP 표면은 공식 product interface다
+
+다음 표면은 우발적 compatibility가 아니라 문서화된 product interface다.
+
+- CLI: `oms query`, `oms search`, `oms vsearch`, `oms get`, `oms multi-get` 등 `oms semantic ...`의 qmd-호환 top-level alias.
+- MCP: `query`, `status`, `get`, `multi_get` qmd-호환 alias와 canonical `oms_semantic_*` / `oms_*_document(s)` tools.
+- MCP resource: `qmd://{path}` document resource.
+
+OMS는 qmd binary를 요구하지 않는다. 위 표면은 native OMS engine/core document adapter로 동작하며, embedding model이 없는 document read 경로도 file-based hydration으로 유지한다. 이름이 qmd-compatible이어도 backend와 ownership은 OMS다.
+
+### D3 — link는 프로젝트 convention 파일에 bridge 사용법을 자동 기입한다
+
+`oms link`는 외부 repo에 bridge를 생성할 때 host adapter가 사용하는 프로젝트 convention 파일(`AGENTS.md` 등)에 OMS bridge 사용법 섹션을 자동 기입한다. 이는 사용 중인 repo가 자기 convention 안에 OMS bridge 사용법을 설명하는 ouroboros 패턴이다.
+
+`oms install`은 사용자 레벨 설치 작업이므로 대상 프로젝트의 `AGENTS.md` 존재를 전제할 수 없다. 따라서 install-time 전역 안내는 기존 host rules(예: `~/.codex/rules/oms.md`, Claude/Hermes의 사용자 레벨 규칙 파일)가 담당하고, D3의 프로젝트 파일 자동 기입 범위에는 포함하지 않는다.
+
+이 ADR은 product contract를 고정한다. 기입 내용은 generic해야 하며 특정 사용자 계정, 절대 개인 경로, 비밀값을 포함하지 않는다.
+
+### D4 — Document identity는 ADR-008의 real path SSOT를 계승한다
+
+qmd-compatible 표면을 제공해도 document identity는 변하지 않는다.
+
+- canonical document id는 vault-relative real path다.
+- `qmd://`는 resource URI scheme일 뿐 slug identity 계층이 아니다.
+- qmd slug와 호환해야 하는 경계가 생기면 ADR-008처럼 `slug(real path) → real path` forward map으로만 처리하고, 사용자·MCP 반환값은 real path를 유지한다.
+
+### D5 — Adapter parity는 의무다
+
+qmd-compatible CLI/MCP alias와 `qmd://` resource 의미론을 변경할 때는 core 구현만 바꾸지 않는다. Claude Code, Codex, Hermes 등 host adapter 문서·skills·manifest·tests가 같은 의미론을 노출해야 하며, 변경 PR은 ADR-009 영향과 adapter parity 갱신 여부를 함께 다룬다.
+
+## Alternatives Considered
+
+### (A) qmd 전역 collection registry 신규 구현 — 기각
+
+qmd의 collection registry를 그대로 재구현하면 외부 repo에서 collection 이름으로 질의하는 경험은 얻지만, OMS의 기존 `oms link` bridge와 중복된다. deep-interview는 qmd 전역 collection registry를 non-goal로 두고 link 기반 수용 기준을 채택했다. 현재 scale에서는 `.oms/links.yaml` + scope가 더 단순하고 검증 가능하다.
+
+### (B) `OMS_VAULT`만 공식 경로로 유지 — 기각
+
+환경변수만으로도 cwd-independent 실행은 가능하지만, repo별 bridge/scope와 host convention 자동 안내를 표현하지 못한다. 외부 repo에서 한 번 link하고 이후 CLI/MCP가 자연스럽게 같은 vault를 쓰는 qmd급 사용감에 미달한다.
+
+### (C) qmd-compatible alias를 best-effort 별칭으로만 취급 — 기각
+
+alias를 우발적 편의로 두면 adapter 문서, MCP clients, 사용자 scripts가 안정적으로 의존할 수 없다. qmd 호환 표면은 이미 deep-interview acceptance criteria의 일부이므로 product interface로 고정한다.
+
+### (D) qmd slug를 OMS document id로 채택 — 기각
+
+ADR-008의 결정을 유지한다. qmd slug는 손실적이며 real path를 별도로 보존해야만 복원된다. OMS는 real path SSOT를 유지하고, `qmd://`는 호환 scheme으로만 제공한다.
+
+## Consequences
+
+### Enables
+
+- 외부 repo에서 `oms link --vault <vault>` 1회 후 CLI/MCP 질의가 같은 vault로 해석된다.
+- qmd와 유사한 query/get 사용감을 제공하면서 qmd runtime dependency는 제거한다.
+- adapter와 문서가 의존할 수 있는 안정적인 product interface contract가 생긴다.
+- ADR-004의 config/access topology와 ADR-008의 real-path identity가 충돌 없이 연결된다.
+
+### Costs / trade-offs
+
+- qmd-compatible surface를 변경할 때 adapter parity와 문서 갱신 비용이 발생한다.
+- `resolveEffectiveVault` 순서가 product contract가 되므로 fallback 순서 변경은 breaking change로 취급해야 한다.
+- qmd 전역 collection registry를 원하는 미래 요구가 생기면 새 ADR/마이그레이션으로 별도 설계해야 한다.
+
+### New constraints
+
+- bridge `.oms/links.yaml`에는 vault pointer와 scope만 둔다. config/secrets/ontology를 복제하지 않는다.
+- qmd-compatible CLI/MCP alias와 `qmd://` resource 의미론을 바꾸는 변경은 ADR-009 영향 평가와 adapter parity 갱신을 포함한다.
+- document identity는 real path SSOT다. slug를 canonical id로 승격하지 않는다.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,6 +11,8 @@ oh-my-secondbrain 프로젝트의 주요 설계 결정을 기록한다.
 | [ADR-005](./ADR-005-graph-access-model.md) | 그래프 접근 모델 — 엣지 계층 · 운영 모드 · MCP tools | Proposed |
 | [ADR-006](./ADR-006-oms-governance-contract-separation.md) | .oms 거버넌스 — 기계검증 계약(yaml) ↔ 의도 기록(documents) 명시적 분리 | Accepted |
 | [ADR-007](./ADR-007-no-fake-embedder-fallback-native-dim-integrity.md) | 임베딩 무결성 불변 — 네이티브 차원 보존 & 가짜 임베더 폴백 금지 | Accepted |
+| [ADR-008](./ADR-008-note-identity-real-path-ssot-no-slug.md) | 노트 식별자 모델 — 실경로 SSOT, 슬러그 비도입 | Accepted |
+| [ADR-009](./ADR-009-qmd-compatible-global-collection-bridge.md) | qmd-호환 전역 컬렉션 브릿지 — link 기반 vault 해석과 product interface 계약 | Accepted |
 
 ## 작성 규칙
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@ Oh My Second Brain v0 is distributed as one npm/GitHub-release package that cont
 
 ## One-line install
 
-The installer uses the published npm package (`oh-my-second-brain@0.1.7`) by default:
+The installer uses the published npm package (`oh-my-second-brain@0.1.8`) by default:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/GoBeromsu/oh-my-second-brain/main/scripts/install.sh | bash
@@ -46,7 +46,7 @@ Environment knobs:
 From npm or a checkout:
 
 ```bash
-npm install -g oh-my-second-brain@0.1.7
+npm install -g oh-my-second-brain@0.1.8
 oh-my-second-brain install --runtime all --vault /path/to/vault --dry-run
 oh-my-second-brain install --runtime all --vault /path/to/vault --yes
 ```

--- a/omx_wiki/oh-my-second-brain-product-and-release-decisions.md
+++ b/omx_wiki/oh-my-second-brain-product-and-release-decisions.md
@@ -80,25 +80,25 @@ Published versions:
 
 - `oh-my-second-brain@0.1.5`: first npm publish after using a recovery code.
 - `oh-my-second-brain@0.1.6`: fixed docs/runtime command surfaces to prefer the published npm package and installed `oh-my-second-brain` binary instead of stale GitHub-release `npx` tarball URLs.
-- `oh-my-second-brain@0.1.7`: current/latest; aligns GitHub repository identity, package metadata, canonical installed command, and release gates around `oh-my-second-brain`.
+- `oh-my-second-brain@0.1.8`: current/latest; aligns package docs and installer defaults with the package metadata.
 
 Install command:
 
 ```bash
-npm install -g oh-my-second-brain@0.1.7
+npm install -g oh-my-second-brain@0.1.8
 oh-my-second-brain --help
 oh-my-second-brain install --runtime all --vault /path/to/vault --dry-run
 ```
 
-GitHub release `oh-my-second-brain-v0.1.7` includes `oh-my-second-brain-0.1.7.tgz`.
+GitHub release `oh-my-second-brain-v0.1.8` includes `oh-my-second-brain-0.1.8.tgz`.
 
 ## Verification evidence
 
 Before release/publish we verified:
 
 - `npm run release:check`
-- npm registry publish and `npm view oh-my-second-brain@0.1.7`
-- temporary `npm install oh-my-second-brain@0.1.7`
+- npm registry publish and `npm view oh-my-second-brain@0.1.8`
+- temporary `npm install oh-my-second-brain@0.1.8`
 - `./node_modules/.bin/oh-my-second-brain --help`
 - `./node_modules/.bin/oh-my-second-brain install --runtime all --vault /tmp/Vault --dry-run`
 - GitHub release asset download and CLI execution from the tarball

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/GoBeromsu/oh-my-second-brain/main/scripts/install.sh | bash
 set -euo pipefail
 
-PACKAGE_SPEC="${OMS_PACKAGE_SPEC:-oh-my-second-brain@0.1.7}"
+PACKAGE_SPEC="${OMS_PACKAGE_SPEC:-oh-my-second-brain@0.1.8}"
 RUNTIME="${OMS_INSTALL_RUNTIME:-auto}"
 VAULT="${OMS_VAULT:-$PWD}"
 EXECUTE="${OMS_EXECUTE_EXTERNAL:-0}"

--- a/skills-manifest.yaml
+++ b/skills-manifest.yaml
@@ -1,0 +1,2012 @@
+# 분산 SSOT, 집계는 generated. Do not edit generated outputs by hand.
+# No private account, vault, host, or absolute-path context belongs in this manifest.
+{
+  "schema_version": 1,
+  "packages": [
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/capture",
+      "name": "oms-capture",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/capture",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/compile",
+      "name": "oms-compile",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/compile",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/define",
+      "name": "oms-define",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/define",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/distill",
+      "name": "oms-distill",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/distill",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/doctor",
+      "name": "oms-doctor",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/doctor",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/retrieve",
+      "name": "oms-retrieve",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/retrieve",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/setup",
+      "name": "oms-setup",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/setup",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/uninstall",
+      "name": "oms-uninstall",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/uninstall",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/update",
+      "name": "oms-update",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/vault-decision-record",
+      "name": "oms-vault-decision-record",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/vault-decision-record",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/vault-lint",
+      "name": "oms-vault-lint",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/vault-lint",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/vault-scaffold",
+      "name": "oms-vault-scaffold",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/vault-scaffold",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/claude-code/wiki",
+      "name": "oms-wiki",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/wiki",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-capture",
+      "name": "oms-capture",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/capture",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-compile",
+      "name": "oms-compile",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/compile",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-distill",
+      "name": "oms-distill",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/distill",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-doctor",
+      "name": "oms-doctor",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/doctor",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-install",
+      "name": "oms-install",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-retrieve",
+      "name": "oms-retrieve",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/retrieve",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-setup",
+      "name": "oms-setup",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/setup",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-uninstall",
+      "name": "oms-uninstall",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/uninstall",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-update",
+      "name": "oms-update",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-vault-lint",
+      "name": "oms-vault-lint",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/vault-lint",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/codex/oms-wiki",
+      "name": "oms-wiki",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "codex"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/wiki",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/capture",
+      "name": "capture",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/capture",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/compile",
+      "name": "compile",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/compile",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/distill",
+      "name": "distill",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/distill",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/doctor",
+      "name": "doctor",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/doctor",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/install",
+      "name": "install",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/setup",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/retrieve",
+      "name": "retrieve",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/retrieve",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/setup",
+      "name": "setup",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/setup",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/uninstall",
+      "name": "uninstall",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/uninstall",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/update",
+      "name": "update",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/adapters/hermes/wiki",
+      "name": "wiki",
+      "kind": "adapter-wrapper",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": "oh-my-secondbrain/core/skills/wiki",
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "declared-omissions",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "skip",
+        "install_doctor": "package",
+        "topology": "adapter-wrapper"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/capture",
+      "name": "capture",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex",
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/compile",
+      "name": "compile",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.1.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex",
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/define",
+      "name": "define",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/distill",
+      "name": "distill",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.1.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex",
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/doctor",
+      "name": "doctor",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex",
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/retrieve",
+      "name": "retrieve",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex",
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/setup",
+      "name": "setup",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.2.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex",
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/uninstall",
+      "name": "oms-uninstall",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.0.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex",
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/vault-decision-record",
+      "name": "vault-decision-record",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.1.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/vault-lint",
+      "name": "vault-lint",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.1.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/vault-scaffold",
+      "name": "vault-scaffold",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.1.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    },
+    {
+      "schema_version": 1,
+      "id": "oh-my-secondbrain/core/wiki",
+      "name": "wiki",
+      "kind": "leaf",
+      "lifecycle": "active",
+      "version": "0.1.0",
+      "owner_repo": "oh-my-secondbrain",
+      "owner_domain": "knowledge-management",
+      "visibility": "public",
+      "compatibility": [
+        "claude-code",
+        "codex",
+        "hermes"
+      ],
+      "provenance": {
+        "upstream": null,
+        "commit": null,
+        "license": "MIT",
+        "absorbed_from": []
+      },
+      "replacement_for": [],
+      "replaced_by": null,
+      "children": [],
+      "adapters": [
+        {
+          "runtime": "claude-code",
+          "surface": "plugin-skill",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "codex",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        },
+        {
+          "runtime": "hermes",
+          "surface": "instruction-file",
+          "status": "generated",
+          "reason": null
+        }
+      ],
+      "validation_profile": {
+        "discovery_parity": "strict",
+        "adapter_parity": "strict",
+        "provenance_license": "strict",
+        "private_data_hygiene": "strict",
+        "deprecation": "strict",
+        "routing_eval": "smoke",
+        "install_doctor": "package",
+        "topology": "leaf"
+      }
+    }
+  ]
+}

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -53,15 +53,31 @@ describe("CLI argument parser", () => {
   it("parses repeated link folders and distinguishes implicit vault defaults", () => {
     const implicit = parseCliArgs(["doctor"], "/tmp/oms-cli");
     const linked = parseCliArgs(
-      ["link", "--vault", "../Vault", "--folder", "notes", "--folder", "15. Work/Project"],
+      ["link", "--vault", "../Vault", "--folder", "notes", "--folder", "15. Work/Project", "--no-convention-note"],
       "/tmp/oms-cli/repo",
     );
 
     expect(implicit.vault).toBe("/tmp/oms-cli");
     expect(implicit.vaultExplicit).toBe(false);
     expect(implicit.folders).toEqual([]);
+    expect(implicit.conventionNote).toBe(true);
     expect(linked.vault).toBe("/tmp/oms-cli/Vault");
     expect(linked.vaultExplicit).toBe(true);
     expect(linked.folders).toEqual(["notes", "15. Work/Project"]);
+    expect(linked.conventionNote).toBe(false);
+  });
+
+  it("parses audit flags", () => {
+    const parsed = parseCliArgs(
+      ["audit", "--vault", "Vault", "--folder", "references", "--json", "--suggest-fields"],
+      "/tmp/oms-cli",
+    );
+
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.command).toBe("audit");
+    expect(parsed.vault).toBe("/tmp/oms-cli/Vault");
+    expect(parsed.folders).toEqual(["references"]);
+    expect(parsed.json).toBe(true);
+    expect(parsed.suggestFields).toBe(true);
   });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -26,6 +26,7 @@ export interface ParsedCliArgs {
   readonly json: boolean;
   readonly maxPerConcept: number | undefined;
   readonly folders: readonly string[];
+  readonly conventionNote: boolean;
   readonly unknownFlags: readonly string[];
   readonly error: CliArgumentError | undefined;
 }
@@ -52,6 +53,7 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
   let json = false;
   let maxPerConcept: number | undefined;
   const folders: string[] = [];
+  let conventionNote = true;
   const unknownFlags: string[] = [];
 
   for (let i = 1; i < argv.length; i++) {
@@ -104,6 +106,8 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
     } else if (arg === "--folder" && next) {
       folders.push(next);
       i++;
+    } else if (arg === "--no-convention-note") {
+      conventionNote = false;
     } else if (arg !== undefined) {
       unknownFlags.push(arg);
     }
@@ -126,6 +130,7 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
     json,
     maxPerConcept,
     folders,
+    conventionNote,
     unknownFlags,
     error: undefined,
   };
@@ -148,6 +153,7 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
       json,
       maxPerConcept,
       folders,
+      conventionNote,
       unknownFlags,
       error: new CliArgumentError(message),
     };

--- a/src/cli/audit.ts
+++ b/src/cli/audit.ts
@@ -1,0 +1,116 @@
+import {
+  collectObservedFields,
+  collectObservedFieldValues,
+  type ObservedField,
+  type ObservedFieldValueDrift,
+} from "../setup/axis.js";
+import { lintVault, type VaultLintViolation } from "../engine/conventions/vault-lint.js";
+import { resolveActiveOntology } from "../ontology/active.js";
+import type { Ontology } from "../ontology/types.js";
+
+/** Fields observed in a folder that its bound concept(s) do not declare. */
+function undeclaredObservedFields(
+  ontology: Ontology,
+  summary: { readonly folder: string; readonly fields: readonly ObservedField[] },
+): ObservedField[] {
+  const binding = ontology.taxonomy.folders[summary.folder];
+  if (!binding || binding.concept === null) return [...summary.fields];
+  const conceptNames = Array.isArray(binding.concept) ? binding.concept : [binding.concept];
+  const declared = new Set<string>();
+  for (const name of conceptNames) {
+    const concept = ontology.concepts.get(name);
+    if (!concept) continue;
+    for (const field of concept.fields) declared.add(field.name);
+  }
+  return summary.fields.filter((field) => !declared.has(field.name));
+}
+
+
+export async function runAudit(opts: {
+  readonly vault: string;
+  readonly json?: boolean;
+  readonly folder?: string;
+  readonly suggestFields?: boolean;
+}): Promise<number> {
+  const { vault, json = false, folder, suggestFields = false } = opts;
+
+  try {
+    const { ontology } = await resolveActiveOntology(vault);
+    const report = await lintVault(vault, ontology, { folder });
+
+    let suggestedFields: Array<{ folder: string; fields: ObservedField[] }> = [];
+    let driftValues: readonly ObservedFieldValueDrift[] = [];
+    if (suggestFields) {
+      const observed = await collectObservedFields({ vault, ontology, folder });
+      suggestedFields = observed
+        .map((summary) => ({
+          folder: summary.folder,
+          fields: undeclaredObservedFields(ontology, summary),
+        }))
+        .filter((summary) => summary.fields.length > 0);
+      driftValues = await collectObservedFieldValues({ vault, ontology, folder });
+    }
+
+    if (json) {
+      console.log(
+        JSON.stringify(
+          {
+            vault,
+            folder: folder ?? null,
+            scannedNotes: report.scannedNotes,
+            excludedNotes: report.excludedNotes,
+            clean: report.clean,
+            violations: report.violations,
+            ...(suggestFields ? { suggestedFields, driftValues } : {}),
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.log(
+        `\nOh My Second Brain audit: ${report.scannedNotes} note(s) scanned, ${report.excludedNotes} excluded, ${report.violations.length} violation(s).`,
+      );
+
+      if (report.violations.length === 0) {
+        console.log("Vault is clean — no contract violations found.\n");
+      } else {
+        const byNote = new Map<string, VaultLintViolation[]>();
+        for (const violation of report.violations) {
+          const list = byNote.get(violation.notePath) ?? [];
+          list.push(violation);
+          byNote.set(violation.notePath, list);
+        }
+        for (const [notePath, violations] of byNote) {
+          console.log(`\n  ${notePath}`);
+          for (const violation of violations) {
+            console.log(`    [${violation.rule}] ${violation.message}`);
+          }
+        }
+        console.log(`\n${report.violations.length} violation(s) across ${byNote.size} note(s).\n`);
+      }
+
+      if (suggestFields) {
+        console.log("--- Unregistered fields observed in vault (candidates for concept schema) ---");
+        if (suggestedFields.length === 0) console.log("  (none)");
+        for (const summary of suggestedFields) {
+          const fieldList = summary.fields.map((field) => `${field.name}:${field.type}(${field.count})`).join(", ");
+          console.log(`  ${summary.folder}: ${fieldList}`);
+        }
+
+        console.log("\n--- Enum drift: values outside declared enum (top 20 by frequency) ---");
+        const top = driftValues.slice(0, 20);
+        if (top.length === 0) console.log("  (none)");
+        for (const drift of top) {
+          console.log(`  ${drift.folder} / ${drift.field} = "${drift.value}" (${drift.count})`);
+        }
+        console.log("");
+      }
+    }
+
+    return report.violations.length > 0 ? 1 : 0;
+  } catch (error) {
+    console.error(`[oms] audit could not complete: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}

--- a/src/cli/link-command.ts
+++ b/src/cli/link-command.ts
@@ -3,8 +3,12 @@ import {
   LINKED_GITIGNORE_PATTERN,
   type CreateVaultLinkResult,
 } from "../link/link.js";
+import { writeConventionUsageSection } from "../link/convention-note.js";
 
-export function formatLinkResult(result: CreateVaultLinkResult): string {
+export function formatLinkResult(
+  result: CreateVaultLinkResult,
+  conventionNotePath?: string,
+): string {
   const lines: string[] = ["Oh My Second Brain vault bridge ready."];
   lines.push(`  Vault:     ${result.record.vault}`);
   lines.push(`  Scope:     ${result.record.scope.join(", ") || "(none)"}`);
@@ -16,6 +20,9 @@ export function formatLinkResult(result: CreateVaultLinkResult): string {
       ? `  Gitignore: added ${LINKED_GITIGNORE_PATTERN}`
       : `  Gitignore: ${LINKED_GITIGNORE_PATTERN} already present`,
   );
+  if (conventionNotePath !== undefined) {
+    lines.push(`  Convention: wrote ${conventionNotePath}`);
+  }
   return lines.join("\n");
 }
 
@@ -24,6 +31,7 @@ export async function runLink(options: {
   readonly vault: string;
   readonly vaultExplicit: boolean;
   readonly folders: readonly string[];
+  readonly conventionNote?: boolean;
 }): Promise<number> {
   if (!options.vaultExplicit) {
     console.error("[oms] link requires --vault <path> (the Obsidian vault to bridge to).");
@@ -40,7 +48,11 @@ export async function runLink(options: {
       vault: options.vault,
       folders: [...options.folders],
     });
-    console.log(formatLinkResult(result));
+    let conventionNotePath: string | undefined;
+    if (options.conventionNote !== false) {
+      conventionNotePath = (await writeConventionUsageSection(options.cwd, result.record.vault)).agentsPath;
+    }
+    console.log(formatLinkResult(result, conventionNotePath));
     return 0;
   } catch (error) {
     console.error(`[oms] ${error instanceof Error ? error.message : String(error)}`);

--- a/src/cli/oms-dispatch.test.ts
+++ b/src/cli/oms-dispatch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { existsSync } from "node:fs";
-import { lstat, mkdir, readFile, readlink, mkdtemp, rm } from "node:fs/promises";
+import { lstat, mkdir, readFile, readlink, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -62,7 +62,7 @@ describe("oms CLI dispatch", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("Usage:");
     expect(result.stdout).toContain("Compatibility alias: oms <command>");
-    for (const command of ["setup", "install", "uninstall", "update", "doctor", "lint", "link", "semantic", "mcp", "hook"]) {
+    for (const command of ["setup", "install", "uninstall", "update", "doctor", "audit", "lint", "link", "semantic", "mcp", "hook"]) {
       expect(result.stdout).toContain(command);
     }
   });
@@ -127,6 +127,43 @@ describe("oms CLI dispatch", () => {
     );
   });
 
+  it("emits audit JSON and exits 0 for a clean fixture folder", () => {
+    const fixtureVault = path.join(repoRoot, "test", "fixtures", "vault");
+    const audit = runCli(["audit", "--vault", fixtureVault, "--folder", "references", "--json"]);
+
+    expect(audit.status).toBe(0);
+    expect(audit.stderr).toBe("");
+    expect(jsonObject(audit.stdout)).toEqual(
+      expect.objectContaining({
+        folder: "references",
+        scannedNotes: 1,
+        excludedNotes: 0,
+        clean: true,
+        violations: [],
+      }),
+    );
+  });
+
+  it("G002-CLI-001 rejects audit folder scopes that are not top-level folders", () => {
+    const fixtureVault = path.join(repoRoot, "test", "fixtures", "vault");
+    const audit = runCli(["audit", "--vault", fixtureVault, "--folder", "references/missing", "--json"]);
+
+    expect(audit.status).toBe(1);
+    expect(audit.stdout).toBe("");
+    expect(audit.stderr).toContain("path separators");
+  });
+
+  it("reports incomplete local .oms during audit instead of falling back to bundled defaults", async () => {
+    const vault = await makeVault();
+    await mkdir(path.join(vault, ".oms", "concepts"), { recursive: true });
+
+    const audit = runCli(["audit", "--vault", vault, "--json"]);
+
+    expect(audit.status).toBe(1);
+    expect(audit.stdout).toBe("");
+    expect(audit.stderr).toContain("Local .oms ontology is incomplete");
+  });
+
   it("supports semantic status as both nested command and top-level alias", async () => {
     const vault = await makeVault();
     const nested = runCli(["semantic", "status", "--vault", vault]);
@@ -145,6 +182,11 @@ describe("oms CLI dispatch", () => {
     const repo = path.join(root, "repo");
     await mkdir(path.join(vault, "notes"), { recursive: true });
     await mkdir(repo, { recursive: true });
+    await writeFile(
+      path.join(vault, "notes", "Alpha.md"),
+      "# Alpha\n\nAlpha bridge lexical search should work immediately after link.\n",
+      "utf-8",
+    );
 
     const setup = runCli(["setup", "--vault", vault, "--yes"]);
     expect(setup.status).toBe(0);
@@ -153,14 +195,29 @@ describe("oms CLI dispatch", () => {
     expect(link.status).toBe(0);
     expect(link.stderr).toBe("");
     expect(link.stdout).toContain("Oh My Second Brain vault bridge ready.");
+    expect(link.stdout).toContain("Convention: wrote");
 
     const linkPath = path.join(repo, ".oms", "linked", "notes");
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
     expect(path.resolve(path.dirname(linkPath), await readlink(linkPath))).toBe(path.join(vault, "notes"));
     expect(await readFile(path.join(repo, ".gitignore"), "utf-8")).toContain(".oms/linked/");
+    const agents = await readFile(path.join(repo, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("<!-- oms:begin -->");
+    expect(agents).toContain(`- Connected vault: ${path.basename(vault)}`);
+    expect(agents).not.toContain(vault);
+    expect(agents).toContain("`oms query \"what context should I know for this change?\"`");
+    expect(agents).toContain("`oms mcp`");
 
     const doctor = runCli(["doctor"], undefined, undefined, repo);
     expect(doctor.status).toBe(0);
     expect(doctor.stdout).toContain(`Vault: ${vault}`);
+    const search = runCli(["search", "--lex", "Alpha"], undefined, undefined, repo);
+    expect(search.status).toBe(0);
+    expect(search.stderr).toBe("");
+    const searchJson = jsonObject(search.stdout);
+    expect(searchJson).toEqual(expect.objectContaining({ available: true }));
+    expect(searchJson.hits).toEqual([
+      expect.objectContaining({ path: "notes/Alpha.md" }),
+    ]);
   });
 });

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -16,6 +16,7 @@ import {
   runUpdate,
 } from "../update/update.js";
 import { parseCliArgs } from "./args.js";
+import { runAudit } from "./audit.js";
 import { runDoctor, runLint } from "./doctor-lint.js";
 import { runLink } from "./link-command.js";
 import { isSemanticCliCommand, runSemanticCli } from "./semantic.js";
@@ -26,6 +27,7 @@ import { printUsage } from "./usage.js";
 export { buildClaudeInstallPlan } from "./claude-install-plan.js";
 export type { ClaudeInstallPlan } from "./claude-install-plan.js";
 export { runDoctor, runLint } from "./doctor-lint.js";
+export { runAudit } from "./audit.js";
 export {
   formatLinkResult,
   runLink,
@@ -45,7 +47,8 @@ function bundledAdapterRoot(): string {
 function shouldResolveBridgeVault(command: string | undefined, vaultExplicit: boolean): boolean {
   return (
     !vaultExplicit &&
-    (command === "doctor" ||
+    (command === "audit" ||
+      command === "doctor" ||
       command === "lint" ||
       command === "mcp" ||
       isSemanticCliCommand(command))
@@ -77,6 +80,7 @@ async function main(): Promise<void> {
     json,
     maxPerConcept,
     folders,
+    conventionNote,
     unknownFlags,
   } = parsedArgs;
 
@@ -93,6 +97,7 @@ async function main(): Promise<void> {
       vault,
       vaultExplicit,
       folders,
+      conventionNote,
     });
     await maybePrintUpdateNotice();
   } else if (command === "install" || command === "uninstall") {
@@ -157,6 +162,14 @@ async function main(): Promise<void> {
     console.log(formatHostOperationResults(results, dryRun));
   } else if (command === "doctor") {
     process.exitCode = await runDoctor({ vault, verbose, json, maxPerConcept });
+    await maybePrintUpdateNotice();
+  } else if (command === "audit") {
+    process.exitCode = await runAudit({
+      vault,
+      json,
+      folder: folders[0],
+      suggestFields,
+    });
     await maybePrintUpdateNotice();
   } else if (command === "lint") {
     process.exitCode = await runLint({ vault, verbose, json });

--- a/src/cli/usage.test.ts
+++ b/src/cli/usage.test.ts
@@ -14,6 +14,7 @@ describe("CLI usage text", () => {
       "uninstall",
       "update",
       "doctor",
+      "audit",
       "lint",
       "link",
       "semantic",

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -13,6 +13,15 @@ const MAIN_USAGE_COMMANDS: readonly MainUsageCommand[] = [
   { name: "uninstall", line: "  uninstall Remove Oh My Second Brain host adapters and MCP registration." },
   { name: "update", line: "  update   Check for or apply an explicit package update, then refresh host adapters." },
   { name: "doctor", line: "  doctor   Validate vault frontmatter against the active ontology, aggregated by field and concept." },
+  {
+    name: "audit",
+    line: "  audit    CI-usable ontology lint: doctor checks with non-zero exit on violations.",
+    detailLines: [
+      "             --folder <name>   Restrict the scan to one top-level vault folder.",
+      "             --json             Emit structured JSON instead of console text.",
+      "             --suggest-fields   Report undeclared observed fields and enum-value drift.",
+    ],
+  },
   { name: "lint", line: "  lint     Check vault link health: broken [[wikilinks]] and orphan notes." },
   { name: "link", line: "  link     Bridge an external repo to scoped vault folders via gitignored symlinks." },
   { name: "semantic", line: "  semantic Native markdown semantic index/search/get commands." },
@@ -60,8 +69,9 @@ Usage:
   oh-my-second-brain uninstall [--runtime <all|${registry.hosts.map((host) => host.runtime).join("|")}>] [--dry-run] [--execute] [--yes]
   oh-my-second-brain update [--check] [--dry-run] [--yes] [--runtime <${runtime}>] [--vault <path>]
   oh-my-second-brain doctor [--vault <path>] [--verbose] [--json] [--max <n>]
+  oh-my-second-brain audit [--vault <path>] [--folder <name>] [--json] [--suggest-fields]
   oh-my-second-brain lint [--vault <path>] [--verbose] [--json]
-  oh-my-second-brain link --vault <path> --folder <name> [--folder <name> ...]
+  oh-my-second-brain link --vault <path> --folder <name> [--folder <name> ...] [--no-convention-note]
   oh-my-second-brain semantic <status|sync|query|search|vsearch|get|multi-get|collection> [options]
   oh-my-second-brain mcp [--vault <path>]
   oh-my-second-brain hook pre-tool-use [--vault <path>]
@@ -81,9 +91,11 @@ Options:
   --dry-run        Preview host config changes without writing files.
   --execute        Allow external host CLIs such as \`claude\` to run when available.
   --verbose        doctor/lint: list every affected note instead of a summary.
-  --json           doctor/lint: emit machine-readable aggregation as JSON.
+  --json           doctor/lint/audit: emit machine-readable output as JSON.
   --max <n>        doctor --verbose: max notes listed per concept (default 50).
-  --folder <name>  link: vault folder or nested vault subpath to expose; repeatable.
+  --folder <name>  audit: restrict scan; link: vault folder/subpath to expose (repeatable for link).
+  --no-convention-note
+                  link: skip writing the managed OMS usage block to AGENTS.md.
 `;
 }
 

--- a/src/core/ontology/loader.ts
+++ b/src/core/ontology/loader.ts
@@ -8,6 +8,12 @@ export async function loadOntology(ontologyDir: string): Promise<Ontology> {
   const taxonomyRaw = await readFile(taxonomyPath, "utf-8");
   const taxonomyParsed = parseYaml(taxonomyRaw) as Record<string, unknown>;
 
+  const rawExclude = taxonomyParsed["exclude"];
+  const exclude =
+    Array.isArray(rawExclude) && rawExclude.every((item) => typeof item === "string")
+      ? rawExclude
+      : undefined;
+
   const taxonomy: Taxonomy = {
     version:
       typeof taxonomyParsed["version"] === "number"
@@ -19,6 +25,7 @@ export async function loadOntology(ontologyDir: string): Promise<Ontology> {
       !Array.isArray(taxonomyParsed["folders"])
         ? (taxonomyParsed["folders"] as Taxonomy["folders"])
         : {},
+    ...(exclude !== undefined ? { exclude } : {}),
   };
 
   const conceptsDir = path.join(ontologyDir, "concepts");

--- a/src/core/ontology/types.ts
+++ b/src/core/ontology/types.ts
@@ -9,6 +9,8 @@ export interface OntologyField {
   intent: string;
   normalize?: Normalize;
   immutable?: boolean;
+  /** Closed vocabulary for string fields; a value outside this list is a lint violation. */
+  enum?: string[];
 }
 
 export interface OntologyLens {
@@ -28,11 +30,22 @@ export interface Concept {
 export interface FolderBinding {
   intent: string;
   concept: string | string[] | null;
+  /**
+   * Marks this folder as an agent-writable zone per the vault routing guideline.
+   * Agent-writable alone is advisory; use routingLawStrict for hard created_by checks.
+   */
+  agentWritable?: boolean;
+  /**
+   * Marks an agent-writable folder as agent-exclusive for hard routing-law enforcement.
+   */
+  routingLawStrict?: boolean;
 }
 
 export interface Taxonomy {
   version: number;
   folders: Record<string, FolderBinding>;
+  /** Vault-relative glob patterns exempt from audit/lint scans. */
+  exclude?: string[];
 }
 
 export interface Ontology {

--- a/src/engine/assemble.test.ts
+++ b/src/engine/assemble.test.ts
@@ -71,10 +71,9 @@ Dynamics in music range from pianissimo (very soft) to fortissimo (very loud).
 // Environment detection
 // ---------------------------------------------------------------------------
 
-// Use the known cached model path or OMS_MODEL_PATH env var
-const KNOWN_MODEL = "/Users/beomsu/.cache/qmd/models/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf";
-const MODEL_PATH = process.env["OMS_MODEL_PATH"] ?? KNOWN_MODEL;
-const SMOKE_ENABLED = process.env["ASSEMBLE_SMOKE"] === "1" || process.env["OMS_MODEL_PATH"] !== undefined;
+// Real-model smoke runs are opt-in: provide the model via OMS_MODEL_PATH.
+const MODEL_PATH = process.env["OMS_MODEL_PATH"] ?? "";
+const SMOKE_ENABLED = MODEL_PATH !== "" && (process.env["ASSEMBLE_SMOKE"] === "1" || process.env["OMS_MODEL_PATH"] !== undefined);
 
 // ---------------------------------------------------------------------------
 // Temp dirs (created/cleaned per describe block that needs them)
@@ -207,14 +206,18 @@ describe.skipIf(!SMOKE_ENABLED)(
   "assembleEngine — real GGUF smoke (OMS_MODEL_PATH or cached model required)",
   () => {
     let engine: Awaited<ReturnType<typeof assembleEngine>> | null = null;
+    let savedUpstage: string | undefined;
 
     beforeAll(() => {
+      savedUpstage = process.env["UPSTAGE_API_KEY"];
+      delete process.env["UPSTAGE_API_KEY"];
       createFixture();
     });
 
     afterAll(async () => {
       await engine?.dispose();
       cleanupFixture();
+      if (savedUpstage !== undefined) process.env["UPSTAGE_API_KEY"] = savedUpstage;
     });
 
     it(

--- a/src/engine/conventions/vault-lint.test.ts
+++ b/src/engine/conventions/vault-lint.test.ts
@@ -1,16 +1,14 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, it, expect } from "vitest";
-import type { Concept } from "../../ontology/types.js";
-import { lintNoteFrontmatter } from "./vault-lint.js";
+import type { Concept, Ontology } from "../../ontology/types.js";
+import { lintNoteFrontmatter, lintVault, routingLawStrictFolders } from "./vault-lint.js";
 
 // ── Inline fixtures — never touch the real vault ──────────────────────────────
 
-/**
- * A literature concept that includes an `enum` constraint on the `status`
- * field. OntologyField doesn't declare `enum` in the shared type, but the
- * YAML loader passes it through at runtime. We widen the fixture with
- * `as unknown as Concept` so the field is carried through to checkEnum().
- */
-const LITERATURE_CONCEPT = {
+/** A literature concept that includes an `enum` constraint on the `status` field. */
+const LITERATURE_CONCEPT: Concept = {
   concept: "literature",
   intent: "A processed reference.",
   folder: "references",
@@ -27,7 +25,7 @@ const LITERATURE_CONCEPT = {
     { name: "tags", type: "list", required: false, intent: "Topical tags." },
     { name: "created_by", type: "string", required: false, intent: "Authoring agent." },
   ],
-} as unknown as Concept;
+};
 
 /** Folders where the routing-law check fires. */
 const AGENT_ZONES = new Set(["references"]);
@@ -233,5 +231,124 @@ describe("lintNoteFrontmatter — BAD: (5) routing-law — missing created_by in
       AGENT_ZONES, // references is agent zone, but PERSONAL_NOTE is in "personal/"
     );
     expect(violations.filter((v) => v.rule === "routing-law")).toHaveLength(0);
+  });
+});
+
+describe("lintVault", () => {
+  it("uses routingLawStrict folders, folder scoping, and exclude globs", async () => {
+    const vault = await mkdtemp(path.join(tmpdir(), "oms-vault-lint-"));
+    try {
+      await mkdir(path.join(vault, "references"), { recursive: true });
+      await mkdir(path.join(vault, "notes"), { recursive: true });
+      await writeFile(
+        path.join(vault, "references", "missing-created-by.md"),
+        [
+          "---",
+          "title: Strict Zone",
+          "source-url: https://example.com/strict",
+          "---",
+          "",
+          "Body.",
+        ].join("\n"),
+        "utf-8",
+      );
+      await writeFile(
+        path.join(vault, "references", "skip.template.md"),
+        [
+          "---",
+          "rogue: true",
+          "---",
+          "",
+          "Template.",
+        ].join("\n"),
+        "utf-8",
+      );
+      await writeFile(
+        path.join(vault, "notes", "user-note.md"),
+        [
+          "---",
+          "title: User Zone",
+          "source-url: https://example.com/user",
+          "---",
+          "",
+          "Body.",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const ontology: Ontology = {
+        taxonomy: {
+          version: 1,
+          folders: {
+            references: {
+              intent: "strict",
+              concept: "literature",
+              agentWritable: true,
+              routingLawStrict: true,
+            },
+            notes: {
+              intent: "writable but mixed",
+              concept: "literature",
+              agentWritable: true,
+            },
+          },
+          exclude: ["**/*.template.md"],
+        },
+        concepts: new Map([["literature", LITERATURE_CONCEPT]]),
+      };
+
+      expect(routingLawStrictFolders(ontology)).toEqual(new Set(["references"]));
+
+      const fullReport = await lintVault(vault, ontology);
+      expect(fullReport.scannedNotes).toBe(2);
+      expect(fullReport.excludedNotes).toBe(1);
+      expect(fullReport.violations.map((violation) => violation.notePath)).toEqual([
+        "references/missing-created-by.md",
+      ]);
+      expect(fullReport.violations[0]?.rule).toBe("routing-law");
+
+      const scopedReport = await lintVault(vault, ontology, { folder: "notes" });
+      expect(scopedReport.scannedNotes).toBe(1);
+      expect(scopedReport.excludedNotes).toBe(0);
+      expect(scopedReport.violations).toEqual([]);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+  it("rejects invalid folder scopes before returning a clean report", async () => {
+    const vault = await mkdtemp(path.join(tmpdir(), "oms-vault-lint-folder-"));
+    try {
+      await mkdir(path.join(vault, "references"), { recursive: true });
+
+      const ontology: Ontology = {
+        taxonomy: {
+          version: 1,
+          folders: {
+            references: {
+              intent: "strict",
+              concept: "literature",
+            },
+            inbox: {
+              intent: "declared but absent",
+              concept: "literature",
+            },
+          },
+        },
+        concepts: new Map([["literature", LITERATURE_CONCEPT]]),
+      };
+
+      await expect(lintVault(vault, ontology, { folder: "references/missing" })).rejects.toThrow(
+        /path separators/,
+      );
+      await expect(lintVault(vault, ontology, { folder: ".." })).rejects.toThrow(/path separators/);
+      await expect(lintVault(vault, ontology, { folder: "unknown" })).rejects.toThrow(
+        /not declared/,
+      );
+      await expect(lintVault(vault, ontology, { folder: "inbox" })).rejects.toThrow(
+        /does not exist/,
+      );
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
   });
 });

--- a/src/engine/conventions/vault-lint.ts
+++ b/src/engine/conventions/vault-lint.ts
@@ -15,24 +15,17 @@
  * DEFAULT MODE: report-only. The vault is NEVER mutated unless
  * `autofixEnabled: true` is passed (human-gate flag).
  *
- * NEVER throws. Notes that cannot be parsed are silently skipped.
+ * Invalid folder scopes throw clear caller-facing errors; individual notes that cannot be parsed are skipped.
  */
 
-import { readFile, readdir } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import type { Concept, Ontology, OntologyField } from "../../ontology/types.js";
-import { validateFrontmatter } from "../../conventions/validate.js";
 import { parseNote } from "../../conventions/frontmatter.js";
+import { validateFrontmatter } from "../../conventions/validate.js";
+import { walkVaultMarkdown } from "../../conventions/vault-walk.js";
+import { resolveConcept } from "../../ontology/resolver.js";
+import type { Concept, Ontology } from "../../ontology/types.js";
 
-// ── Internal extension ────────────────────────────────────────────────────────
-
-/**
- * Concept YAML files may optionally declare an `enum` array on a field.
- * TypeScript doesn't know about it (OntologyField has no `enum` key), but
- * the YAML loader passes it through at runtime. We widen locally here —
- * never modify src/ontology/types.ts for a single consumer.
- */
-type FieldWithEnum = OntologyField & { enum?: string[] };
 
 // ── Public types ──────────────────────────────────────────────────────────────
 
@@ -61,6 +54,8 @@ export interface VaultLintReport {
   violations: VaultLintViolation[];
   /** How many markdown notes with frontmatter were evaluated. */
   scannedNotes: number;
+  /** How many markdown notes were skipped because they matched an exclude glob. */
+  excludedNotes: number;
   /** Convenience flag: true when violations is empty. */
   clean: boolean;
 }
@@ -78,62 +73,107 @@ export interface VaultLintOptions {
    * Default: false (report-only).
    */
   autofixEnabled?: boolean;
+  /** Restrict the scan to a single top-level vault folder. */
+  folder?: string;
+  /** Additional vault-relative glob patterns to exempt from scanning. */
+  excludeGlobs?: readonly string[];
 }
 
 // ── Internals ─────────────────────────────────────────────────────────────────
 
-const SKIP_DIRS = new Set([
-  ".oms",
-  ".obsidian",
-  ".trash",
-  ".git",
-  ".claude",
-  "_archive",
-  "node_modules",
-]);
+/**
+ * Default audit exemptions — deliberately not contract violations: build artifacts,
+ * self-documenting templates, and skill files that intentionally carry no frontmatter.
+ */
+export const DEFAULT_EXCLUDE_GLOBS: readonly string[] = [
+  "25. Digital Garden/.deploy-staging/**",
+  "**/*.template.md",
+  "**/SKILL.md",
+  ".obsidian/**",
+  ".trash/**",
+  ".oms/**",
+  "_attachments/**",
+];
 
-async function* walkMarkdown(
-  dir: string,
-  base: string,
-): AsyncGenerator<string> {
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return;
+/** Convert a `*`/`**` glob into an anchored RegExp. `**` matches across `/`, `*` does not. */
+function globToRegExp(glob: string): RegExp {
+  const GLOBSTAR = "\u0000";
+  const withPlaceholder = glob.replace(/\*\*/g, GLOBSTAR);
+  const escaped = withPlaceholder.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const withStar = escaped.replace(/\*/g, "[^/]*");
+  const pattern = withStar.split(GLOBSTAR).join(".*");
+  return new RegExp(`^${pattern}$`);
+}
+
+export function matchesAnyGlob(notePath: string, globs: readonly string[]): boolean {
+  return globs.some((glob) => globToRegExp(glob).test(notePath));
+}
+
+/** Merge built-in defaults with vault-declared and caller-supplied exclude globs. */
+export function resolveExcludeGlobs(ontology: Ontology, extra: readonly string[] = []): string[] {
+  return [...DEFAULT_EXCLUDE_GLOBS, ...(ontology.taxonomy.exclude ?? []), ...extra];
+}
+
+export async function validateVaultLintFolder(
+  vaultRoot: string,
+  ontology: Ontology,
+  folder: string | undefined,
+): Promise<void> {
+  if (folder === undefined) return;
+
+  if (
+    folder.length === 0 ||
+    folder === "." ||
+    folder.includes("/") ||
+    folder.includes("\\") ||
+    folder.includes("..")
+  ) {
+    throw new Error(
+      `Audit folder "${folder}" must be one top-level vault folder name; path separators and ".." are not allowed.`,
+    );
   }
-  for (const entry of entries) {
-    if (entry.name.startsWith(".") || SKIP_DIRS.has(entry.name)) continue;
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      yield* walkMarkdown(full, base);
-    } else if (entry.isFile() && entry.name.endsWith(".md")) {
-      yield path.relative(base, full).replace(/\\/g, "/");
+
+  if (!Object.prototype.hasOwnProperty.call(ontology.taxonomy.folders, folder)) {
+    throw new Error(`Audit folder "${folder}" is not declared in the active taxonomy.`);
+  }
+
+  try {
+    const info = await stat(path.join(vaultRoot, folder));
+    if (!info.isDirectory()) {
+      throw new Error(`Audit folder "${folder}" does not exist as a top-level vault folder.`);
     }
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      throw new Error(`Audit folder "${folder}" does not exist as a top-level vault folder.`);
+    }
+    throw error;
   }
 }
 
 /**
- * Derive the set of "agent-writable" folders from the loaded ontology.
+ * Derive the set of agent-writable folders from the loaded ontology.
  *
- * A folder is agent-writable when:
- *  - It is declared in taxonomy.folders
- *  - Its bound concept is NOT null
- *  - The concept declares at least one field (i.e. it is NOT a raw-capture
- *    inbox with no structure requirements)
+ * A folder is agent-writable when taxonomy explicitly declares `agentWritable: true`.
  */
-function agentWritableFolders(ontology: Ontology): Set<string> {
+export function agentWritableFolders(ontology: Ontology): Set<string> {
   const zones = new Set<string>();
   for (const [folder, binding] of Object.entries(ontology.taxonomy.folders)) {
-    if (binding.concept === null) continue;
-    const names = Array.isArray(binding.concept)
-      ? binding.concept
-      : [binding.concept];
-    for (const name of names) {
-      const concept = ontology.concepts.get(name);
-      if (concept && concept.fields.length > 0) {
-        zones.add(folder);
-      }
+    if (binding.agentWritable === true) zones.add(folder);
+  }
+  return zones;
+}
+
+/**
+ * Derive folders where the ROUTING LAW is enforced as a hard per-note requirement.
+ *
+ * This is a strict subset of agentWritableFolders(): folders must be marked both
+ * `agentWritable: true` and `routingLawStrict: true`.
+ */
+export function routingLawStrictFolders(ontology: Ontology): Set<string> {
+  const zones = new Set<string>();
+  for (const [folder, binding] of Object.entries(ontology.taxonomy.folders)) {
+    if (binding.agentWritable === true && binding.routingLawStrict === true) {
+      zones.add(folder);
     }
   }
   return zones;
@@ -171,7 +211,7 @@ function checkEnum(
   notePath: string,
 ): VaultLintViolation[] {
   const violations: VaultLintViolation[] = [];
-  for (const field of concept.fields as FieldWithEnum[]) {
+  for (const field of concept.fields) {
     if (!field.enum || field.enum.length === 0) continue;
     const value = frontmatter[field.name];
     if (value === undefined || value === null) continue; // required check handles missing
@@ -292,11 +332,21 @@ export async function lintVault(
     // protocol for M5 vault mutations is fully specified and approved.
   }
 
-  const agentZones = agentWritableFolders(ontology);
+  await validateVaultLintFolder(vaultRoot, ontology, options.folder);
+  const agentZones = routingLawStrictFolders(ontology);
+  const excludeGlobs = resolveExcludeGlobs(ontology, options.excludeGlobs ?? []);
   const violations: VaultLintViolation[] = [];
   let scannedNotes = 0;
+  let excludedNotes = 0;
 
-  for await (const notePath of walkMarkdown(vaultRoot, vaultRoot)) {
+  const walkRoot = options.folder ? path.join(vaultRoot, options.folder) : vaultRoot;
+
+  for await (const notePath of walkVaultMarkdown(walkRoot, { base: vaultRoot })) {
+    if (matchesAnyGlob(notePath, excludeGlobs)) {
+      excludedNotes++;
+      continue;
+    }
+
     let raw: string;
     try {
       raw = await readFile(path.join(vaultRoot, notePath), "utf-8");
@@ -307,18 +357,7 @@ export async function lintVault(
     const { frontmatter, hasFrontmatter } = parseNote(raw);
     if (!hasFrontmatter) continue;
 
-    // Resolve concept via top-level folder (taxonomy shortest-path)
-    const folder = notePath.split("/")[0] ?? "";
-    const binding = ontology.taxonomy.folders[folder];
-    if (binding === undefined || binding.concept === null) continue;
-
-    const conceptNames = Array.isArray(binding.concept)
-      ? binding.concept
-      : [binding.concept];
-    const conceptName = conceptNames[0];
-    if (!conceptName) continue;
-
-    const concept = ontology.concepts.get(conceptName);
+    const concept = resolveConcept(ontology, notePath);
     if (!concept) continue;
 
     scannedNotes++;
@@ -327,5 +366,5 @@ export async function lintVault(
     );
   }
 
-  return { violations, scannedNotes, clean: violations.length === 0 };
+  return { violations, scannedNotes, excludedNotes, clean: violations.length === 0 };
 }

--- a/src/engine/embed/README.md
+++ b/src/engine/embed/README.md
@@ -1,6 +1,6 @@
 ## embed
 
-Responsible for splitting vault documents into overlapping text chunks and producing embedding vectors for each chunk. The chunker respects Markdown heading boundaries and the `ChunkerOptions` token budget; the embedding layer wraps `node-llama-cpp` (GGUF model) with a deterministic hash-projection fallback when no model path is configured. All output conforms to the `Chunk` and `EmbeddingProvider` contracts defined in `../types.ts`.
+Responsible for splitting vault documents into overlapping text chunks and producing embedding vectors for each chunk. The chunker respects Markdown heading boundaries and the `ChunkerOptions` token budget; the embedding layer wraps `node-llama-cpp` (GGUF model) or a configured embedding API. There is no fake/hash fallback: without a real embedding provider the vector path fails loudly (ADR-007), while lexical BM25/FTS remains available. All output conforms to the `Chunk` and `EmbeddingProvider` contracts defined in `../types.ts`.
 
 **Absorbed sources (idea-only, no verbatim code):**
 - `nashsu/llm_wiki` (GPL-3.0) — sliding-window overlap heuristic and heading-aware split boundary detection.

--- a/src/engine/mcp/facade.ts
+++ b/src/engine/mcp/facade.ts
@@ -266,6 +266,10 @@ function enrichQueryHits(result: McpSemanticQueryResult, vault: string): McpSema
   });
   return { available: true, hits };
 }
+function isLexOnlySubQueries(subQueries: readonly { readonly type: string }[]): boolean {
+  return subQueries.length > 0 && subQueries.every((subQuery) => subQuery.type === "lex");
+}
+
 
 // ---------------------------------------------------------------------------
 // Adapter facade
@@ -326,6 +330,16 @@ export class McpEngineAdapter {
       return queryResultUnavailable("No sub-queries derived from options");
     }
     try {
+      if (isLexOnlySubQueries(subQueries)) {
+        const syncResult = await syncEngineStore({
+          vault: opts.vault ?? this.vaultPath,
+          collection: opts.collection,
+          embed: false,
+        });
+        if (!syncResult.available) {
+          return queryResultUnavailable(syncResult.reason ?? "Lexical index sync unavailable");
+        }
+      }
       const k = opts.candidateLimit ?? 20;
       const results = await dispatch(subQueries, this.deps, k);
       const mapped = retrievalResultsToQueryResult(results, opts);

--- a/src/harness/surface-registry.ts
+++ b/src/harness/surface-registry.ts
@@ -75,6 +75,7 @@ export const harnessSurfaceRegistry: HarnessSurfaceRegistry = {
   cliCommands: [
     { name: "setup", owner: "cli", stability: "stable" },
     { name: "doctor", owner: "cli", stability: "stable" },
+    { name: "audit", owner: "cli", stability: "stable" },
     { name: "lint", owner: "cli", stability: "stable" },
     { name: "link", owner: "cli", stability: "experimental" },
     { name: "install", owner: "install", stability: "stable" },
@@ -276,6 +277,15 @@ export const harnessSurfaceRegistry: HarnessSurfaceRegistry = {
     },
     {
       name: "oms_validate_contract",
+      owner: "core",
+      posture: "read",
+      destructive: false,
+      idempotent: true,
+      openWorld: false,
+      stability: "stable",
+    },
+    {
+      name: "oms_vault_audit",
       owner: "core",
       posture: "read",
       destructive: false,

--- a/src/link/convention-note.test.ts
+++ b/src/link/convention-note.test.ts
@@ -1,0 +1,139 @@
+import { mkdir, lstat, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runLink } from "../cli/link-command.js";
+import {
+  CONVENTION_NOTE_BEGIN,
+  CONVENTION_NOTE_END,
+  conventionUsageSection,
+  writeConventionUsageSection,
+} from "./convention-note.js";
+
+let tmp: string;
+let repo: string;
+let vault: string;
+
+beforeEach(async () => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), "oms-convention-note-test-"));
+  repo = path.join(tmp, "repo");
+  vault = path.join(tmp, "vault");
+  await mkdir(repo, { recursive: true });
+  await mkdir(path.join(vault, "notes"), { recursive: true });
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(tmp, { recursive: true, force: true });
+});
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await lstat(target);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function markerCount(content: string, marker: string): number {
+  return content.split(marker).length - 1;
+}
+
+describe("writeConventionUsageSection", () => {
+  it("creates AGENTS.md with the managed OMS usage section", async () => {
+    const result = await writeConventionUsageSection(repo, vault);
+    const content = await readFile(path.join(repo, "AGENTS.md"), "utf-8");
+
+    expect(result).toEqual({
+      agentsPath: path.join(repo, "AGENTS.md"),
+      changed: true,
+      created: true,
+      replaced: false,
+    });
+    expect(content).toContain(CONVENTION_NOTE_BEGIN);
+    expect(content).toContain(CONVENTION_NOTE_END);
+    expect(content).toContain(`- Connected vault: ${path.basename(vault)}`);
+    expect(content).not.toContain(vault);
+    expect(content).toContain("`oms query \"what context should I know for this change?\"`");
+    expect(content).toContain("`oms search \"keyword or topic\"`");
+    expect(content).toContain("`oms get \"note-id-or-path\"`");
+    expect(content).toContain("`oms mcp`");
+  });
+
+  it("replaces the managed block idempotently on rerun", async () => {
+    const oldVault = path.join(tmp, "old-vault");
+    await writeFile(
+      path.join(repo, "AGENTS.md"),
+      `${conventionUsageSection(oldVault)}\n\nUser-owned notes stay here.\n`,
+      "utf-8",
+    );
+
+    const result = await writeConventionUsageSection(repo, vault);
+    const content = await readFile(path.join(repo, "AGENTS.md"), "utf-8");
+    const second = await writeConventionUsageSection(repo, vault);
+    const afterSecond = await readFile(path.join(repo, "AGENTS.md"), "utf-8");
+
+    expect(result.changed).toBe(true);
+    expect(result.created).toBe(false);
+    expect(result.replaced).toBe(true);
+    expect(content).toContain(`- Connected vault: ${path.basename(vault)}`);
+    expect(content).not.toContain(oldVault);
+    expect(content).not.toContain(vault);
+    expect(content).toContain("User-owned notes stay here.");
+    expect(markerCount(content, CONVENTION_NOTE_BEGIN)).toBe(1);
+    expect(markerCount(content, CONVENTION_NOTE_END)).toBe(1);
+    expect(second.changed).toBe(false);
+    expect(afterSecond).toBe(content);
+  });
+
+  it("preserves existing user content outside the managed block", async () => {
+    const before = "# Repo Rules\n\nKeep this prefix.\n\n";
+    const after = "\n\nKeep this suffix exactly.\n";
+    await writeFile(
+      path.join(repo, "AGENTS.md"),
+      `${before}${CONVENTION_NOTE_BEGIN}\nstale generated text\n${CONVENTION_NOTE_END}${after}`,
+      "utf-8",
+    );
+
+    await writeConventionUsageSection(repo, vault);
+    const content = await readFile(path.join(repo, "AGENTS.md"), "utf-8");
+
+    expect(content.startsWith(before)).toBe(true);
+    expect(content.endsWith(after)).toBe(true);
+    expect(content).not.toContain("stale generated text");
+  });
+  it("replaces only the first duplicate managed block and removes the rest", async () => {
+    const staleBlock = `${CONVENTION_NOTE_BEGIN}\nstale generated text\n${CONVENTION_NOTE_END}`;
+    await writeFile(
+      path.join(repo, "AGENTS.md"),
+      `Prefix\n\n${staleBlock}\n\nUser notes between.\n\n${staleBlock}\n\nSuffix\n`,
+      "utf-8",
+    );
+
+    await writeConventionUsageSection(repo, vault);
+    const content = await readFile(path.join(repo, "AGENTS.md"), "utf-8");
+
+    expect(markerCount(content, CONVENTION_NOTE_BEGIN)).toBe(1);
+    expect(markerCount(content, CONVENTION_NOTE_END)).toBe(1);
+    expect(content).not.toContain("stale generated text");
+    expect(content).toContain("User notes between.");
+    expect(content).toContain("Suffix");
+  });
+
+  it("honors link command opt-out by skipping AGENTS.md generation", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const status = await runLink({
+      cwd: repo,
+      vault,
+      vaultExplicit: true,
+      folders: ["notes"],
+      conventionNote: false,
+    });
+
+    expect(status).toBe(0);
+    expect(await pathExists(path.join(repo, "AGENTS.md"))).toBe(false);
+  });
+});

--- a/src/link/convention-note.ts
+++ b/src/link/convention-note.ts
@@ -1,0 +1,78 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const CONVENTION_NOTE_BEGIN = "<!-- oms:begin -->";
+export const CONVENTION_NOTE_END = "<!-- oms:end -->";
+
+export interface ConventionUsageSectionResult {
+  readonly agentsPath: string;
+  readonly changed: boolean;
+  readonly created: boolean;
+  readonly replaced: boolean;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function renderVaultName(vaultPath: string): string {
+  const name = path.basename(path.resolve(vaultPath)) || "linked vault";
+  return name.replace(/\r?\n/g, " ").replaceAll(CONVENTION_NOTE_BEGIN, "[oms begin marker]").replaceAll(CONVENTION_NOTE_END, "[oms end marker]");
+}
+
+export function conventionUsageSection(vaultPath: string): string {
+  const renderedVaultName = renderVaultName(vaultPath);
+  return [
+    CONVENTION_NOTE_BEGIN,
+    "## Oh My Second Brain (OMS)",
+    "",
+    "This repository is linked to an Oh My Second Brain vault. Use the linked vault as the project knowledge base when you need durable context.",
+    "",
+    `- Connected vault: ${renderedVaultName} (connection details live in .oms/links.yaml)`,
+    "- Query context: `oms query \"what context should I know for this change?\"`",
+    "- Search notes: `oms search \"keyword or topic\"`",
+    "- Open a note: `oms get \"note-id-or-path\"`",
+    "- MCP integration: run `oms mcp` from this repository so compatible agents can read the linked vault through MCP.",
+    CONVENTION_NOTE_END,
+  ].join("\n");
+}
+
+export async function writeConventionUsageSection(
+  repoRoot: string,
+  vaultPath: string,
+): Promise<ConventionUsageSectionResult> {
+  const agentsPath = path.join(repoRoot, "AGENTS.md");
+  let existing = "";
+  let created = false;
+
+  try {
+    existing = await readFile(agentsPath, "utf-8");
+  } catch (error) {
+    if (!(error instanceof Error) || (error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    created = true;
+  }
+
+  const block = conventionUsageSection(vaultPath);
+  const managedBlockPattern = new RegExp(
+    `${escapeRegExp(CONVENTION_NOTE_BEGIN)}[\\s\\S]*?${escapeRegExp(CONVENTION_NOTE_END)}`,
+    "g",
+  );
+  const matches = Array.from(existing.matchAll(managedBlockPattern));
+  const replaced = matches.length > 0;
+  let replacedFirst = false;
+  const next = replaced
+    ? existing.replace(managedBlockPattern, () => {
+        if (!replacedFirst) {
+          replacedFirst = true;
+          return block;
+        }
+        return "";
+      })
+    : `${existing}${existing.length === 0 ? "" : existing.endsWith("\n") ? "\n" : "\n\n"}${block}\n`;
+
+  if (next !== existing) {
+    await writeFile(agentsPath, next, "utf-8");
+  }
+
+  return { agentsPath, changed: next !== existing, created, replaced };
+}

--- a/src/link/link.test.ts
+++ b/src/link/link.test.ts
@@ -61,11 +61,11 @@ describe("readLinkRecord / writeLinkRecord", () => {
     expect(record).toEqual({ version: 1, vault, scope: ["notes", "references"] });
   });
 
-  it("returns null when the vault field is absent", async () => {
+  it("throws when links.yaml is present but the vault field is absent", async () => {
     const omsDir = path.join(repo, ".oms");
     await mkdir(omsDir, { recursive: true });
     await writeFile(path.join(omsDir, "links.yaml"), "version: 1\nscope: [a]\n", "utf-8");
-    expect(await readLinkRecord(omsDir)).toBeNull();
+    await expect(readLinkRecord(omsDir)).rejects.toThrow(/missing required string field "vault"/);
   });
 
   it("defaults scope to an empty array and version to current", async () => {
@@ -123,11 +123,10 @@ describe("resolveEffectiveVault", () => {
     expect(resolved).toEqual({ vault: path.resolve(vault), scope: ["notes"], source: "bridge" });
   });
 
-  it("expands a ~ vault path stored in the bridge record", async () => {
+  it("expands a ~ vault path stored in the bridge record before validating existence", async () => {
     const omsDir = path.join(repo, ".oms");
     await writeLinkRecord(omsDir, { version: 1, vault: "~/v", scope: [] });
-    const resolved = await resolveEffectiveVault(repo, {});
-    expect(resolved.vault).toBe(path.resolve(os.homedir(), "v"));
+    await expect(resolveEffectiveVault(repo, {})).rejects.toThrow(path.resolve(os.homedir(), "v"));
   });
 
   it("falls back to OMS_VAULT when no local ontology or bridge exists", async () => {
@@ -152,6 +151,28 @@ describe("resolveEffectiveVault", () => {
     const resolved = await resolveEffectiveVault(repo, { OMS_VAULT: "/somewhere/else" });
     expect(resolved.source).toBe("bridge");
     expect(resolved.vault).toBe(path.resolve(vault));
+  });
+  it("errors on malformed bridge records instead of falling back to OMS_VAULT", async () => {
+    const omsDir = path.join(repo, ".oms");
+    await mkdir(omsDir, { recursive: true });
+    await writeFile(path.join(omsDir, "links.yaml"), "vault: [not valid\n", "utf-8");
+
+    await expect(resolveEffectiveVault(repo, { OMS_VAULT: vault })).rejects.toThrow(/not valid YAML/);
+  });
+
+  it("errors when a bridge record omits the required vault field instead of falling back to cwd", async () => {
+    const omsDir = path.join(repo, ".oms");
+    await mkdir(omsDir, { recursive: true });
+    await writeFile(path.join(omsDir, "links.yaml"), "version: 1\nscope: [notes]\n", "utf-8");
+
+    await expect(resolveEffectiveVault(repo, {})).rejects.toThrow(/missing required string field "vault"/);
+  });
+
+  it("errors when the linked vault path no longer exists", async () => {
+    const omsDir = path.join(repo, ".oms");
+    await writeLinkRecord(omsDir, { version: 1, vault: path.join(tmp, "deleted-vault"), scope: ["notes"] });
+
+    await expect(resolveEffectiveVault(repo, { OMS_VAULT: vault })).rejects.toThrow(/Linked vault path does not exist/);
   });
 });
 

--- a/src/link/link.ts
+++ b/src/link/link.ts
@@ -112,7 +112,8 @@ function parseScope(value: unknown): string[] {
 
 /**
  * Read a bridge link record from `<omsDir>/links.yaml`.
- * Returns `null` when the file is missing or has no usable `vault` field.
+ * Returns `null` only when the file is missing; a present-but-invalid bridge
+ * record is a configuration error and must not silently fall back to cwd/env.
  */
 export async function readLinkRecord(omsDir: string): Promise<LinkRecord | null> {
   const recordPath = path.join(omsDir, "links.yaml");
@@ -126,11 +127,24 @@ export async function readLinkRecord(omsDir: string): Promise<LinkRecord | null>
     throw error;
   }
 
-  const parsed = yamlParse(raw) as Record<string, unknown> | null;
-  if (parsed == null || typeof parsed !== "object") return null;
+  let parsed: Record<string, unknown> | null;
+  try {
+    parsed = yamlParse(raw) as Record<string, unknown> | null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[oms] Invalid bridge record at ${recordPath}: links.yaml is not valid YAML (${message}). Re-run oms link to repair it.`);
+  }
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`[oms] Invalid bridge record at ${recordPath}: expected a YAML mapping with vault and scope.`);
+  }
 
   const vault = parsed["vault"];
-  if (typeof vault !== "string" || vault.trim().length === 0) return null;
+  if (typeof vault !== "string" || vault.trim().length === 0) {
+    throw new Error(`[oms] Invalid bridge record at ${recordPath}: missing required string field "vault". Re-run oms link to repair it.`);
+  }
+  if (parsed["scope"] !== undefined && !Array.isArray(parsed["scope"])) {
+    throw new Error(`[oms] Invalid bridge record at ${recordPath}: field "scope" must be a list.`);
+  }
 
   return {
     version: typeof parsed["version"] === "number" ? parsed["version"] : LINK_RECORD_VERSION,
@@ -170,7 +184,11 @@ export async function resolveEffectiveVault(
 
   const record = await readLinkRecord(omsDir);
   if (record) {
-    return { vault: expandHome(record.vault), scope: record.scope, source: "bridge" };
+    const resolvedVault = expandHome(record.vault);
+    if ((await pathKind(resolvedVault)) !== "directory") {
+      throw new Error(`[oms] Linked vault path does not exist or is not a directory: ${resolvedVault}. Re-run oms link with a valid --vault.`);
+    }
+    return { vault: resolvedVault, scope: record.scope, source: "bridge" };
   }
 
   const envVault = env["OMS_VAULT"];

--- a/src/mcp/semantic-engine.ts
+++ b/src/mcp/semantic-engine.ts
@@ -7,13 +7,14 @@
  *
  *   - {@link assembleFullSemanticEngine} requires OMS_EMBEDDING_PROVIDER +
  *     OMS_EMBEDDING_MODEL and throws a loud, actionable error otherwise. The
- *     MCP server uses it for the eager semantic ops (sync/query/status/...) so a
- *     model-less host loud-guards instead of silently degrading.
+ *     MCP server uses it for vec/HyDE-bearing semantic ops so a model-less host
+ *     loud-guards instead of silently degrading.
  *   - {@link assembleSemanticEngine} returns the vec-capable engine when the
  *     canonical pair is configured, else a core (lex + document) engine where
  *     vec/HyDE fail fast. The CLI, the localhost HTTP transport, and the MCP
- *     server's model-OPTIONAL paths (document reads, retrieve_context's semantic
- *     leg, ReadResource) use it so lex and file-based reads work without a model.
+ *     server's model-OPTIONAL paths (explicit lex-only query, document reads,
+ *     retrieve_context's semantic leg, ReadResource) use it so lex and
+ *     file-based reads work without a model.
  */
 
 import {

--- a/src/mcp/semantic-retrieve.ts
+++ b/src/mcp/semantic-retrieve.ts
@@ -8,15 +8,15 @@ import {
   type ParseResult,
 } from "./semantic-retrieve-args.js";
 import type { McpEngineAdapter } from "../engine/mcp/facade.js";
+import { queryOptionsToSubQueries } from "../engine/mcp/query-mapper.js";
 
 export { semanticMcpTools, retrieveContextSemanticInputProperties } from "./semantic-schemas.js";
 export { semanticOptionsFromArgs };
 
 /**
- * The op-name set that REQUIRES a real embedding model: sync / query / status /
- * collections / contexts / cleanup, plus the bare CLI aliases. The main stdio
- * server assembles the vec-capable engine EAGERLY for these so a model-less host
- * loud-guards (ADR-007) instead of silently degrading.
+ * The op-name set that normally requires a real embedding model. Query is listed
+ * here because its default mode is hybrid lex+vec; `isModelOptionalSemanticQueryOp`
+ * narrows explicit lex-only calls back onto the core BM25/FTS adapter.
  *
  * oms_get_document / oms_multi_get_documents are NOT here: they form the
  * model-OPTIONAL set ({@link isEngineDocumentOp}). The server resolves them on
@@ -35,13 +35,21 @@ const ENGINE_SEMANTIC_OPS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * True when `name` is a semantic op that requires the vec-capable engine. The
- * main stdio server uses this to assemble the model-backed engine ONLY for these
- * ops, keeping get/multi_get (GAP-9) and every non-semantic tool off the eager
- * model path.
+ * True when `name` is a semantic op. The server uses this together with
+ * `isModelOptionalSemanticQueryOp` so vec/HyDE paths loud-guard without a model
+ * while explicit lex-only query uses real model-free BM25/FTS.
  */
 export function isEngineSemanticOp(name: string): boolean {
   return ENGINE_SEMANTIC_OPS.has(name);
+}
+export function isModelOptionalSemanticQueryOp(
+  name: string,
+  args: Record<string, unknown> | undefined,
+  vault: string,
+): boolean {
+  if (name !== "oms_semantic_query" && name !== "query") return false;
+  const subQueries = queryOptionsToSubQueries(semanticQueryOptionsFromArgs(vault, args));
+  return subQueries.length > 0 && subQueries.every((subQuery) => subQuery.type === "lex");
 }
 
 /**

--- a/src/mcp/semantic-server.test.ts
+++ b/src/mcp/semantic-server.test.ts
@@ -126,15 +126,23 @@ Index note for graph neighborhoods and semantic lookup.
           expect.objectContaining({ path: "references/Agent Retrieval.md" }),
         );
       } else {
-        // Loud-guard path: engine assembly throws without explicit embedding
-        // config → isError envelope naming the canonical keys (ADR-007).
-        // Reaching this branch proves the op routed to the engine, not the
-        // legacy hash store.
+        // Loud-guard path: sync and default hybrid query still require explicit
+        // embedding config, but lex-only query is model-free BM25/FTS.
         expect(syncRaw.isError).toBe(true);
         const syncText = syncRaw.content[0]?.type === "text" ? syncRaw.content[0].text : "";
         expect(syncText).toMatch(/OMS_EMBEDDING_PROVIDER|OMS_EMBEDDING_MODEL/);
         const queryRaw = await client.callTool(queryCall);
         expect(queryRaw.isError).toBe(true);
+
+        const lexOnlyQuery = textPayload(
+          await client.callTool({
+            name: "query",
+            arguments: { query: "", lex: "agent retrieval", collection: "obsidian", limit: 1 },
+          }),
+        );
+        expect((lexOnlyQuery.hits as Array<Record<string, unknown>>)[0]).toEqual(
+          expect.objectContaining({ path: "references/Agent Retrieval.md" }),
+        );
       }
 
       const templates = await client.listResourceTemplates();

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -62,6 +62,9 @@ describe("Oh My Second Brain MCP stdio server", () => {
       const getTool = tools.tools.find((tool) => tool.name === "oms_get_document");
       expect(getTool?.annotations?.readOnlyHint).toBe(true);
       expect(getTool?.annotations?.destructiveHint).toBe(false);
+      const auditTool = tools.tools.find((tool) => tool.name === "oms_vault_audit");
+      expect(auditTool?.annotations?.readOnlyHint).toBe(true);
+      expect(JSON.stringify(auditTool?.inputSchema)).toContain("folder");
 
       const status = await client.callTool({ name: "oms_graph_status", arguments: {} });
       const parsedStatus = textPayload(status);
@@ -80,6 +83,31 @@ describe("Oh My Second Brain MCP stdio server", () => {
       const parsedValidation = textPayload(validation);
       expect(parsedValidation.valid).toBe(true);
       expect(parsedValidation.concept).toBe("literature");
+      const audit = await client.callTool({
+        name: "oms_vault_audit",
+        arguments: { folder: "references" },
+      });
+      const parsedAudit = textPayload(audit);
+      expect(parsedAudit.clean).toBe(true);
+      expect(parsedAudit.scannedNotes).toBe(1);
+      expect(parsedAudit.excludedNotes).toBe(0);
+      const nonStringFolderAudit = await client.callTool({
+        name: "oms_vault_audit",
+        arguments: { folder: 123 },
+      });
+      expect(nonStringFolderAudit.isError).toBe(true);
+      expect(nonStringFolderAudit.content[0]?.type === "text" ? nonStringFolderAudit.content[0].text : "").toContain(
+        'Argument "folder" must be a string',
+      );
+
+      const missingVaultFolderAudit = await client.callTool({
+        name: "oms_vault_audit",
+        arguments: { folder: "inbox" },
+      });
+      expect(missingVaultFolderAudit.isError).toBe(true);
+      expect(
+        missingVaultFolderAudit.content[0]?.type === "text" ? missingVaultFolderAudit.content[0].text : "",
+      ).toContain('Audit folder "inbox" does not exist');
     } finally {
       await client.close();
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, stat } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -12,6 +12,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { parseNote } from "../conventions/frontmatter.js";
 import { validateFrontmatter } from "../conventions/validate.js";
+import { lintVault } from "../engine/conventions/vault-lint.js";
 import {
   commitCapture,
   prepareCapture,
@@ -24,16 +25,16 @@ import {
   graphCachePath,
   lazyLoadNoteBody,
 } from "../graph/cache.js";
-import { loadOntology } from "../ontology/loader.js";
+import { resolveActiveOntology } from "../ontology/active.js";
 import { resolveConcept } from "../ontology/resolver.js";
 import { retrieveMorningContext } from "../retrieve/morning.js";
 import { makeEngineMorningBackend } from "./engine-morning-backend.js";
-import { resolveBundledAssetPaths } from "../runtime/assets.js";
-import type { Concept, Ontology } from "../ontology/types.js";
+import type { Concept } from "../ontology/types.js";
 import {
   handleSemanticTool,
   isEngineSemanticOp,
   isEngineDocumentOp,
+  isModelOptionalSemanticQueryOp,
   semanticMcpTools,
   semanticOptionsFromArgs,
   retrieveContextSemanticInputProperties,
@@ -43,46 +44,6 @@ import { assembleFullSemanticEngine, embeddingConfigPresent } from "./semantic-e
 import type { McpEngineAdapter } from "../engine/mcp/facade.js";
 
 const SERVER_VERSION = "0.0.0";
-const bundledAssets = resolveBundledAssetPaths();
-
-async function activeOntology(vault: string): Promise<{ ontology: Ontology; source: string }> {
-  const localOntologyDir = path.join(vault, ".oms");
-  const omsKind = await pathKind(localOntologyDir);
-  if (omsKind === "missing") {
-    return { ontology: await loadOntology(bundledAssets.ontologyDir), source: "bundled" };
-  }
-  if (omsKind !== "directory") {
-    throw new Error("Local .oms exists but is not a directory.");
-  }
-
-  const taxonomyKind = await pathKind(path.join(localOntologyDir, "taxonomy.yaml"));
-  const conceptsKind = await pathKind(path.join(localOntologyDir, "concepts"));
-
-  if (taxonomyKind === "missing" && conceptsKind === "missing") {
-    return { ontology: await loadOntology(bundledAssets.ontologyDir), source: "bundled" };
-  }
-  if (taxonomyKind !== "file" || conceptsKind !== "directory") {
-    throw new Error(
-      "Local .oms ontology is incomplete; expected .oms/taxonomy.yaml and .oms/concepts/.",
-    );
-  }
-
-  return { ontology: await loadOntology(localOntologyDir), source: "vault" };
-}
-
-async function pathKind(target: string): Promise<"missing" | "file" | "directory" | "other"> {
-  try {
-    const info = await stat(target);
-    if (info.isFile()) return "file";
-    if (info.isDirectory()) return "directory";
-    return "other";
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return "missing";
-    }
-    throw error;
-  }
-}
 
 function jsonText(value: unknown): CallToolResult {
   return {
@@ -281,6 +242,27 @@ export const omsMcpTools: Tool[] = [
     },
   },
   {
+    name: "oms_vault_audit",
+    title: "Oh My Second Brain vault audit",
+    description:
+      "Scan vault notes against the active ontology and return a structured violation report. Read-only; the CLI counterpart is `oms audit`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        folder: {
+          type: "string",
+          description: "Restrict the scan to one top-level vault folder, for example \"references\".",
+        },
+      },
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
     name: "oms_capture_prepare",
     title: "Oh My Second Brain capture prepare",
     description:
@@ -454,7 +436,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       // throw escape ALL inner catch branches and break the MCP handler.
       const engineGraph = await engine.adapter.graphStatus(vault).catch(() => null);
       try {
-        const { ontology, source } = await activeOntology(vault);
+        const { ontology, source } = await resolveActiveOntology(vault);
         const cacheStatus = await graphCacheStatus(vault, ontology);
         return jsonText({
           vault,
@@ -496,7 +478,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
 
     try {
     if (request.params.name === "oms_graph_build") {
-      const { ontology, source } = await activeOntology(vault);
+      const { ontology, source } = await resolveActiveOntology(vault);
       const cache = await buildGraphCache({ vault, ontology, write: true });
       return jsonText({
         vault,
@@ -511,7 +493,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     }
 
     if (request.params.name === "oms_list_concepts") {
-      const { ontology, source } = await activeOntology(vault);
+      const { ontology, source } = await resolveActiveOntology(vault);
       return jsonText({
         vault,
         ontologySource: source,
@@ -550,7 +532,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       // fast) otherwise. get/multi_get and ReadResource make the SAME choice, so a
       // docid emitted here always hydrates on the backend that produced it.
       const semanticBackend = makeEngineMorningBackend(resolveDocumentAdapter(), vault);
-      const { ontology, source } = await activeOntology(vault);
+      const { ontology, source } = await resolveActiveOntology(vault);
       const limitValue = args?.["limit"];
       const maxNeighborsValue = args?.["maxNeighbors"];
       const useCacheValue = args?.["useCache"];
@@ -579,17 +561,18 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     }
 
     // Semantic / sync / cleanup / document ops route to the native engine adapter:
-    //   - isEngineSemanticOp → EAGER getSemanticEngine().adapter (vec-capable): a
-    //     model-less host throws a loud ADR-007 error (surfaces via the dispatch
+    //   - vec/HyDE semantic ops → EAGER getSemanticEngine().adapter (vec-capable):
+    //     a model-less host throws a loud ADR-007 error (surfaces via the dispatch
     //     catch below).
-    //   - isEngineDocumentOp → resolveDocumentAdapter(): vec-capable engine when a
-    //     model is configured (hydrates retrieve_context real-path docids on the
-    //     same backend), else the core engine (file-based reads need no model).
+    //   - lex-only query and document ops → resolveDocumentAdapter(): vec-capable
+    //     engine when a model is configured, else the core engine. Lex is a real
+    //     model-free BM25/FTS feature, not an ADR-007 fake vector fallback.
     // Every other tool never touches the engine here.
     if (isEngineSemanticOp(request.params.name) || isEngineDocumentOp(request.params.name)) {
-      const semanticAdapter = isEngineSemanticOp(request.params.name)
-        ? getSemanticEngine().adapter
-        : resolveDocumentAdapter();
+      const semanticAdapter =
+        isEngineSemanticOp(request.params.name) && !isModelOptionalSemanticQueryOp(request.params.name, args, vault)
+          ? getSemanticEngine().adapter
+          : resolveDocumentAdapter();
       const semanticToolResult = await handleSemanticTool(request.params.name, args, vault, semanticAdapter);
       if (semanticToolResult) {
         return semanticToolResult.ok ? jsonText(semanticToolResult.value) : errorText(semanticToolResult.message);
@@ -617,7 +600,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
         return errorText(error instanceof Error ? error.message : String(error));
       }
 
-      const { ontology, source } = await activeOntology(vault);
+      const { ontology, source } = await resolveActiveOntology(vault);
       const normalizedNotePath = path.relative(vault, fullPath).replace(/\\/g, "/");
       const concept = resolveConcept(ontology, normalizedNotePath);
       if (!concept) {
@@ -651,8 +634,30 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       });
     }
 
+    if (request.params.name === "oms_vault_audit") {
+      if (
+        args !== undefined &&
+        Object.prototype.hasOwnProperty.call(args, "folder") &&
+        typeof args["folder"] !== "string"
+      ) {
+        return errorText('Argument "folder" must be a string top-level folder name.');
+      }
+      const folder = stringArg(args, "folder");
+      const { ontology, source } = await resolveActiveOntology(vault);
+      const report = await lintVault(vault, ontology, { folder });
+      return jsonText({
+        vault,
+        ontologySource: source,
+        folder: folder ?? null,
+        scannedNotes: report.scannedNotes,
+        excludedNotes: report.excludedNotes,
+        clean: report.clean,
+        violations: report.violations,
+      });
+    }
+
     if (request.params.name === "oms_capture_prepare") {
-      const { ontology, source } = await activeOntology(vault);
+      const { ontology, source } = await resolveActiveOntology(vault);
       const frontmatterArg = args?.["frontmatter"];
       const frontmatter = isRecord(frontmatterArg) ? frontmatterArg : {};
       return jsonText({
@@ -670,7 +675,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     }
 
     if (request.params.name === "oms_capture_commit") {
-      const { ontology, source } = await activeOntology(vault);
+      const { ontology, source } = await resolveActiveOntology(vault);
       const notePath = stringArg(args, "notePath");
       const body = stringArg(args, "body");
       const mode = stringArg(args, "mode");

--- a/src/ontology/active.ts
+++ b/src/ontology/active.ts
@@ -1,0 +1,51 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { resolveBundledAssetPaths } from "../runtime/assets.js";
+import { loadOntology } from "./loader.js";
+import type { Ontology } from "./types.js";
+
+export type ActiveOntologySource = "vault" | "bundled";
+
+export interface ActiveOntology {
+  readonly ontology: Ontology;
+  readonly source: ActiveOntologySource;
+}
+
+const bundledAssets = resolveBundledAssetPaths();
+
+async function pathKind(target: string): Promise<"missing" | "file" | "directory" | "other"> {
+  try {
+    const info = await stat(target);
+    if (info.isFile()) return "file";
+    if (info.isDirectory()) return "directory";
+    return "other";
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return "missing";
+    }
+    throw error;
+  }
+}
+
+export async function resolveActiveOntology(vault: string): Promise<ActiveOntology> {
+  const localOntologyDir = path.join(vault, ".oms");
+  const omsKind = await pathKind(localOntologyDir);
+  if (omsKind === "missing") {
+    return { ontology: await loadOntology(bundledAssets.ontologyDir), source: "bundled" };
+  }
+  if (omsKind !== "directory") {
+    throw new Error("Local .oms exists but is not a directory.");
+  }
+
+  const taxonomyKind = await pathKind(path.join(localOntologyDir, "taxonomy.yaml"));
+  const conceptsKind = await pathKind(path.join(localOntologyDir, "concepts"));
+
+  if (taxonomyKind === "missing" && conceptsKind === "missing") {
+    return { ontology: await loadOntology(bundledAssets.ontologyDir), source: "bundled" };
+  }
+  if (taxonomyKind !== "file" || conceptsKind !== "directory") {
+    throw new Error("Local .oms ontology is incomplete; expected .oms/taxonomy.yaml and .oms/concepts/.");
+  }
+
+  return { ontology: await loadOntology(localOntologyDir), source: "vault" };
+}

--- a/src/setup/axis.test.ts
+++ b/src/setup/axis.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -8,7 +8,7 @@ import {
   mergeObservedFieldsIntoConcept,
   parseLensDefinitions,
 } from "./axis.js";
-import type { Concept } from "../ontology/types.js";
+import type { Concept, Ontology } from "../ontology/types.js";
 
 let tmpVault: string | undefined;
 
@@ -32,9 +32,7 @@ async function makeVault(): Promise<string> {
     "utf-8",
   );
   await writeFile(path.join(tmpVault, "README.txt"), "status: draft\n", "utf-8");
-  await import("node:fs/promises").then(({ mkdir }) =>
-    mkdir(path.join(tmpVault ?? "", "references"), { recursive: true }),
-  );
+  await mkdir(path.join(tmpVault, "references"), { recursive: true });
   await writeFile(
     path.join(tmpVault, "references", "source.md"),
     [
@@ -80,6 +78,35 @@ describe("setup axis discovery", () => {
     expect(references?.warnings).toHaveLength(1);
   });
 
+  it("uses audit folder scope and exclude globs when collecting suggested fields", async () => {
+    const vault = await makeVault();
+    await writeFile(
+      path.join(vault, "references", "skip.template.md"),
+      "---\nignored-field: true\n---\n# Template",
+      "utf-8",
+    );
+
+    const ontology: Ontology = {
+      taxonomy: {
+        version: 1,
+        folders: {
+          references: {
+            intent: "References",
+            concept: "literature",
+          },
+        },
+        exclude: ["references/broken.md"],
+      },
+      concepts: new Map(),
+    };
+
+    const summaries = await collectObservedFields({ vault, ontology, folder: "references" });
+    const references = summaries.find((summary) => summary.folder === "references");
+
+    expect(summaries.map((summary) => summary.folder)).toEqual(["references"]);
+    expect(references?.warnings).toEqual([]);
+    expect(references?.fields.map((field) => field.name)).not.toContain("ignored-field");
+  });
   it("SETUP-AXIS-004 rejects lenses that reference unknown fields", () => {
     expect(() => parseLensDefinitions("synthesis:title,missing", new Set(["title"]))).toThrow(
       /unknown field "missing"/,

--- a/src/setup/axis.ts
+++ b/src/setup/axis.ts
@@ -1,7 +1,10 @@
-import { readFile, readdir } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { parseNote } from "../conventions/frontmatter.js";
-import type { Concept, FieldType, OntologyField, OntologyLens } from "../ontology/types.js";
+import { walkVaultMarkdown } from "../conventions/vault-walk.js";
+import { resolveConcept } from "../ontology/resolver.js";
+import { matchesAnyGlob, resolveExcludeGlobs, validateVaultLintFolder } from "../engine/conventions/vault-lint.js";
+import type { Concept, FieldType, Ontology, OntologyField, OntologyLens } from "../ontology/types.js";
 
 export interface ObservedField {
   readonly name: string;
@@ -20,36 +23,6 @@ interface FieldAccumulator {
   values: unknown[];
 }
 
-const SKIP_DIRS = new Set(["node_modules"]);
-
-async function* walkVaultMarkdown(
-  dir: string,
-  base: string,
-): AsyncGenerator<{ readonly relativePath: string; readonly fullPath: string }> {
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch (error) {
-    if (error instanceof Error) {
-      return;
-    }
-    throw error;
-  }
-
-  for (const entry of entries) {
-    if (entry.name.startsWith(".")) continue;
-    if (SKIP_DIRS.has(entry.name)) continue;
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      yield* walkVaultMarkdown(fullPath, base);
-    } else if (entry.isFile() && entry.name.endsWith(".md")) {
-      yield {
-        relativePath: path.relative(base, fullPath).replace(/\\/g, "/"),
-        fullPath,
-      };
-    }
-  }
-}
 
 function firstFolder(relativePath: string): string | null {
   const slashIndex = relativePath.indexOf("/");
@@ -107,28 +80,46 @@ function getOrCreateAccumulator(
   return accumulator;
 }
 
-export async function collectObservedFields(opts: {
+interface ObservedScanOptions {
   readonly vault: string;
+  readonly ontology?: Ontology;
+  readonly folder?: string;
+  readonly excludeGlobs?: readonly string[];
   readonly maxFilesPerFolder?: number;
-}): Promise<readonly ObservedFolderSummary[]> {
+}
+
+function scanExcludeGlobs(opts: { readonly ontology?: Ontology; readonly excludeGlobs?: readonly string[] }): readonly string[] {
+  if (opts.ontology === undefined) return opts.excludeGlobs ?? [];
+  return resolveExcludeGlobs(opts.ontology, opts.excludeGlobs ?? []);
+}
+
+async function validateObservedFolderScope(opts: ObservedScanOptions): Promise<void> {
+  if (opts.ontology === undefined) return;
+  await validateVaultLintFolder(opts.vault, opts.ontology, opts.folder);
+}
+
+export async function collectObservedFields(opts: ObservedScanOptions): Promise<readonly ObservedFolderSummary[]> {
   const fieldsByFolder = new Map<string, Map<string, FieldAccumulator>>();
   const warningsByFolder = new Map<string, string[]>();
   const filesByFolder = new Map<string, number>();
   const maxFilesPerFolder = opts.maxFilesPerFolder ?? 100;
+  const excludeGlobs = scanExcludeGlobs(opts);
+  await validateObservedFolderScope(opts);
 
-  for await (const file of walkVaultMarkdown(opts.vault, opts.vault)) {
-    const folder = firstFolder(file.relativePath);
-    if (folder === null) continue;
+  for await (const relativePath of walkVaultMarkdown(opts.vault)) {
+    if (matchesAnyGlob(relativePath, excludeGlobs)) continue;
+    const folder = firstFolder(relativePath);
+    if (folder === null || (opts.folder !== undefined && folder !== opts.folder)) continue;
     const seen = filesByFolder.get(folder) ?? 0;
     if (seen >= maxFilesPerFolder) continue;
     filesByFolder.set(folder, seen + 1);
 
-    const raw = await readFile(file.fullPath, "utf-8");
+    const raw = await readFile(path.join(opts.vault, relativePath), "utf-8");
     const parsed = parseNote(raw);
     if (parsed.diagnostics.length > 0) {
       const warnings = warningsByFolder.get(folder) ?? [];
       for (const diagnostic of parsed.diagnostics) {
-        warnings.push(`${file.relativePath}: ${diagnostic.message}`);
+        warnings.push(`${relativePath}: ${diagnostic.message}`);
       }
       warningsByFolder.set(folder, warnings);
       continue;
@@ -154,6 +145,78 @@ export async function collectObservedFields(opts: {
       warnings: warningsByFolder.get(folder) ?? [],
     }))
     .sort((left, right) => left.folder.localeCompare(right.folder));
+}
+
+// ── Enum drift detection ──────────────────────────────────────────────────────
+
+/** One frontmatter value observed outside a field's declared `enum`. */
+export interface ObservedFieldValueDrift {
+  readonly folder: string;
+  readonly field: string;
+  readonly value: string;
+  readonly count: number;
+}
+
+/**
+ * Scan the vault for string values that violate declared enum constraints,
+ * grouped by folder/field/value with a frequency count.
+ */
+export async function collectObservedFieldValues(opts: ObservedScanOptions & {
+  readonly ontology: Ontology;
+}): Promise<readonly ObservedFieldValueDrift[]> {
+  const drift = new Map<string, Map<string, Map<string, { count: number }>>>();
+  const filesByFolder = new Map<string, number>();
+  const excludeGlobs = scanExcludeGlobs(opts);
+  await validateObservedFolderScope(opts);
+
+  for await (const relativePath of walkVaultMarkdown(opts.vault)) {
+    if (matchesAnyGlob(relativePath, excludeGlobs)) continue;
+    const folder = firstFolder(relativePath);
+    if (folder === null || (opts.folder !== undefined && folder !== opts.folder)) continue;
+
+    if (opts.maxFilesPerFolder !== undefined) {
+      const seen = filesByFolder.get(folder) ?? 0;
+      if (seen >= opts.maxFilesPerFolder) continue;
+      filesByFolder.set(folder, seen + 1);
+    }
+    const concept = resolveConcept(opts.ontology, relativePath);
+    if (!concept) continue;
+
+    const raw = await readFile(path.join(opts.vault, relativePath), "utf-8");
+    const parsed = parseNote(raw);
+    if (parsed.diagnostics.length > 0) continue;
+
+    for (const field of concept.fields) {
+      if (!field.enum || field.enum.length === 0) continue;
+      const value = parsed.frontmatter[field.name];
+      if (typeof value !== "string" || value.trim() === "") continue;
+      if (field.enum.includes(value)) continue;
+
+      const byField = drift.get(folder) ?? new Map<string, Map<string, { count: number }>>();
+      drift.set(folder, byField);
+      const byValue = byField.get(field.name) ?? new Map<string, { count: number }>();
+      byField.set(field.name, byValue);
+      const entry = byValue.get(value);
+      if (entry) {
+        entry.count += 1;
+      } else {
+        byValue.set(value, { count: 1 });
+      }
+    }
+  }
+
+  const results: ObservedFieldValueDrift[] = [];
+  for (const [folder, byField] of drift) {
+    for (const [field, byValue] of byField) {
+      for (const [value, entry] of byValue) {
+        results.push({ folder, field, value, count: entry.count });
+      }
+    }
+  }
+
+  return results.sort(
+    (left, right) => right.count - left.count || left.value.localeCompare(right.value),
+  );
 }
 
 function observedFieldIntent(field: ObservedField): string {


### PR DESCRIPTION
## 요약
로컬에만 있던 vault-audit 작업을 새 harness 구조(dispatcher/core-ontology/surface-registry) 위로 재이식하고, qmd-호환 브릿지를 공식 제품 계약으로 승격(ADR-009)합니다.

## 커밋 단위
1. **feat(ontology)** — core ontology 스키마 확장(enum/agentWritable/routingLawStrict/exclude) + CLI·MCP 공유 strict active-ontology 해석(손상된 .oms는 번들 fallback 없이 명시 실패)
2. **feat(audit)** — `oms audit` CLI + 읽기 전용 `oms_vault_audit` MCP tool(registry parity 포함). folder 인자는 공통 진입점에서 검증(오타→가짜 clean 금지, `..` 탈출 금지)
3. **feat(semantic)** — lex-only 쿼리는 임베딩 provider 없이 BM25/FTS로 동작(자동 인덱싱); vec/HyDE는 ADR-007 loud-guard 유지
4. **feat(link)** — link 시 대상 프로젝트 AGENTS.md에 managed 사용법 블록 자동 기입(idempotent, 개인경로 무유출, 옥트아웃); 손상된 links.yaml/삭제된 vault는 명시 에러
5. **docs** — ADR-009 + ADR 인덱스 수리(ADR-008 누락) + 0.1.7→0.1.8 드리프트 + compile CoT 표현 제거
6. **chore(governance)** — 분산 skill manifest(schema v1)

## 검증
- 전체 테스트 729 passed / 0 failed (신규 회귀 포함)
- 외부 repo E2E: `oms link` 1회 → `oms search --lex`/`oms get` + MCP `query(lex)/get`이 연결 vault로 해석
- red-team: 존재하지 않는 folder/비문자열 인자/손상 links.yaml/삭제 vault 전부 명시 에러 확인

🤖 Generated with GJC (deep-interview → ralplan → ultragoal)