### PR TITLE
docs: add Cursor Cloud specific setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,3 +116,14 @@ after editing imports.
 | `/core/AGENTS.md` | Vault-convention SSOT for end users | Separate lane |
 
 Do not conflate them. Do not create or modify `core/AGENTS.md` from this lane.
+
+---
+
+## Cursor Cloud specific instructions
+
+Environment: Node 22 (satisfies `engines.node >=20`), npm, and a C/C++ toolchain (`gcc`/`g++`/`make`/`python3`) are preinstalled. The startup update script runs `npm install`, which prebuilds/compiles the native deps (`better-sqlite3`, `sqlite-vec`, `node-llama-cpp`) — they load out of the box, no extra system packages needed.
+
+- **Build before running the CLI/MCP.** `bin` points at compiled `dist/` (`dist/cli/oms.js`), so `npm install` alone does not make `oms` runnable. Run `npm run build` first, then invoke `node dist/cli/oms.js <command>`. Standard commands are in the "Build and Test Commands" section above.
+- **No long-running daemon for tests.** `npm test` (vitest) covers everything (incl. `src/e2e.test.ts`, `src/setup.e2e.test.ts`) without starting a server.
+- **Exercising the product end-to-end:** point at any folder of markdown notes, e.g. `node dist/cli/oms.js setup --vault <path> --yes` (writes `.oms/taxonomy.yaml`), then `doctor` / `lint`. The MCP server is stdio: `node dist/cli/oms.js mcp --vault <path>` and speaks JSON-RPC (`initialize` → `tools/list` → `tools/call`).
+- **Semantic search is optional and off by default.** It needs a real embedding model via `OMS_EMBEDDING_PROVIDER` + `OMS_EMBEDDING_MODEL` (ADR-007: no fake fallback). Graph retrieval + convention validation work without any model, so semantic setup is not required to run/test the core product.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the Cloud Agent development environment for Oh My Second Brain and verified it end-to-end. The only code change is a documentation addition to `AGENTS.md`.

## What was done

- Installed dependencies with `npm install` — native modules (`better-sqlite3`, `sqlite-vec`, `node-llama-cpp`) prebuild/compile cleanly with the preinstalled Node 22 + C/C++ toolchain.
- Verified the standard dev flow: `npm run build`, `npm run lint`, `npm test` (445 passed, 11 skipped).
- Exercised the product end-to-end on a sample markdown vault: `oms setup` → `oms doctor` → `oms lint`, plus a full stdio MCP JSON-RPC session (`initialize` → `tools/list` → `oms_graph_build` / `oms_list_concepts`).

## Changes

- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing non-obvious gotchas for future agents (build-before-run because `bin` targets compiled `dist/`, native deps work out of the box, tests need no daemon, semantic search is optional and needs an embedding model).

## Environment startup

- Update script (run on VM startup): `npm install`

No functional/runtime code was modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55439002-7849-4b9d-80b5-c6c033008e21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55439002-7849-4b9d-80b5-c6c033008e21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

