### PR TITLE
fix(claude): make MCP cleanup plugin-owned and fail-safe

### DIFF
--- a/adapters/claude-code/.claude-plugin/plugin.json
+++ b/adapters/claude-code/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
     "name": "gobeumsu"
   },
   "license": "MIT",
+  "mcpServers": "./.mcp.json",
   "keywords": [
     "obsidian",
     "knowledge-base",

--- a/adapters/claude-code/.mcp.json
+++ b/adapters/claude-code/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "oms": {
+      "command": "oms",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/adapters/claude-code/skills/setup/SKILL.md
+++ b/adapters/claude-code/skills/setup/SKILL.md
@@ -38,7 +38,7 @@ The CLI will:
 | `--vault <path>` | Path to your Obsidian vault root (default: current directory) |
 | `--yes` | Non-interactive: accept all defaults, no prompts |
 | `--suggest-fields` | Merge observed note frontmatter fields into concept schemas without mutating notes. |
-| `--install-claude` | Legacy setup-only dry-run that prints Claude Code plugin install and MCP registration commands. |
+| `--install-claude` | Legacy setup-only dry-run that prints the Claude Code plugin install command and plugin-owned MCP asset. |
 | `install --runtime <name>` | Install host adapter/MCP registration for `auto`, `all`, `claude`, `codex`, or `hermes`. |
 | `install --dry-run` | Preview host writes without mutating config. |
 | `install --execute` | Allow external host CLIs such as `claude plugin install` to run when available. |
@@ -71,7 +71,7 @@ Run `/oms-doctor` to validate your existing notes against the convention.
 
 ## Roadmap
 
-Setup plus `oms install`/`oms uninstall` host lifecycle commands are real and release-gated by unpacked npm tarball smoke tests. The MCP command starts
+Setup plus `oms install`/`oms uninstall` host lifecycle commands are real and release-gated by unpacked npm tarball smoke tests. The plugin-owned MCP asset starts
 the status/read/cache/retrieve/write runtime (`oms_graph_status`, `oms_graph_build`,
 `oms_list_concepts`, `oms_retrieve_context`, `oms_retrieve_by_axis`,
 `oms_lazy_load_note`, `oms_validate_contract`, `write`).

--- a/adapters/claude-code/skills/uninstall/SKILL.md
+++ b/adapters/claude-code/skills/uninstall/SKILL.md
@@ -31,4 +31,4 @@ oms uninstall --runtime all --dry-run
 oms uninstall --runtime all --yes
 ```
 
-Use `--execute` only when you want Oh My Second Brain to call external host CLIs such as `claude mcp remove oms` or `claude plugin uninstall oms`.
+Use `--execute` only when you want Oh My Second Brain to call external host CLIs such as the scoped `claude mcp remove oms --scope local|project|user` commands or `claude plugin uninstall oms`.

--- a/docs/harness-architecture.md
+++ b/docs/harness-architecture.md
@@ -165,7 +165,7 @@ The Phase 1 command surface is intentionally dry-run for Claude runtime registra
 oms setup --vault /path/to/vault --yes --install-claude
 ```
 
-This initializes `.oms/` and prints a Claude Code plugin install command plus a `claude mcp add ...` command. It does not mutate Claude config. Capture/write tools are only available through the gated safe-write path.
+This initializes `.oms/` and prints a Claude Code plugin install command plus the plugin-owned MCP asset. It does not mutate Claude config. Capture/write tools are only available through the gated safe-write path.
 
 Phase 3 adds a derived cache at `vault/.oms/cache/graph.json`. This file is not canonical. It can be rebuilt from markdown plus `.oms/` and contains:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -62,7 +62,7 @@ Runtime selection follows the Ouroboros pattern:
 
 | Host | Install behavior |
 | --- | --- |
-| Claude Code | Upserts `~/.claude/mcp.json` entry for `oms`; prints Claude plugin/MCP commands; with `--execute`, runs `claude plugin install` and `claude mcp add` when the CLI is available. |
+| Claude Code | Installs the plugin-owned `.mcp.json` surface; removes stale `oms` registrations across local/project/user scopes; with `--execute`, runs the Claude plugin lifecycle commands when the CLI is available. |
 | Codex | Installs `~/.codex/rules/oms.md`, `~/.codex/skills/oms-*`, copies adapter files to `~/.codex/plugins/oms`, and writes a managed `[mcp_servers.oms]` block plus `OMS_AGENT_RUNTIME=codex` env in `~/.codex/config.toml`. |
 | Hermes | Installs `~/.hermes/skills/knowledge-management/oms/`, copies adapter files to `~/.hermes/adapters/oms`, and writes `mcp_servers.oms` in `~/.hermes/config.yaml`. |
 
@@ -106,7 +106,7 @@ Typical printed commands look like:
 
 ```bash
 claude plugin install /path/to/oh-my-second-brain/adapters/claude-code
-claude mcp add oms -- oms mcp --vault /path/to/vault
+# MCP is declared by the installed plugin in adapters/claude-code/.mcp.json.
 ```
 
 ## Uninstall

--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -95,8 +95,8 @@ function setupSmoke(packageRoot, vault) {
   assertPath(path.join(vault, ".oms/taxonomy.yaml"), "vault taxonomy");
   assertPath(path.join(vault, ".oms/concepts"), "vault concepts directory");
   if (!output.includes("claude plugin install")) fail("setup output did not include Claude plugin install command");
-  if (!output.includes("claude mcp add oms -- oms mcp --vault")) {
-    fail("setup output did not include Claude MCP registration command");
+  if (!output.includes("plugin-owned and plugin-qualified")) {
+    fail("setup output did not declare the plugin-owned Claude MCP surface");
   }
   const pluginPathLine = output.split(/\r?\n/).find((line) => line.includes("Plugin path:"));
   if (!pluginPathLine) fail("setup output did not include Plugin path line");

--- a/src/cli/claude-install-plan.ts
+++ b/src/cli/claude-install-plan.ts
@@ -5,7 +5,7 @@ const bundledAssets = resolveBundledAssetPaths();
 export interface ClaudeInstallPlan {
   pluginPath: string;
   pluginInstallCommand: string;
-  mcpRegistrationCommand: string;
+  pluginMcpAsset: string;
   mcpRuntimeStatus: "read-status-runtime";
 }
 
@@ -16,12 +16,12 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-export function buildClaudeInstallPlan(opts: { vault: string }): ClaudeInstallPlan {
+export function buildClaudeInstallPlan(_opts: { vault: string }): ClaudeInstallPlan {
   const pluginPath = bundledAssets.claudeAdapterDir;
   return {
     pluginPath,
     pluginInstallCommand: `claude plugin install ${shellQuote(pluginPath)}`,
-    mcpRegistrationCommand: `claude mcp add oms -- oms mcp --vault ${shellQuote(opts.vault)}`,
+    pluginMcpAsset: `${pluginPath}/.mcp.json`,
     mcpRuntimeStatus: "read-status-runtime",
   };
 }
@@ -30,7 +30,8 @@ export function printClaudeInstallPlan(plan: ClaudeInstallPlan): void {
   console.log("Claude Code harness install plan (dry-run).");
   console.log(`  Plugin path: ${plan.pluginPath}`);
   console.log(`  Plugin command: ${plan.pluginInstallCommand}`);
-  console.log(`  MCP command: ${plan.mcpRegistrationCommand}`);
+  console.log(`  MCP asset: ${plan.pluginMcpAsset}`);
+  console.log("  MCP registration: plugin-owned and plugin-qualified; no bare `claude mcp add oms` command.");
   console.log(
     "  MCP status: status/read/cache/retrieval plus write; write is gated by vault confinement and contract validation.",
   );

--- a/src/cli/oms-dispatch.test.ts
+++ b/src/cli/oms-dispatch.test.ts
@@ -220,4 +220,29 @@ describe("oms CLI dispatch", () => {
       expect.objectContaining({ path: "notes/Alpha.md" }),
     ]);
   });
+
+  it("routes update-reconcile dry-run through the scoped Claude cleanup plan", async () => {
+    const vault = await makeVault();
+    const result = runCli(["update-reconcile", "--runtime", "claude", "--vault", vault, "--dry-run"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("claude mcp remove oms --scope local");
+    expect(result.stdout).toContain("claude mcp remove oms --scope project");
+    expect(result.stdout).toContain("claude mcp remove oms --scope user");
+  });
+
+  it("returns stable cleanup fields for host JSON output", async () => {
+    const vault = await makeVault();
+    const result = runCli(["install", "--runtime", "claude", "--vault", vault, "--dry-run", "--json"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const output = jsonObject(result.stdout) as {
+      dryRun: boolean;
+      results: Array<{ cleanup: unknown[]; messages: string[] }>;
+    };
+    expect(output.dryRun).toBe(true);
+    expect(output.results[0]?.cleanup).toEqual([]);
+    expect(output.results[0]?.messages.join(" ")).toContain("scope local");
+  });
 });

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -6,6 +6,7 @@ import { runPostToolUse } from "../hook/post-tool-use.js";
 import { runPreToolUse } from "../hook/pre-tool-use.js";
 import {
   formatHostOperationResults,
+  formatHostOperationResultsJson,
   runHostOperation,
 } from "../install/hosts.js";
 import { resolveEffectiveVault } from "../link/link.js";
@@ -117,7 +118,7 @@ async function main(): Promise<void> {
       yes,
       adapterRoot: bundledAdapterRoot(),
     });
-    console.log(formatHostOperationResults(results, dryRun));
+    console.log(json ? formatHostOperationResultsJson(results, dryRun) : formatHostOperationResults(results, dryRun));
     await maybePrintUpdateNotice();
   } else if (command === "update") {
     if (unknownFlags.length > 0) {
@@ -159,7 +160,7 @@ async function main(): Promise<void> {
       yes: true,
       adapterRoot: bundledAdapterRoot(),
     });
-    console.log(formatHostOperationResults(results, dryRun));
+    console.log(json ? formatHostOperationResultsJson(results, dryRun) : formatHostOperationResults(results, dryRun));
   } else if (command === "doctor") {
     process.exitCode = await runDoctor({ vault, verbose, json, maxPerConcept });
     await maybePrintUpdateNotice();

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -65,8 +65,8 @@ oh-my-second-brain — Oh My Second Brain convention layer for Obsidian vaults
 
 Usage:
   oh-my-second-brain setup [--vault <path>] [--yes] [--suggest-fields] [--install-claude]
-  oh-my-second-brain install [--vault <path>] [--runtime <${runtime}>] [--dry-run] [--execute] [--yes]
-  oh-my-second-brain uninstall [--runtime <all|${registry.hosts.map((host) => host.runtime).join("|")}>] [--dry-run] [--execute] [--yes]
+  oh-my-second-brain install [--vault <path>] [--runtime <${runtime}>] [--dry-run] [--execute] [--yes] [--json]
+  oh-my-second-brain uninstall [--runtime <all|${registry.hosts.map((host) => host.runtime).join("|")}>] [--dry-run] [--execute] [--yes] [--json]
   oh-my-second-brain update [--check] [--dry-run] [--yes] [--runtime <${runtime}>] [--vault <path>]
   oh-my-second-brain doctor [--vault <path>] [--verbose] [--json] [--max <n>]
   oh-my-second-brain audit [--vault <path>] [--folder <name>] [--json] [--suggest-fields]

--- a/src/harness/surface-registry.ts
+++ b/src/harness/surface-registry.ts
@@ -326,7 +326,7 @@ export const harnessSurfaceRegistry: HarnessSurfaceRegistry = {
       guidanceFiles: ["CLAUDE.md"],
       hookFiles: ["hooks/oms-guard.mjs", "hooks/oms-post-guard.mjs"],
       ruleFiles: [],
-      mcpConfigFiles: [],
+      mcpConfigFiles: [".mcp.json"],
       hardHookGuarantee: true,
     },
     {

--- a/src/install/claude-hooks.ts
+++ b/src/install/claude-hooks.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { isRecord, writeJsonObject } from "./common.js";
@@ -8,12 +8,16 @@ const GUARD_MARKER = "oms-guard";
 const POST_GUARD_MARKER = "oms-post-guard";
 const HOOK_MATCHER = "Write|Edit|NotebookEdit";
 
+function escapeShellDoubleQuoted(value: string): string {
+  return value.replace(/["\\$`]/g, "\\$&");
+}
+
 export function toShellVaultPath(absPath: string, homeDir: string): string {
   const rel = path.relative(homeDir, absPath);
   if (rel.length > 0 && !rel.startsWith("..") && !path.isAbsolute(rel)) {
-    return `"$HOME/${rel.replace(/\\/g, "/")}"`;
+    return `"$HOME/${escapeShellDoubleQuoted(rel.replace(/\\/g, "/"))}"`;
   }
-  return `"${absPath}"`;
+  return `"${escapeShellDoubleQuoted(absPath)}"`;
 }
 
 export function buildGuardCommandString(
@@ -34,18 +38,101 @@ function buildOmsHookEntry(matcher: string, command: string): Record<string, unk
   return { matcher, hooks: [{ type: "command", command }] };
 }
 
+function tokenizeHookCommand(command: string): string[] | null {
+  const tokens: string[] = [];
+  let token = "";
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  for (const character of command) {
+    if (escaped) {
+      token += character;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      token += character;
+      escaped = true;
+      continue;
+    }
+    if (quote !== null) {
+      token += character;
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      token += character;
+      quote = character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      if (token.length > 0) {
+        tokens.push(token);
+        token = "";
+      }
+      continue;
+    }
+    token += character;
+  }
+
+  if (quote !== null || escaped) return null;
+  if (token.length > 0) tokens.push(token);
+  return tokens;
+}
+
+function isOwnedAssignment(token: string, key: "OMS_VAULT" | "OMS_AGENT_VAULT"): boolean {
+  const prefix = `${key}="`;
+  if (!token.startsWith(prefix) || !token.endsWith('"')) return false;
+  const value = token.slice(prefix.length, -1);
+  if (value.length === 0) return false;
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index];
+    if (character === "\\") {
+      const escaped = value[index + 1];
+      if (escaped !== '"' && escaped !== "\\" && escaped !== "$" && escaped !== "`") return false;
+      index++;
+      continue;
+    }
+    if (character === "$" && index === 0 && value.length > "$HOME/".length && value.startsWith("$HOME/")) {
+      index += "$HOME/".length - 1;
+      continue;
+    }
+    if (character === '"' || character === "$" || character === "`") return false;
+  }
+  return true;
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  return actual.length === keys.length && actual.every((key, index) => key === [...keys].sort()[index]);
+}
+
 export function isOmsHookEntry(entry: unknown, marker: string): boolean {
   if (!isRecord(entry)) return false;
+  if (!hasExactKeys(entry, ["hooks", "matcher"])) return false;
+  if (entry["matcher"] !== HOOK_MATCHER) return false;
   const inner = entry["hooks"];
-  if (!Array.isArray(inner)) return false;
-  return inner.some(
-    (h) => isRecord(h) && typeof h["command"] === "string" && h["command"].includes(marker),
-  );
+  if (!Array.isArray(inner) || inner.length !== 1) return false;
+  return inner.every((h) => {
+    if (!isRecord(h) || h["type"] !== "command" || typeof h["command"] !== "string") return false;
+    if (!hasExactKeys(h, ["command", "type"])) return false;
+    const tokens = tokenizeHookCommand(h["command"]);
+    if (tokens === null || tokens.at(-1) !== marker) return false;
+    if (tokens.length === 2) return isOwnedAssignment(tokens[0] ?? "", "OMS_VAULT");
+    if (tokens.length === 3) {
+      return (
+        isOwnedAssignment(tokens[0] ?? "", "OMS_VAULT") &&
+        isOwnedAssignment(tokens[1] ?? "", "OMS_AGENT_VAULT")
+      );
+    }
+    return false;
+  });
 }
 
 interface SettingsReadResult {
   readonly data: Record<string, unknown> | null;
   readonly corrupt: boolean;
+  readonly raw: string | null;
 }
 
 function isHookMap(value: unknown): value is Record<string, unknown[]> {
@@ -57,13 +144,171 @@ async function readSettingsJsonSafe(settingsPath: string): Promise<SettingsReadR
   try {
     const raw = await readFile(settingsPath, "utf-8");
     const parsed = JSON.parse(raw) as unknown;
-    return { data: isRecord(parsed) ? parsed : {}, corrupt: false };
+    return isRecord(parsed)
+      ? { data: parsed, corrupt: false, raw }
+      : { data: null, corrupt: true, raw };
   } catch (err) {
     if (err instanceof Error && "code" in err && err.code === "ENOENT") {
-      return { data: {}, corrupt: false };
+      return { data: {}, corrupt: false, raw: null };
     }
-    return { data: null, corrupt: true };
+    return { data: null, corrupt: true, raw: null };
   }
+}
+
+function skipJsonWhitespace(raw: string, start: number): number {
+  let index = start;
+  while (index < raw.length && /\s/.test(raw[index] ?? "")) index++;
+  return index;
+}
+
+function scanJsonString(raw: string, start: number): number | null {
+  if (raw[start] !== '"') return null;
+  let escaped = false;
+  for (let index = start + 1; index < raw.length; index++) {
+    const character = raw[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (character === '"') return index + 1;
+  }
+  return null;
+}
+
+function scanJsonValue(raw: string, start: number): number | null {
+  const first = raw[start];
+  if (first === '"') return scanJsonString(raw, start);
+  if (first !== "{" && first !== "[") {
+    let index = start;
+    while (index < raw.length && !",}]".includes(raw[index] ?? "")) index++;
+    return index;
+  }
+
+  const closing = first === "{" ? "}" : "]";
+  let index = start + 1;
+  while (index < raw.length) {
+    index = skipJsonWhitespace(raw, index);
+    if (raw[index] === closing) return index + 1;
+    if (first === "{") {
+      const keyEnd = scanJsonString(raw, index);
+      if (keyEnd === null) return null;
+      index = skipJsonWhitespace(raw, keyEnd);
+      if (raw[index] !== ":") return null;
+      index = skipJsonWhitespace(raw, index + 1);
+    }
+    const valueEnd = scanJsonValue(raw, index);
+    if (valueEnd === null) return null;
+    index = skipJsonWhitespace(raw, valueEnd);
+    if (raw[index] === ",") {
+      index++;
+      continue;
+    }
+    if (raw[index] === closing) return index + 1;
+    return null;
+  }
+  return null;
+}
+
+interface RootJsonProperty {
+  readonly keyStart: number;
+  readonly valueStart: number;
+  readonly valueEnd: number;
+}
+
+function findRootJsonProperty(raw: string, key: string): RootJsonProperty | null {
+  const rootStart = skipJsonWhitespace(raw, 0);
+  const rootEnd = scanJsonValue(raw, rootStart);
+  if (raw[rootStart] !== "{" || rootEnd === null) return null;
+  let index = skipJsonWhitespace(raw, rootStart + 1);
+  while (index < rootEnd - 1) {
+    const keyStart = index;
+    const keyEnd = scanJsonString(raw, keyStart);
+    if (keyEnd === null) return null;
+    let parsedKey: unknown;
+    try {
+      parsedKey = JSON.parse(raw.slice(keyStart, keyEnd));
+    } catch {
+      return null;
+    }
+    index = skipJsonWhitespace(raw, keyEnd);
+    if (raw[index] !== ":") return null;
+    const valueStart = skipJsonWhitespace(raw, index + 1);
+    const valueEnd = scanJsonValue(raw, valueStart);
+    if (valueEnd === null) return null;
+    if (parsedKey === key) return { keyStart, valueStart, valueEnd };
+    index = skipJsonWhitespace(raw, valueEnd);
+    if (raw[index] !== ",") break;
+    index = skipJsonWhitespace(raw, index + 1);
+  }
+  return null;
+}
+
+function formatJsonValue(value: unknown, propertyIndent: string): string {
+  const serialized = JSON.stringify(value, null, 2);
+  if (propertyIndent.length === 0) return JSON.stringify(value);
+  return serialized
+    .split("\n")
+    .map((line, index) => (index === 0 ? line : `${propertyIndent}${line}`))
+    .join("\n");
+}
+
+export function replaceRootJsonPropertyPreservingBytes(raw: string, key: string, value: unknown): string | null {
+  const property = findRootJsonProperty(raw, key);
+  if (property === null) {
+    if (value === undefined) return raw;
+    const rootStart = skipJsonWhitespace(raw, 0);
+    const rootEnd = scanJsonValue(raw, rootStart);
+    if (rootEnd === null) return null;
+    const closeIndex = rootEnd - 1;
+    const closeLineStart = raw.lastIndexOf("\n", closeIndex) + 1;
+    const closeIndent = raw.slice(closeLineStart, closeIndex);
+    const hasMembers = raw.slice(rootStart + 1, closeIndex).trim().length > 0;
+    if (!/^\s*$/.test(closeIndent)) {
+      const compact = `${hasMembers ? "," : ""}${JSON.stringify(key)}:${JSON.stringify(value)}`;
+      return `${raw.slice(0, closeIndex)}${compact}${raw.slice(closeIndex)}`;
+    }
+    const propertyIndent = hasMembers ? closeIndent + "  " : "  ";
+    const propertyText = `${JSON.stringify(key)}: ${formatJsonValue(value, propertyIndent)}`;
+    const insertion = `${hasMembers ? "," : ""}\n${propertyIndent}${propertyText}\n${closeIndent}`;
+    return `${raw.slice(0, closeIndex)}${insertion}${raw.slice(closeIndex)}`;
+  }
+
+  const lineStart = raw.lastIndexOf("\n", property.keyStart) + 1;
+  const linePrefix = raw.slice(lineStart, property.keyStart);
+  const propertyIndent = /^\s*$/.test(linePrefix) ? linePrefix : "";
+  if (value !== undefined) {
+    return `${raw.slice(0, property.valueStart)}${formatJsonValue(value, propertyIndent)}${raw.slice(property.valueEnd)}`;
+  }
+
+  let removeStart = propertyIndent.length > 0 ? lineStart : property.keyStart;
+  let removeEnd = property.valueEnd;
+  const afterValue = skipJsonWhitespace(raw, removeEnd);
+  if (raw[afterValue] === ",") {
+    removeEnd = afterValue + 1;
+  } else {
+    let previous = removeStart - 1;
+    while (previous >= 0 && /\s/.test(raw[previous] ?? "")) previous--;
+    if (raw[previous] === ",") removeStart = previous;
+  }
+  return `${raw.slice(0, removeStart)}${raw.slice(removeEnd)}`;
+}
+
+async function writeSettingsJson(
+  settingsPath: string,
+  originalRaw: string | null,
+  settings: Record<string, unknown>,
+  dryRun: boolean,
+): Promise<boolean> {
+  if (dryRun) return false;
+  if (originalRaw === null) return writeJsonObject(settingsPath, settings, false);
+  const next = replaceRootJsonPropertyPreservingBytes(originalRaw, "hooks", settings["hooks"]);
+  if (next === null) throw new Error(`Could not preserve unmanaged settings bytes in ${settingsPath}.`);
+  await writeFile(settingsPath, next, "utf-8");
+  return true;
 }
 
 export async function upsertClaudeHooks(
@@ -72,14 +317,14 @@ export async function upsertClaudeHooks(
 ): Promise<{ changed: boolean; messages: string[] }> {
   const settingsPath = path.join(claudeDir, "settings.json");
   const homeDir = options.homeDir ?? homedir();
-  const { data, corrupt } = await readSettingsJsonSafe(settingsPath);
+  const { data, corrupt, raw } = await readSettingsJsonSafe(settingsPath);
   const messages: string[] = [];
 
   if (corrupt || data === null) {
     const preCmd = buildGuardCommandString(options.vault, options.agentVault, homeDir, GUARD_MARKER);
     const postCmd = buildGuardCommandString(options.vault, options.agentVault, homeDir, POST_GUARD_MARKER);
     messages.push(
-      `WARNING: ${settingsPath} is not valid JSON — hook wiring skipped to avoid data loss.`,
+      `WARNING: ${settingsPath} is not a supported JSON object — hook wiring skipped to avoid data loss.`,
       `Manual step: add these entries to ${settingsPath}:`,
       `  hooks.PreToolUse:  {"matcher":"${HOOK_MATCHER}","hooks":[{"type":"command","command":"${preCmd}"}]}`,
       `  hooks.PostToolUse: {"matcher":"${HOOK_MATCHER}","hooks":[{"type":"command","command":"${postCmd}"}]}`,
@@ -89,6 +334,10 @@ export async function upsertClaudeHooks(
 
   const settings = data;
   const rawHooks = settings["hooks"];
+  if (rawHooks !== undefined && !isHookMap(rawHooks)) {
+    messages.push(`WARNING: ${settingsPath} has unsupported hook metadata — hook wiring skipped to avoid data loss.`);
+    return { changed: false, messages };
+  }
   const hooks: Record<string, unknown[]> = isHookMap(rawHooks) ? rawHooks : {};
   let changed = false;
 
@@ -115,8 +364,11 @@ export async function upsertClaudeHooks(
   }
 
   settings["hooks"] = hooks;
-  if (!options.dryRun) {
-    await writeJsonObject(settingsPath, settings, false);
+  try {
+    await writeSettingsJson(settingsPath, raw, settings, Boolean(options.dryRun));
+  } catch {
+    messages.push(`WARNING: Could not write ${settingsPath}; hook wiring skipped. Add the generated entries manually.`);
+    return { changed: false, messages };
   }
   messages.push(`Wired ${GUARD_MARKER}/${POST_GUARD_MARKER} into ${settingsPath}.`);
   return { changed: true, messages };
@@ -127,17 +379,21 @@ export async function removeClaudeHooks(
   claudeDir: string,
 ): Promise<{ changed: boolean; messages: string[] }> {
   const settingsPath = path.join(claudeDir, "settings.json");
-  const { data, corrupt } = await readSettingsJsonSafe(settingsPath);
+  const { data, corrupt, raw } = await readSettingsJsonSafe(settingsPath);
   const messages: string[] = [];
 
   if (corrupt || data === null) {
-    messages.push(`WARNING: ${settingsPath} is not valid JSON — skipping hook removal.`);
+    messages.push(`WARNING: ${settingsPath} is not a supported JSON object — skipping hook removal.`);
     return { changed: false, messages };
   }
 
   const settings = data;
   const rawHooks = settings["hooks"];
-  if (!isRecord(rawHooks)) {
+  if (rawHooks === undefined) {
+    return { changed: false, messages };
+  }
+  if (!isHookMap(rawHooks)) {
+    messages.push(`WARNING: ${settingsPath} has unsupported hook metadata — hook removal skipped to avoid data loss.`);
     return { changed: false, messages };
   }
   const hooks = rawHooks;
@@ -151,7 +407,8 @@ export async function removeClaudeHooks(
     if (!Array.isArray(arr)) continue;
     const filtered = arr.filter((e) => !isOmsHookEntry(e, marker));
     if (filtered.length < arr.length) {
-      hooks[eventName] = filtered.length > 0 ? filtered : undefined;
+      if (filtered.length > 0) hooks[eventName] = filtered;
+      else delete hooks[eventName];
       changed = true;
     }
   }
@@ -160,18 +417,18 @@ export async function removeClaudeHooks(
     return { changed: false, messages };
   }
 
-  const hasRemainingHooks = Object.values(hooks).some((v) => v !== undefined && Array.isArray(v) && v.length > 0);
+  const hasRemainingHooks = Object.keys(hooks).length > 0;
   if (!hasRemainingHooks) {
     delete settings["hooks"];
   } else {
-    for (const key of Object.keys(hooks)) {
-      if (hooks[key] === undefined) delete hooks[key];
-    }
     settings["hooks"] = hooks;
   }
 
-  if (!options.dryRun) {
-    await writeJsonObject(settingsPath, settings, false);
+  try {
+    await writeSettingsJson(settingsPath, raw, settings, Boolean(options.dryRun));
+  } catch {
+    messages.push(`WARNING: Could not write ${settingsPath}; hook removal skipped. Remove OMS entries manually.`);
+    return { changed: false, messages };
   }
   messages.push(`Removed ${GUARD_MARKER}/${POST_GUARD_MARKER} entries from ${settingsPath}.`);
   return { changed: true, messages };

--- a/src/install/claude.ts
+++ b/src/install/claude.ts
@@ -1,59 +1,185 @@
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { HarnessHostSurface } from "../harness/surface-registry.js";
 import { resolveHostAdapterSource } from "./adapter-source.js";
-import { commandExists, hostHome, isRecord, mcpArgs, mcpServerEntry, readJsonObject, runExternal, writeJsonObject } from "./common.js";
-import { removeClaudeHooks, upsertClaudeHooks } from "./claude-hooks.js";
-import type { HostOperationOptions, HostOperationResult } from "./types.js";
+import { commandExists, hostHome, isRecord, runExternal } from "./common.js";
+import { removeClaudeHooks, replaceRootJsonPropertyPreservingBytes, upsertClaudeHooks } from "./claude-hooks.js";
+import type {
+  ClaudeMcpScope,
+  HostOperationOptions,
+  HostOperationResult,
+  LegacyCleanupResult,
+} from "./types.js";
 
-async function upsertClaudeMcp(options: HostOperationOptions, claudeDir: string): Promise<boolean> {
-  const mcpPath = path.join(claudeDir, "mcp.json");
-  const data = await readJsonObject(mcpPath);
-  const existingServers = data["mcpServers"];
-  const mcpServers = isRecord(existingServers) ? existingServers : {};
-  mcpServers["oms"] = mcpServerEntry(options);
-  data["mcpServers"] = mcpServers;
-  return writeJsonObject(mcpPath, data, Boolean(options.dryRun));
+const CLAUDE_MCP_SCOPES: readonly ClaudeMcpScope[] = ["local", "project", "user"];
+
+function claudeMcpRemoveCommand(scope: ClaudeMcpScope): string {
+  return `claude mcp remove oms --scope ${scope}`;
 }
 
-async function removeClaudeMcp(options: HostOperationOptions, claudeDir: string): Promise<boolean> {
+function classifyCleanupResult(
+  scope: ClaudeMcpScope,
+  result: ReturnType<typeof runExternal>,
+): LegacyCleanupResult {
+  const manualCommand = claudeMcpRemoveCommand(scope);
+  if (result.ok) {
+    return { scope, status: "removed", reasonCode: "legacy_removed", manualCommand };
+  }
+
+  const stderr = result.stderr;
+  const localNotFound =
+    scope === "local" && /No local mcp server found with name:\s*oms/i.test(stderr);
+  const projectNotFound =
+    scope === "project" &&
+    /No MCP server found with name:\s*oms/i.test(stderr) &&
+    /\.mcp\.json|project/i.test(stderr);
+  if (localNotFound || projectNotFound) {
+    return { scope, status: "not_found", reasonCode: "legacy_not_found", manualCommand };
+  }
+
+  return { scope, status: "failed", reasonCode: "legacy_cleanup_failed", manualCommand };
+}
+
+function cleanupMessage(result: LegacyCleanupResult): string {
+  if (result.status === "removed") {
+    return `Claude MCP cleanup (${result.scope}): removed stale oms registration.`;
+  }
+  if (result.status === "not_found") {
+    return `Claude MCP cleanup (${result.scope}): no stale oms registration found.`;
+  }
+  return `WARNING: Claude MCP cleanup (${result.scope}) failed [${result.reasonCode}]. Install continued. Manual step: ${result.manualCommand}`;
+}
+
+function plannedCleanupMessages(dryRun: boolean): string[] {
+  const prefix = dryRun ? "dry-run: would execute" : "planned external cleanup";
+  return CLAUDE_MCP_SCOPES.map((scope) => `Claude MCP cleanup (${scope}): ${prefix} ${claudeMcpRemoveCommand(scope)}.`);
+}
+
+function externalLifecycleFailure(action: "install" | "uninstall", result: ReturnType<typeof runExternal>): string {
+  const reasonCode = result.exitCode === null ? "claude_cli_spawn_failed" : `claude_plugin_${action}_failed`;
+  return `WARNING: Claude plugin ${action} failed [${reasonCode}]. Plugin-owned MCP activation remains a manual step.`;
+}
+
+function runClaudeMcpCleanup(
+  options: HostOperationOptions,
+): { results: LegacyCleanupResult[]; messages: string[]; changed: boolean } {
+  if (options.dryRun) {
+    return { results: [], messages: plannedCleanupMessages(true), changed: false };
+  }
+  if (!options.executeExternal) {
+    return {
+      results: [],
+      messages: [
+        "Claude MCP cleanup was not executed; pass --execute to remove stale registrations through the Claude CLI.",
+        ...plannedCleanupMessages(false),
+      ],
+      changed: false,
+    };
+  }
+  if (!commandExists("claude")) {
+    const results = CLAUDE_MCP_SCOPES.map((scope) => ({
+      scope,
+      status: "failed" as const,
+      reasonCode: "claude_cli_unavailable",
+      manualCommand: claudeMcpRemoveCommand(scope),
+    }));
+    return {
+      results,
+      messages: results.map(cleanupMessage),
+      changed: false,
+    };
+  }
+
+  const results = CLAUDE_MCP_SCOPES.map((scope) => {
+    const result = runExternal("claude", ["mcp", "remove", "oms", "--scope", scope]);
+    return classifyCleanupResult(scope, result);
+  });
+  return {
+    results,
+    messages: results.map(cleanupMessage),
+    changed: results.some((result) => result.status === "removed"),
+  };
+}
+
+async function removeClaudeMcp(
+  options: HostOperationOptions,
+  claudeDir: string,
+): Promise<{ changed: boolean; message?: string }> {
   const mcpPath = path.join(claudeDir, "mcp.json");
-  const data = await readJsonObject(mcpPath);
+  let raw: string;
+  try {
+    raw = await readFile(mcpPath, "utf-8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return { changed: false };
+    return { changed: false, message: `WARNING: Could not read ${mcpPath}; direct MCP cleanup skipped. Remove stale oms manually.` };
+  }
+  let data: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) {
+      return { changed: false, message: `WARNING: ${mcpPath} is not a JSON object; direct MCP cleanup skipped.` };
+    }
+    data = parsed;
+  } catch {
+    return { changed: false, message: `WARNING: ${mcpPath} is malformed JSON; direct MCP cleanup skipped.` };
+  }
   const existingServers = data["mcpServers"];
+  if (existingServers !== undefined && !isRecord(existingServers)) {
+    return { changed: false, message: `WARNING: ${mcpPath} has unsupported mcpServers metadata; direct MCP cleanup skipped.` };
+  }
   if (!isRecord(existingServers) || !("oms" in existingServers)) {
-    return false;
+    return { changed: false };
   }
   delete existingServers["oms"];
-  data["mcpServers"] = existingServers;
-  return writeJsonObject(mcpPath, data, Boolean(options.dryRun));
+  const next = replaceRootJsonPropertyPreservingBytes(raw, "mcpServers", existingServers);
+  if (next === null) {
+    return { changed: false, message: `WARNING: Could not preserve unmanaged MCP config bytes in ${mcpPath}; direct cleanup skipped.` };
+  }
+  if (!options.dryRun) {
+    try {
+      await writeFile(mcpPath, next, "utf-8");
+    } catch {
+      return { changed: false, message: `WARNING: Could not write ${mcpPath}; direct MCP cleanup skipped. Remove stale oms manually.` };
+    }
+  }
+  return { changed: !options.dryRun };
 }
 
 export async function installClaude(options: HostOperationOptions, host: HarnessHostSurface): Promise<HostOperationResult> {
   const claudeDir = hostHome(options.homeDir, ".claude", "OMS_CLAUDE_HOME");
   const pluginPath = resolveHostAdapterSource(options.adapterRoot, host);
   const commands = [
+    ...CLAUDE_MCP_SCOPES.map(claudeMcpRemoveCommand),
     `claude plugin install ${pluginPath}`,
-    `claude mcp add oms -- oms ${mcpArgs(options).join(" ")}`,
   ];
-  const messages = ["Claude Code adapter is installed through Claude's plugin/MCP surfaces."];
-  let changed = false;
+  const messages = [
+    "Claude Code adapter is installed through the plugin-owned MCP surface declared in .mcp.json.",
+  ];
+  const directCleanup = await removeClaudeMcp(options, claudeDir);
+  let changed = directCleanup.changed;
+  if (directCleanup.changed) messages.push("Removed stale direct oms MCP registration from Claude local config.");
+  if (directCleanup.message) messages.push(directCleanup.message);
+  let pluginInstalled = false;
+
+  const cleanup = runClaudeMcpCleanup(options);
+  messages.push(...cleanup.messages);
+  changed = cleanup.changed || changed;
 
   if (options.executeExternal) {
     if (!commandExists("claude")) {
-      messages.push("claude CLI was not found; wrote MCP config only and left plugin command for manual execution.");
+      messages.push("Claude CLI was not found; no plugin or MCP activation was performed. Run the listed plugin command manually.");
     } else if (!options.dryRun) {
-      const externalCommands: [string, ...string[]][] = [
-        ["claude", "plugin", "install", pluginPath],
-        ["claude", "mcp", "add", "oms", "--", "oms", ...mcpArgs(options)],
-      ];
+      const externalCommands: [string, ...string[]][] = [["claude", "plugin", "install", pluginPath]];
       for (const [command, ...args] of externalCommands) {
         const result = runExternal(command, args);
-        messages.push(result.ok ? `Executed: ${result.message}` : `External command failed: ${result.message}`);
+        messages.push(result.ok ? `Executed: ${result.message}` : externalLifecycleFailure("install", result));
         changed = changed || result.ok;
+        pluginInstalled = result.ok;
       }
     }
   }
 
-  changed = (await upsertClaudeMcp(options, claudeDir)) || changed;
+  if (!pluginInstalled) messages.push("Claude plugin was not installed; plugin-owned MCP activation remains a manual step.");
   const hookResult = await upsertClaudeHooks(options, claudeDir);
   changed = hookResult.changed || changed;
   messages.push(...hookResult.messages);
@@ -63,30 +189,37 @@ export async function installClaude(options: HostOperationOptions, host: Harness
     action: "install",
     changed: changed && !options.dryRun,
     skipped: false,
-    paths: [path.join(claudeDir, "mcp.json"), pluginPath],
+    paths: [pluginPath, path.join(claudeDir, "settings.json")],
     commands,
     messages,
+    cleanup: cleanup.results,
   };
 }
 
 export async function uninstallClaude(options: HostOperationOptions): Promise<HostOperationResult> {
   const claudeDir = hostHome(options.homeDir, ".claude", "OMS_CLAUDE_HOME");
-  const commands = ["claude mcp remove oms", "claude plugin uninstall oms"];
+  const commands = [
+    ...CLAUDE_MCP_SCOPES.map(claudeMcpRemoveCommand),
+    "claude plugin uninstall oms",
+  ];
   const messages = ["Claude Code uninstall removes the Oh My Second Brain MCP entry and, when requested, asks Claude CLI to uninstall the plugin."];
-  let changed = await removeClaudeMcp(options, claudeDir);
+  const directCleanup = await removeClaudeMcp(options, claudeDir);
+  let changed = directCleanup.changed;
+  if (directCleanup.message) messages.push(directCleanup.message);
+
+  const cleanup = runClaudeMcpCleanup(options);
+  messages.push(...cleanup.messages);
+  changed = cleanup.changed || changed;
 
   const hookResult = await removeClaudeHooks(options, claudeDir);
   changed = hookResult.changed || changed;
   messages.push(...hookResult.messages);
 
   if (options.executeExternal && commandExists("claude") && !options.dryRun) {
-    const externalCommands: [string, ...string[]][] = [
-      ["claude", "mcp", "remove", "oms"],
-      ["claude", "plugin", "uninstall", "oms"],
-    ];
+    const externalCommands: [string, ...string[]][] = [["claude", "plugin", "uninstall", "oms"]];
     for (const [command, ...args] of externalCommands) {
       const result = runExternal(command, args);
-      messages.push(result.ok ? `Executed: ${result.message}` : `External command failed: ${result.message}`);
+      messages.push(result.ok ? `Executed: ${result.message}` : externalLifecycleFailure("uninstall", result));
       changed = changed || result.ok;
     }
   }
@@ -99,5 +232,6 @@ export async function uninstallClaude(options: HostOperationOptions): Promise<Ho
     paths: [path.join(claudeDir, "mcp.json")],
     commands,
     messages,
+    cleanup: cleanup.results,
   };
 }

--- a/src/install/common.ts
+++ b/src/install/common.ts
@@ -92,12 +92,40 @@ export function mcpServerEntry(options: HostOperationOptions): Record<string, un
   };
 }
 
-export function runExternal(command: string, args: string[]): { ok: boolean; message: string } {
+export interface ExternalCommandResult {
+  readonly ok: boolean;
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly message: string;
+}
+
+export function runExternal(command: string, args: string[]): ExternalCommandResult {
   const result = spawnSync(command, args, { stdio: "pipe", encoding: "utf-8" });
-  if (result.status === 0) return { ok: true, message: `${command} ${args.join(" ")}` };
-  const stderr = result.stderr.trim();
-  const stdout = result.stdout.trim();
-  return { ok: false, message: stderr || stdout || `${command} exited ${result.status ?? "unknown"}` };
+  const stdout = typeof result.stdout === "string" ? result.stdout : "";
+  const stderr = typeof result.stderr === "string" ? result.stderr : "";
+  const exitCode = result.status;
+  const signal = result.signal;
+  if (exitCode === 0) {
+    return {
+      ok: true,
+      exitCode,
+      signal,
+      stdout,
+      stderr,
+      message: `${command} ${args.join(" ")}`,
+    };
+  }
+  const spawnError = result.error instanceof Error ? result.error.message : "";
+  return {
+    ok: false,
+    exitCode,
+    signal,
+    stdout,
+    stderr,
+    message: spawnError || stderr.trim() || stdout.trim() || `${command} exited ${exitCode ?? "unknown"}`,
+  };
 }
 
 function refuseSymlinkedLeaf(target: string): void {

--- a/src/install/hosts.test.ts
+++ b/src/install/hosts.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import {
   runHostOperation,
   formatHostOperationResults,
+  formatHostOperationResultsJson,
   upsertClaudeHooks,
   removeClaudeHooks,
   toShellVaultPath,
@@ -60,7 +61,7 @@ describe("host installer/uninstaller", () => {
     expect(existsSync(path.join(codexSkillsDir, "personal-skill"))).toBe(true);
   });
 
-  it("registers Claude MCP with the installed oms command when executing external install", async () => {
+  it("installs the plugin-owned Claude MCP surface when executing external install", async () => {
     const home = await mkdtemp(path.join(tmpdir(), "oms-install-claude-external-"));
     const binDir = path.join(home, "bin");
     const argvLog = path.join(home, "claude-argv.log");
@@ -96,8 +97,15 @@ describe("host installer/uninstaller", () => {
       });
 
       const executedCommands = (await readFile(argvLog, "utf-8")).trim().split("\n");
-      expect(executedCommands).not.toContain("claude mcp add oms -- npx mcp --vault /tmp/Vault");
-      expect(executedCommands).toContain("claude mcp add oms -- oms mcp --vault /tmp/Vault");
+      expect(executedCommands).toContain("claude mcp remove oms --scope local");
+      expect(executedCommands).toContain("claude mcp remove oms --scope project");
+      expect(executedCommands).toContain("claude mcp remove oms --scope user");
+      expect(executedCommands.some((command) => command.startsWith("claude plugin install "))).toBe(true);
+      expect(executedCommands.every((command) => !command.includes("mcp add oms"))).toBe(true);
+      const pluginManifest = await readFile(path.join(adapterRoot, "claude-code", ".claude-plugin", "plugin.json"), "utf-8");
+      const pluginMcp = await readFile(path.join(adapterRoot, "claude-code", ".mcp.json"), "utf-8");
+      expect(pluginManifest).toContain('"mcpServers": "./.mcp.json"');
+      expect(pluginMcp).toContain('"oms"');
     } finally {
       if (originalPath === undefined) {
         delete process.env.PATH;
@@ -110,6 +118,133 @@ describe("host installer/uninstaller", () => {
         process.env.CLAUDE_ARGV_LOG = originalArgvLog;
       }
     }
+  });
+
+  it("continues plugin installation when one scoped cleanup fails", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-install-claude-cleanup-failure-"));
+    const binDir = path.join(home, "bin");
+    const argvLog = path.join(home, "claude-argv.log");
+    const claudePath = path.join(binDir, "claude");
+    const originalPath = process.env.PATH;
+    const originalArgvLog = process.env.CLAUDE_ARGV_LOG;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      claudePath,
+      [
+        "#!/bin/sh",
+        "printf 'claude' >> \"$CLAUDE_ARGV_LOG\"",
+        "for arg in \"$@\"; do printf ' %s' \"$arg\" >> \"$CLAUDE_ARGV_LOG\"; done",
+        "printf '\\n' >> \"$CLAUDE_ARGV_LOG\"",
+        "if [ \"$1\" = \"mcp\" ] && [ \"$5\" = \"project\" ]; then",
+        "  printf 'permission denied\\n' >&2",
+        "  exit 7",
+        "fi",
+        "if [ \"$1\" = \"mcp\" ] && [ \"$5\" = \"user\" ]; then",
+        "  printf 'No local mcp server found with name: oms\\n' >&2",
+        "  exit 1",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      "utf-8",
+    );
+    await chmod(claudePath, 0o755);
+
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+    process.env.CLAUDE_ARGV_LOG = argvLog;
+
+    try {
+      const [result] = await runHostOperation({
+        action: "install",
+        runtime: "claude",
+        vault: "/tmp/Vault",
+        homeDir: home,
+        adapterRoot,
+        executeExternal: true,
+      });
+
+      expect(result.cleanup).toEqual([
+        expect.objectContaining({ scope: "local", status: "removed" }),
+        expect.objectContaining({ scope: "project", status: "failed", reasonCode: "legacy_cleanup_failed" }),
+        expect.objectContaining({ scope: "user", status: "failed", reasonCode: "legacy_cleanup_failed" }),
+      ]);
+      expect(result.messages.some((message) => message.includes("Install continued"))).toBe(true);
+      expect((await readFile(argvLog, "utf-8"))).toContain("claude plugin install");
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      if (originalArgvLog === undefined) delete process.env.CLAUDE_ARGV_LOG;
+      else process.env.CLAUDE_ARGV_LOG = originalArgvLog;
+    }
+  });
+
+  it("dry-run lists all scoped Claude cleanup attempts without mutating", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-install-claude-cleanup-dry-"));
+    const [result] = await runHostOperation({
+      action: "install",
+      runtime: "claude",
+      vault: "/tmp/Vault",
+      homeDir: home,
+      adapterRoot,
+      dryRun: true,
+      executeExternal: true,
+    });
+
+    expect(result.messages).toEqual(expect.arrayContaining([
+      expect.stringContaining("claude mcp remove oms --scope local"),
+      expect.stringContaining("claude mcp remove oms --scope project"),
+      expect.stringContaining("claude mcp remove oms --scope user"),
+    ]));
+    expect(existsSync(path.join(home, ".claude", "mcp.json"))).toBe(false);
+  });
+
+  it("reports manual plugin activation when Claude CLI is unavailable", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-install-claude-no-cli-"));
+    const originalPath = process.env.PATH;
+    process.env.PATH = path.join(home, "missing-bin");
+    try {
+      const [result] = await runHostOperation({
+        action: "install",
+        runtime: "claude",
+        vault: "/tmp/Vault",
+        homeDir: home,
+        adapterRoot,
+        executeExternal: true,
+      });
+
+      expect(result.cleanup).toEqual([
+        expect.objectContaining({ scope: "local", status: "failed", reasonCode: "claude_cli_unavailable" }),
+        expect.objectContaining({ scope: "project", status: "failed", reasonCode: "claude_cli_unavailable" }),
+        expect.objectContaining({ scope: "user", status: "failed", reasonCode: "claude_cli_unavailable" }),
+      ]);
+      expect(result.messages.join(" ")).toContain("no plugin or MCP activation was performed");
+      expect(result.messages.join(" ")).not.toContain("wrote MCP config");
+      expect(existsSync(path.join(home, ".claude", "mcp.json"))).toBe(false);
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+    }
+  });
+
+  it("removes a stale direct Claude MCP entry without rewriting unrelated config bytes", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-install-claude-mcp-migrate-"));
+    const claudeDir = path.join(home, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    const original = '{"custom":"  unmanaged spacing  ","mcpServers":{"oms":{"command":"oms"},"other":{"command":"keep"}}}';
+    const mcpPath = path.join(claudeDir, "mcp.json");
+    await writeFile(mcpPath, original, "utf-8");
+
+    await runHostOperation({
+      action: "install",
+      runtime: "claude",
+      vault: "/tmp/Vault",
+      homeDir: home,
+      adapterRoot,
+    });
+    const updated = await readFile(mcpPath, "utf-8");
+    expect(updated).not.toContain('"oms":');
+    const parsed = JSON.parse(updated) as { mcpServers: { other: { command: string } }; custom: string };
+    expect(parsed.mcpServers.other.command).toBe("keep");
+    expect(parsed.custom).toBe("  unmanaged spacing  ");
   });
 
   it("installs and uninstalls Hermes native skill bundle and MCP config", async () => {
@@ -135,6 +270,24 @@ describe("host installer/uninstaller", () => {
     expect(formatHostOperationResults(results, true)).toContain("dry-run");
     expect(existsSync(path.join(home, ".codex"))).toBe(false);
     expect(existsSync(path.join(home, ".hermes"))).toBe(false);
+  });
+
+  it("renders cleanup outcomes as stable JSON", async () => {
+    const results = await runHostOperation({
+      action: "install",
+      runtime: "claude",
+      vault: "/tmp/Vault",
+      homeDir: await mkdtemp(path.join(tmpdir(), "oms-install-json-")),
+      adapterRoot,
+      dryRun: true,
+    });
+    const parsed = JSON.parse(formatHostOperationResultsJson(results, true)) as {
+      dryRun: boolean;
+      results: Array<{ cleanup: unknown[]; messages: string[] }>;
+    };
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.results[0]?.cleanup).toEqual([]);
+    expect(parsed.results[0]?.messages.join(" ")).toContain("scope local");
   });
 });
 
@@ -164,9 +317,46 @@ describe("Claude Code hook wiring helpers", () => {
   });
 
   it("isOmsHookEntry detects marker in hook command", () => {
-    const entry = { matcher: ".*", hooks: [{ type: "command", command: "OMS_VAULT=$HOME/V oms-guard" }] };
+    const entry = { matcher: "Write|Edit|NotebookEdit", hooks: [{ type: "command", command: 'OMS_VAULT="$HOME/V" oms-guard' }] };
     expect(isOmsHookEntry(entry, "oms-guard")).toBe(true);
     expect(isOmsHookEntry(entry, "oms-post-guard")).toBe(false);
+  });
+
+  it("does not claim a user hook with a suffix after the quoted assignment", () => {
+    const entry = {
+      matcher: ".*",
+      hooks: [{ type: "command", command: 'OMS_VAULT="/x"suffix oms-guard' }],
+    };
+    expect(isOmsHookEntry(entry, "oms-guard")).toBe(false);
+  });
+
+  it("does not claim escaped-quote assignments", () => {
+    const entry = {
+      matcher: ".*",
+      hooks: [{ type: "command", command: 'OMS_VAULT="/x\\q" oms-guard' }],
+    };
+    expect(isOmsHookEntry(entry, "oms-guard")).toBe(false);
+  });
+
+  it("does not claim a matching command under a different hook shape", () => {
+    const wrongMatcher = { matcher: ".*", hooks: [{ type: "command", command: 'OMS_VAULT="/x" oms-guard' }] };
+    const multipleHooks = {
+      matcher: "Write|Edit|NotebookEdit",
+      hooks: [
+        { type: "command", command: 'OMS_VAULT="/x" oms-guard' },
+        { type: "command", command: "other-hook" },
+      ],
+    };
+    const wrongType = { matcher: "Write|Edit|NotebookEdit", hooks: [{ type: "prompt", command: 'OMS_VAULT="/x" oms-guard' }] };
+    const extraField = { matcher: "Write|Edit|NotebookEdit", hooks: [{ type: "command", command: 'OMS_VAULT="/x" oms-guard', owner: "user" }] };
+    const embeddedHome = { matcher: "Write|Edit|NotebookEdit", hooks: [{ type: "command", command: 'OMS_VAULT="prefix$HOME/foo" oms-guard' }] };
+    const emptyAssignment = { matcher: "Write|Edit|NotebookEdit", hooks: [{ type: "command", command: 'OMS_VAULT="" oms-guard' }] };
+    expect(isOmsHookEntry(wrongMatcher, "oms-guard")).toBe(false);
+    expect(isOmsHookEntry(multipleHooks, "oms-guard")).toBe(false);
+    expect(isOmsHookEntry(wrongType, "oms-guard")).toBe(false);
+    expect(isOmsHookEntry(extraField, "oms-guard")).toBe(false);
+    expect(isOmsHookEntry(embeddedHome, "oms-guard")).toBe(false);
+    expect(isOmsHookEntry(emptyAssignment, "oms-guard")).toBe(false);
   });
 });
 
@@ -221,6 +411,27 @@ describe("upsertClaudeHooks / removeClaudeHooks", () => {
     expect(JSON.stringify(preArr)).toContain("other-tool");
   });
 
+  it("preserves unmanaged root JSON bytes while splicing hooks", async () => {
+    const claudeDir = await makeClaudeDir("bytes");
+    const home = path.dirname(claudeDir);
+    const original = [
+      "{",
+      '  "permissions": { "allow": ["keep-exactly"] },',
+      '  "hooks": { "PreToolUse": [] },',
+      '  "custom": "  unmanaged spacing  "',
+      "}",
+      "",
+    ].join("\n");
+    const settingsPath = path.join(claudeDir, "settings.json");
+    await writeFile(settingsPath, original, "utf-8");
+
+    await upsertClaudeHooks({ vault: path.join(home, "Vault"), homeDir: home }, claudeDir);
+    const updated = await readFile(settingsPath, "utf-8");
+
+    expect(updated).toContain('  "permissions": { "allow": ["keep-exactly"] },');
+    expect(updated).toContain('  "custom": "  unmanaged spacing  "');
+  });
+
   it("removeClaudeHooks removes only OMS entries, leaves others intact", async () => {
     const claudeDir = await makeClaudeDir("remove");
     const home = path.dirname(claudeDir);
@@ -249,6 +460,82 @@ describe("upsertClaudeHooks / removeClaudeHooks", () => {
     expect(result.messages[0]).toContain("WARNING");
     const raw = await readFile(settingsPath, "utf-8");
     expect(raw).toBe("{ this is not valid json");
+  });
+
+  it("does not overwrite valid non-object settings.json", async () => {
+    const claudeDir = await makeClaudeDir("non-object");
+    const settingsPath = path.join(claudeDir, "settings.json");
+    await writeFile(settingsPath, "[]\n", "utf-8");
+    const result = await upsertClaudeHooks({ vault: "/tmp/Vault" }, claudeDir);
+    expect(result.changed).toBe(false);
+    expect(result.messages[0]).toContain("supported JSON object");
+    expect(await readFile(settingsPath, "utf-8")).toBe("[]\n");
+  });
+
+  it("does not overwrite unsupported hook metadata", async () => {
+    const claudeDir = await makeClaudeDir("metadata");
+    const settingsPath = path.join(claudeDir, "settings.json");
+    await writeFile(settingsPath, JSON.stringify({ hooks: { metadata: "keep" } }, null, 2), "utf-8");
+    const result = await upsertClaudeHooks({ vault: "/tmp/Vault" }, claudeDir);
+    expect(result.changed).toBe(false);
+    expect(result.messages[0]).toContain("unsupported hook metadata");
+    expect(JSON.parse(await readFile(settingsPath, "utf-8"))).toEqual({ hooks: { metadata: "keep" } });
+  });
+
+  it("keeps compact settings JSON valid during hook removal", async () => {
+    const claudeDir = await makeClaudeDir("compact");
+    const settingsPath = path.join(claudeDir, "settings.json");
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        permissions: 1,
+        hooks: {
+          PreToolUse: [{ matcher: "Write|Edit|NotebookEdit", hooks: [{ type: "command", command: 'OMS_VAULT="/x" oms-guard' }] }],
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await removeClaudeHooks({}, claudeDir);
+    expect(result.changed).toBe(true);
+    const parsed = JSON.parse(await readFile(settingsPath, "utf-8")) as { hooks?: unknown; permissions: number };
+    expect(parsed.hooks).toBeUndefined();
+    expect(parsed.permissions).toBe(1);
+  });
+
+  it("keeps generated quoted vault paths idempotent", async () => {
+    const claudeDir = await makeClaudeDir("quoted-vault");
+    const home = path.dirname(claudeDir);
+    const options = { vault: path.join(home, 'Vault"Quote'), homeDir: home };
+    await upsertClaudeHooks(options, claudeDir);
+    await upsertClaudeHooks(options, claudeDir);
+    const installed = JSON.parse(await readFile(path.join(claudeDir, "settings.json"), "utf-8")) as {
+      hooks: { PreToolUse: unknown[]; PostToolUse: unknown[] };
+    };
+    expect(installed.hooks.PreToolUse).toHaveLength(1);
+    expect(installed.hooks.PostToolUse).toHaveLength(1);
+
+    await removeClaudeHooks({}, claudeDir);
+    const removed = JSON.parse(await readFile(path.join(claudeDir, "settings.json"), "utf-8")) as { hooks?: unknown };
+    expect(removed.hooks).toBeUndefined();
+  });
+
+  it("reports malformed direct MCP config without mutating it", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-install-claude-mcp-invalid-"));
+    const claudeDir = path.join(home, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    const mcpPath = path.join(claudeDir, "mcp.json");
+    await writeFile(mcpPath, "[]\n", "utf-8");
+
+    const [result] = await runHostOperation({
+      action: "install",
+      runtime: "claude",
+      vault: "/tmp/Vault",
+      homeDir: home,
+      adapterRoot,
+    });
+    expect(result.messages.join(" ")).toContain("not a JSON object");
+    expect(await readFile(mcpPath, "utf-8")).toBe("[]\n");
   });
 
   it("install+uninstall Claude runtime writes and then removes hooks from settings.json", async () => {

--- a/src/install/hosts.ts
+++ b/src/install/hosts.ts
@@ -17,6 +17,7 @@ export {
   buildGuardCommandString,
   isOmsHookEntry,
   removeClaudeHooks,
+  replaceRootJsonPropertyPreservingBytes,
   toShellVaultPath,
   upsertClaudeHooks,
 } from "./claude-hooks.js";
@@ -70,4 +71,27 @@ export function formatHostOperationResults(
     ];
     return lines.join("\n");
   }).join("\n\n");
+}
+
+export function formatHostOperationResultsJson(
+  results: readonly HostOperationResult[],
+  dryRun = false,
+): string {
+  return JSON.stringify(
+    {
+      dryRun,
+      results: results.map((result) => ({
+        runtime: result.runtime,
+        action: result.action,
+        changed: result.changed,
+        skipped: result.skipped,
+        paths: result.paths,
+        commands: result.commands,
+        messages: result.messages,
+        cleanup: result.cleanup ?? [],
+      })),
+    },
+    null,
+    2,
+  );
 }

--- a/src/install/types.ts
+++ b/src/install/types.ts
@@ -4,6 +4,16 @@ export type HostRuntime = HarnessHostRuntime;
 export type RuntimeSelection = HostRuntime | "auto" | "all";
 export type HostAction = "install" | "uninstall";
 
+export type ClaudeMcpScope = "local" | "project" | "user";
+export type LegacyCleanupStatus = "removed" | "not_found" | "failed";
+
+export interface LegacyCleanupResult {
+  readonly scope: ClaudeMcpScope;
+  readonly status: LegacyCleanupStatus;
+  readonly reasonCode: string;
+  readonly manualCommand: string;
+}
+
 export interface HostOperationOptions {
   readonly action: HostAction;
   readonly runtime: RuntimeSelection;
@@ -25,4 +35,5 @@ export interface HostOperationResult {
   readonly paths: string[];
   readonly commands: string[];
   readonly messages: string[];
+  readonly cleanup?: readonly LegacyCleanupResult[];
 }

--- a/src/setup.e2e.test.ts
+++ b/src/setup.e2e.test.ts
@@ -188,9 +188,7 @@ describe("runSetup --yes E2E", () => {
 
     expect(plan.pluginPath).toContain("adapters/claude-code");
     expect(plan.pluginInstallCommand).toContain("claude plugin install");
-    expect(plan.mcpRegistrationCommand).toBe(
-      "claude mcp add oms -- oms mcp --vault '/tmp/My Vault'",
-    );
+    expect(plan.pluginMcpAsset).toContain("adapters/claude-code/.mcp.json");
     expect(plan.mcpRuntimeStatus).toBe("read-status-runtime");
   });
 });


### PR DESCRIPTION
## Summary
- make Claude MCP registration plugin-owned through the bundled `.mcp.json` surface
- clean stale local/project/user registrations independently with stable failure reporting
- preserve unmanaged settings/config bytes and fail closed on ambiguous hooks/configs
- add structured host JSON output and update-reconcile/dry-run regression coverage

## Verification
- `npm run lint`
- `npm run build`
- `npm test` (55 passed, 1 skipped)
- `npm run release:artifact-smoke`
- Architect and Executor red-team review: CLEAR/APPROVE, zero blockers