### PR TITLE
feat(write): verified-target write kernel enforcing the global vault target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ after editing imports.
 - The active convention is **user-owned**: resolved from `vault/.oms/` at runtime.
 - Oh My Second Brain ships read-only **defaults** in `core/ontology/`.
 - Enforcement policy: `onViolation: warn` for doctor/audit reporting. MCP `write` rejects contract violations and does not change the disk.
+- Write target policy: `write` demands a verified target vault (`explicit` > local vault `.oms` > bridge `links.yaml` > `OMS_VAULT` > `~/.oms/config.yaml`). A `cwd`-inferred target is read-only and writes are rejected. See [docs/verified-target.md](./docs/verified-target.md).
 - Schema policy: `additionalProperties: preserve` — unknown fields are kept, not rejected.
 - Never change these defaults to blocking/error without an explicit product decision.
 

--- a/docs/verified-target.md
+++ b/docs/verified-target.md
@@ -1,0 +1,166 @@
+# Verified-Target Writes
+
+Reading a vault is safe from anywhere. Writing is not. If an MCP server boots in `~/Documents` and an agent asks it to capture a note, "wherever the process happens to be" is the wrong answer. Oh My Second Brain's write surface therefore refuses to guess: a note is persisted only into a vault that was resolved from a trusted source, and only after the note that landed on disk has been read back and re-checked.
+
+This page describes the write kernel, the global vault registry it leans on, and every rejection it can return. Read tools and CLI read commands (`audit`, `doctor`, `lint`, semantic search) are unchanged and still run anywhere.
+
+## The write loop
+
+Every `write` call runs the same four phases.
+
+**1. Prepare.** Resolve the target vault and its resolution source, load the active ontology, plan the note path (explicit `notePath`, or concept plus folder plus filename), and evaluate the concept contract against the frontmatter you supplied.
+
+**2. Write Attempt.** Render the staged note in memory: frontmatter plus body, exactly as the file will hold it. Nothing touches disk yet.
+
+**3. Evaluation.** Two gates. Before persisting, the staged render is re-parsed and re-checked against the concept contract, which catches values that don't survive the render unchanged. After persisting, the file is read back off disk, the contract runs again on the persisted frontmatter, and the persisted body is compared against what was staged.
+
+**4. Receipt.** A write that clears both gates returns a receipt naming the vault, the resolution source, and the note path. No receipt, no persisted note.
+
+### Admission Rules vs Acceptance Criteria
+
+The gates are split by when they run and what they protect.
+
+| | Admission Rules | Acceptance Criteria |
+| --- | --- | --- |
+| When | Before any disk mutation | Pre-persist on the staged render, post-persist on the file |
+| Checks | Target verification, path safety, mode preconditions, overwrite safety, concept binding | Frontmatter against the concept contract, body content and intent, post-write read-back |
+| Failure means | Zero files created or modified | Pre-persist: nothing written. Post-persist: the file is left in place, never auto-deleted |
+
+Admission answers "may I write?". Acceptance answers "did it come out right?". Splitting them is what guarantees a refusal never leaves a half-written note behind.
+
+Concretely, admission verifies:
+
+- **Target** the vault came from a trusted resolution source, and a globally registered vault still holds a `.oms` ontology.
+- **Path** the note path is vault-relative, ends in `.md`, stays inside the vault, and avoids hidden or internal folders.
+- **Mode** `append` and `update` carry a `notePath`; `update` carries frontmatter, a body, or both; `create` carries a body.
+- **Overwrite** `create` refuses an existing note; `append` and `update` refuse a missing one.
+- **Binding** for `append` and `update`, the note path resolves to a folder bound to a concept in `taxonomy.yaml`. A `create` that matches no binding isn't rejected at all: it comes back as an `inbox` routing plan instead.
+
+Acceptance verifies:
+
+- The frontmatter satisfies the concept's required fields, types, and declared intent.
+- The staged render survives round-tripping without dropping or mangling contract fields.
+- The staged body isn't empty.
+- The persisted file, re-read from disk, still satisfies the contract and contains the intended body.
+
+## The global vault registry
+
+`~/.oms/config.yaml` remembers which vault is yours, so an MCP server started outside a vault still has a verified target.
+
+```yaml
+version: 1
+vault: /Users/you/Obsidian/second-brain
+```
+
+Two fields, both required in practice:
+
+- `version` an integer, currently `1`. Defaults to `1` when absent.
+- `vault` an absolute path, or a `~/...` path that gets expanded at read time. A bare relative value like `../notes` is rejected loudly, because it would resolve against whatever directory the process started in, which is the exact bug this file exists to prevent.
+
+A missing file is fine and simply means "no global target". A file that exists but is malformed (bad YAML, not a mapping, missing `vault`, relative `vault`) is a hard error naming the config path and telling you to run `oms setup`.
+
+**Who writes it:**
+
+- `oms setup` registers the vault it set up, overwriting any previous entry. This is the explicit "this is my vault" command.
+- `oms install --vault <path>` registers that vault the same way.
+- `oms install` without `--vault` backfills from `OMS_VAULT` when that variable points at a real directory, and only when no config exists yet. It never overwrites an existing entry, not even a corrupt one.
+
+Registry write-back is never fatal. If it fails, you get an `[oms] warning:` line on stderr and the command continues.
+
+There is one primary vault. Multiple registered vaults are not implemented.
+
+## Resolution precedence
+
+`resolveEffectiveVault` picks the target in this order, first match wins:
+
+| Rank | Source | Where it comes from | Write surface |
+| --- | --- | --- | --- |
+| 1 | `explicit` | `--vault <path>` on the command line | Verified |
+| 2 | `vault` | Local vault ontology: `.oms/concepts/` or `.oms/taxonomy.yaml` in the current directory | Verified |
+| 3 | `bridge` | Local bridge record: `.oms/links.yaml` | Verified |
+| 4 | `env` | `OMS_VAULT` environment variable | Verified |
+| 5 | `global` | `~/.oms/config.yaml` | Verified, if the registered path still holds a `.oms` ontology |
+| 6 | `cwd` | Fallback to the starting directory | **Unverified**, writes rejected |
+
+The first two `.oms` profiles never collide because resolution is content-based: a directory holding concepts or a taxonomy is a vault, a directory holding `links.yaml` is a bridge.
+
+`cwd` is a read-only fallback. Every read tool works fine on it. The `write` tool rejects with `target-unverified` rather than creating a note in whatever directory the server booted from. `oms mcp` still starts normally on a `cwd` target, since refusing to boot would break the read tools; only the write surface is gated. You can see the posture in the `oms_graph_status` response, whose `writeTools` field reads `write-disabled-target-unverified` on a `cwd` target and `write-gated-by-verified-target-and-contract` otherwise.
+
+## Rejection codes
+
+Every refusal returns a structured payload:
+
+```json
+{
+  "stage": "admission",
+  "code": "target-unverified",
+  "message": "Refusing to write: the target vault was inferred from the current directory ...",
+  "recoverable": true,
+  "remediation": "run `oms setup` in your Obsidian vault (or set OMS_VAULT / register the vault in ~/.oms/config.yaml), then retry"
+}
+```
+
+`recoverable: true` means retrying with corrected inputs can succeed without touching anything outside the call. `recoverable: false` means the environment or the vault itself needs attention first.
+
+| Code | Stage | Recoverable | What happened | Remediation |
+| --- | --- | --- | --- | --- |
+| `target-unverified` | admission | `true` | The vault was inferred from the current directory, which is not a verified target | Run `oms setup` in your vault, set `OMS_VAULT`, or register the vault in `~/.oms/config.yaml`, then retry |
+| `target-invalid` | admission | `false` | The globally registered vault has no `.oms` ontology (stale pointer) | Point `~/.oms/config.yaml` at your real vault, or run `oms setup` in that vault |
+| `path-unsafe` | admission | `true` | The note path escapes the vault, isn't `.md`, or targets a hidden or internal folder | Pass a vault-relative `notePath` ending in `.md` that stays inside the vault |
+| `note-exists` | admission | `false` | `create` was asked to overwrite an existing note | Use mode `append` or `update`, or choose a different filename |
+| `note-missing` | admission | `false` | `append` or `update` targeted a note that isn't there | Create the note first with mode `create`, or correct `notePath` |
+| `concept-unbound` | admission | `false` | The note path doesn't resolve to a concept binding | Move the note into a folder bound to a concept in `taxonomy.yaml`, or target an existing bound note |
+| `contract-violation` | admission (missing fields) / acceptance (staged render) | `true` | The frontmatter doesn't satisfy the concept contract, or the values don't survive the render unchanged | Provide or correct the fields named in the message, then retry |
+| `body-missing` | admission (no `body` argument) / acceptance (staged render is empty) | `true` | `create` was called without a body, or the rendered note carries no body content | Pass a non-empty `body`, then retry |
+| `args-invalid` | admission | `true` | Required arguments for the mode are missing (`notePath` for `append`/`update`, frontmatter or body for `update`) | Pass the missing argument, then retry |
+| `postcondition-failed` | acceptance | `false` | The persisted file failed re-validation: frontmatter broke the contract, or the body doesn't match what was staged | Inspect the persisted file (it was **not** removed) and repair or delete it before retrying |
+
+Contract-fixable results come back with `status: "ask"` and carry a `contract-violation` rejection alongside `missingFields`, so an agent can ask you for the missing values and retry. Everything else that refuses comes back with `status: "rejected"`.
+
+## Receipts
+
+A successful write carries a receipt. It's how you confirm where the note actually landed without trusting the agent's narration.
+
+| Field | Meaning |
+| --- | --- |
+| `resolvedVault` | Absolute path of the vault the note was written into |
+| `resolutionSource` | Which rule picked that vault: `explicit`, `vault`, `bridge`, `env`, or `global` |
+| `notePath` | Vault-relative path of the note |
+| `mode` | `create`, `append`, or `update` |
+| `concept` | The bound concept name, or `null` |
+| `postconditionVerified` | Always `true` on a receipt: the file was re-read and re-validated after persisting |
+
+Receipts are issued only for persisted, postcondition-verified writes. A `dryRun` gets no receipt because nothing was persisted. An `inbox` routing plan gets neither a receipt nor a rejection, since it's a suggestion rather than a write.
+
+Independently of the receipt, every MCP `write` response also carries top-level `resolvedVault` and `resolutionSource` keys, so even a rejection tells you which vault the server was aiming at.
+
+## Migration
+
+If you installed Oh My Second Brain before verified-target writes shipped, you have no `~/.oms/config.yaml`. Reads keep working, and writes from inside your vault keep working. Writes from an MCP server started outside a vault will be rejected with `target-unverified` until you register the vault once:
+
+```bash
+cd /path/to/your/vault
+oms setup
+```
+
+Or let the installer backfill from your existing environment variable:
+
+```bash
+OMS_VAULT=/path/to/your/vault oms install
+```
+
+The backfill only fires when no global config exists yet, so re-running install won't clobber a vault you registered deliberately. Verify either way:
+
+```bash
+cat ~/.oms/config.yaml
+```
+
+## Adapter parity
+
+The fix is entirely server-side. **No adapter files change.**
+
+- `adapters/claude-code` keeps `.mcp.json` with `args: ["mcp"]`. The server now resolves the vault from the global registry instead of the launch directory, which is exactly the behavior this registration always wanted.
+- `adapters/codex` keeps its `--vault .` registration, which resolves as `explicit` and was never affected.
+- `adapters/hermes` registers the same `oms mcp` command through `~/.hermes/config.yaml`; nothing to change.
+
+Related but not fixed here: issue #56, where the Claude plugin registers a bare user-scoped MCP server rather than a plugin-owned one and ships no usable write skill. That's a packaging and skill-surface problem in the adapter layer. Verified-target writes make the bare registration behave correctly at runtime, but they don't turn it into a plugin-owned server or add the missing write skill.

--- a/src/capture/safe.test.ts
+++ b/src/capture/safe.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, afterEach } from "vitest";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { cp, mkdtemp, readFile, rm } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { loadOntology } from "../core/ontology/loader.js";
 import type { Concept, Ontology } from "../core/ontology/types.js";
-import { commitCapture, prepareCapture, safeVaultNotePath, writeNote } from "./safe.js";
+import {
+  commitCapture,
+  evaluateStagedNote,
+  prepareCapture,
+  safeVaultNotePath,
+  writeNote,
+} from "./safe.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -98,6 +104,7 @@ describe("safe capture", () => {
     await expect(
       commitCapture({
         vault: tmpVault,
+        source: "vault",
         ontology,
         notePath,
         frontmatter,
@@ -109,6 +116,7 @@ describe("safe capture", () => {
     await expect(
       commitCapture({
         vault: tmpVault,
+        source: "vault",
         ontology,
         notePath,
         frontmatter,
@@ -124,6 +132,7 @@ describe("safe capture", () => {
     await expect(
       commitCapture({
         vault: tmpVault,
+        source: "vault",
         ontology,
         notePath: "../outside.md",
         frontmatter,
@@ -172,7 +181,7 @@ describe("writeNote kernel", () => {
     tmpVault = await mkdtemp(path.join(tmpdir(), "oms-write-ask-"));
     const ontology = testOntology();
     const missing = await writeNote({
-      vault: tmpVault,
+      target: { vault: tmpVault, source: "vault" },
       ontology,
       mode: "create",
       dryRun: false,
@@ -185,7 +194,7 @@ describe("writeNote kernel", () => {
     expect(missing.fields.map((field) => field.name)).toContain("source-url");
 
     const badEnum = await writeNote({
-      vault: tmpVault,
+      target: { vault: tmpVault, source: "vault" },
       ontology,
       mode: "create",
       dryRun: false,
@@ -206,7 +215,7 @@ describe("writeNote kernel", () => {
     const ontology = testOntology();
     const notePath = "references/new-book.md";
     const created = await writeNote({
-      vault: tmpVault,
+      target: { vault: tmpVault, source: "vault" },
       ontology,
       mode: "create",
       dryRun: false,
@@ -219,9 +228,14 @@ describe("writeNote kernel", () => {
       body: "Initial body.",
     });
     expect(created).toMatchObject({ status: "written", mode: "create", notePath });
+    expect(created.receipt).toMatchObject({
+      mode: "create",
+      notePath,
+      postconditionVerified: true,
+    });
 
     const appended = await writeNote({
-      vault: tmpVault,
+      target: { vault: tmpVault, source: "vault" },
       ontology,
       mode: "append",
       dryRun: false,
@@ -229,9 +243,10 @@ describe("writeNote kernel", () => {
       body: "Appended body.",
     });
     expect(appended).toMatchObject({ status: "written", mode: "append", notePath });
+    expect(appended.receipt).toMatchObject({ mode: "append", postconditionVerified: true });
 
     const updated = await writeNote({
-      vault: tmpVault,
+      target: { vault: tmpVault, source: "vault" },
       ontology,
       mode: "update",
       dryRun: false,
@@ -239,6 +254,7 @@ describe("writeNote kernel", () => {
       frontmatter: { status: "published" },
     });
     expect(updated.status).toBe("written");
+    expect(updated.receipt).toMatchObject({ mode: "update", postconditionVerified: true });
     expect(updated.frontmatter["my-rating"]).toBe(5);
     expect(updated.frontmatter["status"]).toBe("published");
 
@@ -254,7 +270,7 @@ describe("writeNote kernel", () => {
     const ontology = testOntology();
     const notePath = "references/keep.md";
     await writeNote({
-      vault: tmpVault,
+      target: { vault: tmpVault, source: "vault" },
       ontology,
       mode: "create",
       dryRun: false,
@@ -267,7 +283,7 @@ describe("writeNote kernel", () => {
     });
 
     const rejected = await writeNote({
-      vault: tmpVault,
+      target: { vault: tmpVault, source: "vault" },
       ontology,
       mode: "update",
       dryRun: false,
@@ -285,7 +301,7 @@ describe("writeNote kernel", () => {
   it("rejects an explicit unsafe notePath instead of writing", async () => {
     tmpVault = await mkdtemp(path.join(tmpdir(), "oms-write-path-"));
     const rejected = await writeNote({
-      vault: tmpVault,
+      target: { vault: tmpVault, source: "vault" },
       ontology: testOntology(),
       mode: "create",
       dryRun: false,
@@ -301,3 +317,659 @@ describe("writeNote kernel", () => {
   });
 });
 
+
+describe("writeNote admission rules", () => {
+  const goodFrontmatter = {
+    title: "Admission",
+    "source-url": "https://example.com/admission",
+  };
+
+  it("rejects an unverified cwd target without touching disk", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-cwd-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "cwd" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath: "references/cwd.md",
+      frontmatter: goodFrontmatter,
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("rejected");
+    expect(result.rejection?.stage).toBe("admission");
+    expect(result.rejection?.code).toBe("target-unverified");
+    expect(result.rejection?.recoverable).toBe(true);
+    expect(result.rejection?.remediation).toContain("oms setup");
+    expect(result.receipt).toBeUndefined();
+    expect(await readdir(tmpVault)).toEqual([]);
+  });
+
+  it("rejects an unverified cwd target for append and update too", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-cwd-modes-"));
+    for (const mode of ["append", "update"] as const) {
+      const result = await writeNote({
+        target: { vault: tmpVault, source: "cwd" },
+        ontology: testOntology(),
+        mode,
+        dryRun: false,
+        notePath: "references/cwd.md",
+        frontmatter: goodFrontmatter,
+        body: "Body.",
+      });
+      expect(result.status).toBe("rejected");
+      expect(result.rejection?.code).toBe("target-unverified");
+      expect(result.mode).toBe(mode);
+    }
+    expect(await readdir(tmpVault)).toEqual([]);
+  });
+
+  it("rejects a global target whose vault lacks a .oms ontology", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-global-stale-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "global" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath: "references/stale.md",
+      frontmatter: goodFrontmatter,
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("rejected");
+    expect(result.rejection?.stage).toBe("admission");
+    expect(result.rejection?.code).toBe("target-invalid");
+    expect(result.rejection?.recoverable).toBe(false);
+    expect(await readdir(tmpVault)).toEqual([]);
+  });
+
+  it("admits a global target whose vault carries a .oms ontology", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-global-ok-"));
+    await mkdir(path.join(tmpVault, ".oms"), { recursive: true });
+    await writeFile(path.join(tmpVault, ".oms", "taxonomy.yaml"), "version: 1\n", "utf-8");
+
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "global" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath: "references/global-ok.md",
+      frontmatter: goodFrontmatter,
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("written");
+    expect(result.rejection).toBeUndefined();
+    expect(await readFile(path.join(tmpVault, "references/global-ok.md"), "utf-8")).toContain(
+      "Body.",
+    );
+  });
+
+  it("admits a global target whose vault carries a .oms concepts dir", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-global-concepts-"));
+    await mkdir(path.join(tmpVault, ".oms", "concepts"), { recursive: true });
+
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "global" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath: "references/global-concepts.md",
+      frontmatter: goodFrontmatter,
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("written");
+    expect(result.rejection).toBeUndefined();
+  });
+
+  it("trusts vault/bridge/env/explicit sources without an ontology presence check", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-trusted-"));
+    const ontology = testOntology();
+    for (const source of ["vault", "bridge", "env", "explicit"] as const) {
+      const result = await writeNote({
+        target: { vault: tmpVault, source },
+        ontology,
+        mode: "create",
+        dryRun: false,
+        notePath: `references/${source}.md`,
+        frontmatter: goodFrontmatter,
+        body: "Body.",
+      });
+      expect(result.status).toBe("written");
+      expect(result.rejection).toBeUndefined();
+    }
+  });
+
+  it("stamps admission rejection codes on every legacy pre-write failure", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-legacy-"));
+    const ontology = testOntology();
+    const target = { vault: tmpVault, source: "vault" } as const;
+
+    await writeNote({
+      target,
+      ontology,
+      mode: "create",
+      dryRun: false,
+      notePath: "references/exists.md",
+      frontmatter: goodFrontmatter,
+      body: "Body.",
+    });
+    await writeFile(
+      path.join(tmpVault, "references", "unbound.md"),
+      "---\ntitle: Unbound\n---\n\nBody.\n",
+      "utf-8",
+    );
+    await mkdir(path.join(tmpVault, "loose"), { recursive: true });
+    await writeFile(
+      path.join(tmpVault, "loose", "unbound.md"),
+      "---\ntitle: Unbound\n---\n\nBody.\n",
+      "utf-8",
+    );
+
+    const cases: Array<{
+      name: string;
+      input: Parameters<typeof writeNote>[0];
+      code: string;
+      reason: RegExp;
+    }> = [
+      {
+        name: "note-exists",
+        input: {
+          target,
+          ontology,
+          mode: "create",
+          dryRun: false,
+          notePath: "references/exists.md",
+          frontmatter: goodFrontmatter,
+          body: "Body.",
+        },
+        code: "note-exists",
+        reason: /Cannot create capture: target note already exists/,
+      },
+      {
+        name: "note-missing",
+        input: {
+          target,
+          ontology,
+          mode: "update",
+          dryRun: false,
+          notePath: "references/nope.md",
+          frontmatter: { status: "draft" },
+        },
+        code: "note-missing",
+        reason: /Cannot update capture: target note does not exist/,
+      },
+      {
+        name: "body-missing (create)",
+        input: {
+          target,
+          ontology,
+          mode: "create",
+          dryRun: false,
+          notePath: "references/no-body.md",
+          frontmatter: goodFrontmatter,
+        },
+        code: "body-missing",
+        reason: /create requires a body/,
+      },
+      {
+        name: "body-missing (append)",
+        input: {
+          target,
+          ontology,
+          mode: "append",
+          dryRun: false,
+          notePath: "references/exists.md",
+        },
+        code: "body-missing",
+        reason: /append requires a body/,
+      },
+      {
+        name: "args-invalid (append notePath)",
+        input: { target, ontology, mode: "append", dryRun: false, body: "Body." },
+        code: "args-invalid",
+        reason: /append requires notePath/,
+      },
+      {
+        name: "args-invalid (update notePath)",
+        input: { target, ontology, mode: "update", dryRun: false, frontmatter: { a: 1 } },
+        code: "args-invalid",
+        reason: /update requires notePath/,
+      },
+      {
+        name: "args-invalid (update payload)",
+        input: {
+          target,
+          ontology,
+          mode: "update",
+          dryRun: false,
+          notePath: "references/exists.md",
+        },
+        code: "args-invalid",
+        reason: /update requires frontmatter or body/,
+      },
+      {
+        name: "concept-unbound (append)",
+        input: {
+          target,
+          ontology,
+          mode: "append",
+          dryRun: false,
+          notePath: "loose/unbound.md",
+          body: "More.",
+        },
+        code: "concept-unbound",
+        reason: /notePath does not resolve to a concept binding/,
+      },
+      {
+        name: "concept-unbound (update)",
+        input: {
+          target,
+          ontology,
+          mode: "update",
+          dryRun: false,
+          notePath: "loose/unbound.md",
+          frontmatter: { title: "Renamed" },
+        },
+        code: "concept-unbound",
+        reason: /notePath does not resolve to a concept binding/,
+      },
+      {
+        name: "path-unsafe (traversal)",
+        input: {
+          target,
+          ontology,
+          mode: "create",
+          dryRun: false,
+          notePath: "../outside.md",
+          frontmatter: goodFrontmatter,
+          body: "Body.",
+        },
+        code: "path-unsafe",
+        reason: /unsafe|inside|relative/,
+      },
+      {
+        name: "path-unsafe (absolute)",
+        input: {
+          target,
+          ontology,
+          mode: "append",
+          dryRun: false,
+          notePath: `${tmpVault}/references/exists.md`,
+          body: "Body.",
+        },
+        code: "path-unsafe",
+        reason: /relative/,
+      },
+      {
+        name: "path-unsafe (hidden dir)",
+        input: {
+          target,
+          ontology,
+          mode: "update",
+          dryRun: false,
+          notePath: ".oms/cache/bad.md",
+          frontmatter: { title: "Bad" },
+        },
+        code: "path-unsafe",
+        reason: /hidden|internal|dependency/,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = await writeNote(testCase.input);
+      expect(result.status, testCase.name).toBe("rejected");
+      expect(result.rejection?.code, testCase.name).toBe(testCase.code);
+      expect(result.rejection?.stage, testCase.name).toBe("admission");
+      expect(result.receipt, testCase.name).toBeUndefined();
+      expect(result.reason ?? "", testCase.name).toMatch(testCase.reason);
+    }
+  });
+
+  it("attaches a contract-violation rejection to ask results without changing status", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-ask-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath: "references/ask.md",
+      frontmatter: { title: "Only title" },
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("ask");
+    expect(result.missingFields).toContain("source-url");
+    expect(result.rejection?.stage).toBe("admission");
+    expect(result.rejection?.code).toBe("contract-violation");
+    expect(result.rejection?.recoverable).toBe(true);
+    expect(result.rejection?.remediation).toContain("source-url");
+    expect(result.receipt).toBeUndefined();
+    expect(await readdir(tmpVault)).toEqual([]);
+  });
+
+  it("keeps inbox routing free of rejection and receipt payloads", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-admit-inbox-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      concept: "missing-concept",
+      folder: "unknown",
+      frontmatter: { title: "Loose thought" },
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("inbox");
+    expect(result.rejection).toBeUndefined();
+    expect(result.receipt).toBeUndefined();
+  });
+});
+
+describe("writeNote acceptance criteria", () => {
+  const goodFrontmatter = {
+    title: "Acceptance",
+    "source-url": "https://example.com/acceptance",
+  };
+
+  const RATED: Concept = {
+    concept: "literature",
+    intent: "A processed reference with a numeric rating.",
+    folder: "references",
+    fields: [
+      { name: "title", type: "string", required: true, intent: "Title." },
+      { name: "source-url", type: "url", required: true, intent: "Canonical URL." },
+      { name: "rating", type: "number", required: true, intent: "Numeric rating." },
+    ],
+  };
+
+  it("issues a receipt naming the resolved vault and resolution source on create", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-create-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "explicit" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath: "references/receipt.md",
+      frontmatter: goodFrontmatter,
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("written");
+    expect(result.rejection).toBeUndefined();
+    expect(result.receipt).toEqual({
+      resolvedVault: tmpVault,
+      resolutionSource: "explicit",
+      notePath: "references/receipt.md",
+      mode: "create",
+      concept: "literature",
+      postconditionVerified: true,
+    });
+  });
+
+  it("issues receipts for append and update on an existing note", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-modes-"));
+    const ontology = testOntology();
+    const notePath = "references/modes.md";
+    await writeNote({
+      target: { vault: tmpVault, source: "bridge" },
+      ontology,
+      mode: "create",
+      dryRun: false,
+      notePath,
+      frontmatter: goodFrontmatter,
+      body: "Initial body.",
+    });
+
+    const appended = await writeNote({
+      target: { vault: tmpVault, source: "bridge" },
+      ontology,
+      mode: "append",
+      dryRun: false,
+      notePath,
+      body: "Appended body.",
+    });
+    expect(appended.status).toBe("written");
+    expect(appended.receipt).toEqual({
+      resolvedVault: tmpVault,
+      resolutionSource: "bridge",
+      notePath,
+      mode: "append",
+      concept: "literature",
+      postconditionVerified: true,
+    });
+
+    const updated = await writeNote({
+      target: { vault: tmpVault, source: "env" },
+      ontology,
+      mode: "update",
+      dryRun: false,
+      notePath,
+      frontmatter: { status: "published" },
+    });
+    expect(updated.status).toBe("written");
+    expect(updated.receipt).toEqual({
+      resolvedVault: tmpVault,
+      resolutionSource: "env",
+      notePath,
+      mode: "update",
+      concept: "literature",
+      postconditionVerified: true,
+    });
+  });
+
+  it("keeps receipt.mode aligned with result.mode when append creates the note", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-append-create-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology: testOntology(),
+      mode: "append",
+      dryRun: false,
+      notePath: "references/fresh.md",
+      frontmatter: goodFrontmatter,
+      body: "Fresh body.",
+    });
+
+    expect(result.status).toBe("written");
+    expect(result.mode).toBe("append");
+    expect(result.receipt?.mode).toBe("append");
+    expect(result.receipt?.postconditionVerified).toBe(true);
+    expect(await readFile(path.join(tmpVault, "references/fresh.md"), "utf-8")).toContain(
+      "Fresh body.",
+    );
+  });
+
+  it("rejects a staged render whose body is empty without touching disk", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-staged-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath: "references/blank-body.md",
+      frontmatter: goodFrontmatter,
+      // Passes the admission body check (defined) but renders to an empty body.
+      body: "   \n\t\n",
+    });
+
+    expect(result.status).toBe("rejected");
+    expect(result.rejection?.stage).toBe("acceptance");
+    expect(result.rejection?.code).toBe("body-missing");
+    expect(result.receipt).toBeUndefined();
+    expect(await readdir(tmpVault)).toEqual([]);
+  });
+
+  it("evaluates the staged render directly against the concept contract", () => {
+    // A staged render that diverges from its input frontmatter: the declared
+    // number field arrived as a string in the rendered note.
+    const staged = `---\ntitle: Staged\nsource-url: https://example.com/staged\nrating: "4"\n---\n\nBody.\n`;
+    const evaluation = evaluateStagedNote(staged, RATED, "references/staged.md", new Set());
+    expect(evaluation.ok).toBe(false);
+    expect(evaluation.violations.map((violation) => violation.field)).toContain("rating");
+    expect(evaluation.violations.map((violation) => violation.rule)).toContain("type");
+    expect(evaluation.body.trim()).toBe("Body.");
+
+    const clean = `---\ntitle: Staged\nsource-url: https://example.com/staged\nrating: 4\n---\n\nBody.\n`;
+    const ok = evaluateStagedNote(clean, RATED, "references/staged.md", new Set());
+    expect(ok.ok).toBe(true);
+    expect(ok.violations).toEqual([]);
+    expect(ok.frontmatter["rating"]).toBe(4);
+  });
+
+  it("flags a staged render missing a routing-law field the input carried", () => {
+    // Divergence shape the staged gate exists for: the rendered note lost a
+    // field the caller supplied, so the strict-zone routing law now fails.
+    const staged = `---\ntitle: Staged\nsource-url: https://example.com/staged\nrating: 4\n---\n\nBody.\n`;
+    const evaluation = evaluateStagedNote(
+      staged,
+      RATED,
+      "references/staged.md",
+      new Set(["references"]),
+    );
+    expect(evaluation.ok).toBe(false);
+    expect(evaluation.violations.map((violation) => violation.rule)).toContain("routing-law");
+  });
+
+  it("keeps multiline and date-like frontmatter values intact through the staged render", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-roundtrip-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath: "references/roundtrip.md",
+      frontmatter: {
+        title: "2024-01-02",
+        "source-url": "https://example.com/roundtrip",
+        note: "line one\nline two",
+      },
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("written");
+    expect(result.receipt?.postconditionVerified).toBe(true);
+    const persisted = await readFile(path.join(tmpVault, "references/roundtrip.md"), "utf-8");
+    expect(persisted).toContain("line one");
+    expect(persisted).toContain("line two");
+  });
+
+  it("rejects with postcondition-failed when the persisted note fails re-validation", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-postcondition-"));
+    const notePath = "references/postcondition.md";
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: false,
+      notePath,
+      frontmatter: goodFrontmatter,
+      body: "Body.",
+      readBack: async () => "---\ntitle: \"\"\n---\n\nCorrupted.\n",
+    });
+
+    expect(result.status).toBe("rejected");
+    expect(result.rejection?.stage).toBe("acceptance");
+    expect(result.rejection?.code).toBe("postcondition-failed");
+    expect(result.rejection?.recoverable).toBe(false);
+    expect(result.rejection?.remediation).toContain(path.join(tmpVault, notePath));
+    expect(result.receipt).toBeUndefined();
+
+    // The persisted file is NOT auto-deleted: it stays on disk for inspection.
+    const persisted = await readFile(path.join(tmpVault, notePath), "utf-8");
+    expect(persisted).toContain("Body.");
+  });
+
+  it("rejects with postcondition-failed when the persisted body is missing on append", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-postcondition-append-"));
+    const ontology = testOntology();
+    const notePath = "references/append-postcondition.md";
+    await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology,
+      mode: "create",
+      dryRun: false,
+      notePath,
+      frontmatter: goodFrontmatter,
+      body: "Initial body.",
+    });
+
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology,
+      mode: "append",
+      dryRun: false,
+      notePath,
+      body: "Appended body.",
+      readBack: async () =>
+        `---\ntitle: Acceptance\nsource-url: https://example.com/acceptance\n---\n\nInitial body.\n`,
+    });
+
+    expect(result.status).toBe("rejected");
+    expect(result.rejection?.code).toBe("postcondition-failed");
+    expect(result.reason).toContain("persisted body does not match the staged content");
+    expect(result.receipt).toBeUndefined();
+    const persisted = await readFile(path.join(tmpVault, notePath), "utf-8");
+    expect(persisted).toContain("Appended body.");
+  });
+
+  it("returns staged results with no receipt and no disk writes on dryRun create", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-dryrun-"));
+    const result = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology: testOntology(),
+      mode: "create",
+      dryRun: true,
+      notePath: "references/dry.md",
+      frontmatter: goodFrontmatter,
+      body: "Body.",
+    });
+
+    expect(result.status).toBe("written");
+    expect(result.notePath).toBe("references/dry.md");
+    expect(result.receipt).toBeUndefined();
+    expect(result.rejection).toBeUndefined();
+    expect(await readdir(tmpVault)).toEqual([]);
+  });
+
+  it("returns no receipt on dryRun append and update", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-accept-dryrun-modes-"));
+    const ontology = testOntology();
+    const notePath = "references/dry-modes.md";
+    await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology,
+      mode: "create",
+      dryRun: false,
+      notePath,
+      frontmatter: goodFrontmatter,
+      body: "Initial body.",
+    });
+    const before = await readFile(path.join(tmpVault, notePath), "utf-8");
+
+    const appended = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology,
+      mode: "append",
+      dryRun: true,
+      notePath,
+      body: "Dry append.",
+    });
+    expect(appended.status).toBe("written");
+    expect(appended.receipt).toBeUndefined();
+
+    const updated = await writeNote({
+      target: { vault: tmpVault, source: "vault" },
+      ontology,
+      mode: "update",
+      dryRun: true,
+      notePath,
+      frontmatter: { status: "published" },
+    });
+    expect(updated.status).toBe("written");
+    expect(updated.receipt).toBeUndefined();
+
+    expect(await readFile(path.join(tmpVault, notePath), "utf-8")).toBe(before);
+  });
+});

--- a/src/capture/safe.ts
+++ b/src/capture/safe.ts
@@ -1,4 +1,4 @@
-import { access, appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, appendFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { stringify as yamlStringify } from "yaml";
 import { parseNote } from "../conventions/frontmatter.js";
@@ -9,6 +9,12 @@ import {
   type WriteContractViolation,
   type WriteFieldDescriptor,
 } from "../conventions/write-contract.js";
+import {
+  rejection,
+  type WriteRejection,
+  type WriteReceipt,
+  type WriteTargetSource,
+} from "../conventions/write-protocol.js";
 import { resolveConcept } from "../core/ontology/resolver.js";
 import type { Concept, Ontology } from "../core/ontology/types.js";
 
@@ -38,8 +44,14 @@ export interface CapturePlan {
   reason?: string;
 }
 
+export interface WriteTarget {
+  vault: string;
+  source: WriteTargetSource;
+}
+
 export interface CaptureCommitInput {
   vault: string;
+  source: WriteTargetSource;
   ontology: Ontology;
   notePath: string;
   frontmatter: Record<string, unknown>;
@@ -54,7 +66,7 @@ export interface CaptureCommitResult {
 }
 
 export interface WriteNoteInput {
-  vault: string;
+  target: WriteTarget;
   ontology: Ontology;
   mode: WriteMode;
   dryRun: boolean;
@@ -64,6 +76,12 @@ export interface WriteNoteInput {
   notePath?: string;
   frontmatter?: Record<string, unknown>;
   body?: string;
+  /**
+   * Test-only DI seam for the postcondition read-back. Defaults to reading the
+   * persisted file with node:fs/promises. Exists so tests can force a
+   * postcondition failure deterministically without mocking node:fs/promises.
+   */
+  readBack?: (fullPath: string) => Promise<string>;
 }
 
 export interface WriteNoteResult {
@@ -77,6 +95,8 @@ export interface WriteNoteResult {
   missingFields: string[];
   violations: WriteContractViolation[];
   reason?: string;
+  rejection?: WriteRejection;
+  receipt?: WriteReceipt;
 }
 
 function slugify(value: string): string {
@@ -146,6 +166,24 @@ function inboxResult(
   });
 }
 
+function pathUnsafeRejection(reason: string): WriteRejection {
+  return rejection(
+    "admission",
+    "path-unsafe",
+    reason,
+    "pass a vault-relative `notePath` ending in .md that stays inside the vault and avoids hidden or internal folders",
+  );
+}
+
+function conceptUnboundRejection(): WriteRejection {
+  return rejection(
+    "admission",
+    "concept-unbound",
+    "Cannot commit capture: notePath does not resolve to a concept binding",
+    "move the note into a folder bound to a concept in taxonomy.yaml, or target an existing bound note",
+  );
+}
+
 function rejectedResult(
   mode: WriteMode,
   notePath: string,
@@ -153,6 +191,7 @@ function rejectedResult(
   frontmatter: Record<string, unknown>,
   violations: WriteContractViolation[],
   reason: string,
+  rejectionPayload?: WriteRejection,
 ): WriteNoteResult {
   return writeResult({
     status: "rejected",
@@ -165,6 +204,7 @@ function rejectedResult(
     missingFields: violations.map((violation) => violation.field),
     violations,
     reason,
+    ...(rejectionPayload ? { rejection: rejectionPayload } : {}),
   });
 }
 
@@ -185,6 +225,14 @@ function askResult(
     frontmatter,
     missingFields: violations.map((violation) => violation.field),
     violations,
+    rejection: rejection(
+      "admission",
+      "contract-violation",
+      "Capture does not satisfy the concept contract yet",
+      `provide or correct these fields, then retry: ${violations
+        .map((violation) => violation.field)
+        .join(", ")}`,
+    ),
   });
 }
 
@@ -193,6 +241,7 @@ function writtenResult(
   notePath: string,
   concept: Concept | undefined,
   frontmatter: Record<string, unknown>,
+  receipt?: WriteReceipt,
 ): WriteNoteResult {
   return writeResult({
     status: "written",
@@ -204,6 +253,7 @@ function writtenResult(
     frontmatter,
     missingFields: [],
     violations: [],
+    ...(receipt ? { receipt } : {}),
   });
 }
 
@@ -351,6 +401,17 @@ async function fileExists(fullPath: string): Promise<boolean> {
   }
 }
 
+async function isDirectory(fullPath: string): Promise<boolean> {
+  try {
+    return (await stat(fullPath)).isDirectory();
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT") || hasErrorCode(error, "ENOTDIR")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 export function prepareCapture(input: CapturePrepareInput): CapturePlan {
   const frontmatter = input.frontmatter ?? {};
   const planned = planCreatePlacement(
@@ -408,9 +469,255 @@ export function prepareCapture(input: CapturePrepareInput): CapturePlan {
   };
 }
 
+/**
+ * Admission Rules - target verification.
+ *
+ * Runs before ANY disk mutation. `cwd` resolution is unverified for the write
+ * surface (the process may have booted anywhere). A `global` registry pointer
+ * must still point at a real `.oms` ontology; every other source is trusted
+ * without an ontology presence check so the bundled-ontology fallback keeps
+ * working.
+ */
+async function admitTarget(target: WriteTarget): Promise<WriteRejection | undefined> {
+  if (target.source === "cwd") {
+    return rejection(
+      "admission",
+      "target-unverified",
+      `Refusing to write: the target vault was inferred from the current directory (${target.vault}), which is not a verified Oh My Second Brain vault`,
+      "run `oms setup` in your Obsidian vault (or set OMS_VAULT / register the vault in ~/.oms/config.yaml), then retry",
+    );
+  }
+
+  if (target.source === "global") {
+    const hasOntology =
+      (await isDirectory(path.join(target.vault, ".oms", "concepts"))) ||
+      (await fileExists(path.join(target.vault, ".oms", "taxonomy.yaml")));
+    if (!hasOntology) {
+      return rejection(
+        "admission",
+        "target-invalid",
+        `Refusing to write: the registered global vault target has no .oms ontology: ${target.vault}`,
+        "update ~/.oms/config.yaml to point at your vault, or run `oms setup` in that vault, then retry",
+      );
+    }
+  }
+
+  return undefined;
+}
+
+function targetRejectedResult(
+  mode: WriteMode,
+  input: WriteNoteInput,
+  frontmatter: Record<string, unknown>,
+  rejectionPayload: WriteRejection,
+): WriteNoteResult {
+  return rejectedResult(
+    mode,
+    input.notePath ?? "",
+    undefined,
+    frontmatter,
+    [],
+    rejectionPayload.message,
+    rejectionPayload,
+  );
+}
+
+export interface StagedEvaluation {
+  ok: boolean;
+  violations: WriteContractViolation[];
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+/**
+ * Acceptance Criteria - staged evaluation (pre-persist).
+ *
+ * Parses the note content that is ABOUT to be written and re-runs the kernel
+ * write contract against the RENDERED frontmatter. This catches divergence
+ * between the caller-supplied frontmatter and what actually lands on disk
+ * (yaml round-trip artifacts such as `NaN` rendering as `.nan` and parsing
+ * back as `null`).
+ */
+export function evaluateStagedNote(
+  stagedContent: string,
+  concept: Concept,
+  notePath: string,
+  strictZones: ReadonlySet<string>,
+): StagedEvaluation {
+  const parsed = parseNote(stagedContent);
+  const contract = evaluateWriteContract(parsed.frontmatter, concept, notePath, strictZones);
+  return {
+    ok: contract.valid,
+    violations: contract.violations,
+    frontmatter: parsed.frontmatter,
+    body: parsed.body,
+  };
+}
+
+function sameViolationSet(
+  left: readonly WriteContractViolation[],
+  right: readonly WriteContractViolation[],
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  const key = (violation: WriteContractViolation): string =>
+    `${violation.field}\u0000${violation.rule}\u0000${violation.message}`;
+  const leftKeys = left.map(key).sort();
+  const rightKeys = right.map(key).sort();
+  return leftKeys.every((entry, index) => entry === rightKeys[index]);
+}
+
+/**
+ * Acceptance rejection for a staged render that diverges from the (already
+ * passing) input evaluation. Callers only reach this when the input-level
+ * contract check passed, so the violation is a genuine render divergence.
+ */
+function stagedRejectedResult(
+  mode: WriteMode,
+  notePath: string,
+  concept: Concept,
+  frontmatter: Record<string, unknown>,
+  violations: WriteContractViolation[],
+): WriteNoteResult {
+  const fields = violations.map((violation) => violation.field).join(", ");
+  return rejectedResult(
+    mode,
+    notePath,
+    concept,
+    frontmatter,
+    violations,
+    "Cannot write: the rendered note violates the concept contract",
+    rejection(
+      "acceptance",
+      "contract-violation",
+      `Staged note render violates the concept contract (${fields})`,
+      `these values do not survive the note render unchanged - correct them, then retry: ${fields}`,
+    ),
+  );
+}
+
+function stagedBodyMissingResult(
+  mode: WriteMode,
+  notePath: string,
+  concept: Concept,
+  frontmatter: Record<string, unknown>,
+): WriteNoteResult {
+  return rejectedResult(
+    mode,
+    notePath,
+    concept,
+    frontmatter,
+    [],
+    "create requires a body",
+    rejection(
+      "acceptance",
+      "body-missing",
+      "Staged note render carries no body content",
+      "pass a non-empty `body` for the note, then retry",
+    ),
+  );
+}
+
+function postconditionRejectedResult(
+  mode: WriteMode,
+  notePath: string,
+  fullPath: string,
+  concept: Concept,
+  frontmatter: Record<string, unknown>,
+  violations: WriteContractViolation[],
+  detail: string,
+): WriteNoteResult {
+  return rejectedResult(
+    mode,
+    notePath,
+    concept,
+    frontmatter,
+    violations,
+    `Postcondition failed after writing ${notePath}: ${detail}`,
+    rejection(
+      "acceptance",
+      "postcondition-failed",
+      `Postcondition failed after writing ${notePath}: ${detail}`,
+      `inspect the persisted file at ${fullPath} (it was NOT removed) and repair or delete it before retrying`,
+    ),
+  );
+}
+
+function receiptFor(
+  input: WriteNoteInput,
+  mode: WriteMode,
+  notePath: string,
+  concept: Concept | undefined,
+): WriteReceipt {
+  return {
+    resolvedVault: input.target.vault,
+    resolutionSource: input.target.source,
+    notePath,
+    mode,
+    concept: concept?.concept ?? null,
+    postconditionVerified: true,
+  };
+}
+
+function normalizeBody(body: string): string {
+  return body.replace(/\s+$/, "");
+}
+
+interface PostconditionCheck {
+  ok: boolean;
+  violations: WriteContractViolation[];
+  detail: string;
+}
+
+/**
+ * Acceptance Criteria - postcondition (post-persist).
+ *
+ * Re-reads the persisted note through the `readBack` seam, re-runs the write
+ * contract on what is actually on disk, and asserts the intended body content
+ * landed. The persisted file is never auto-deleted on failure.
+ */
+async function verifyPostcondition(
+  input: WriteNoteInput,
+  fullPath: string,
+  notePath: string,
+  concept: Concept,
+  strictZones: ReadonlySet<string>,
+  expectation: { kind: "full"; body: string } | { kind: "suffix"; body: string },
+): Promise<PostconditionCheck> {
+  const read = input.readBack ?? ((target: string) => readFile(target, "utf-8"));
+  const persisted = await read(fullPath);
+  const parsed = parseNote(persisted);
+  const contract = evaluateWriteContract(parsed.frontmatter, concept, notePath, strictZones);
+  if (!contract.valid) {
+    return {
+      ok: false,
+      violations: contract.violations,
+      detail: `persisted frontmatter violates the concept contract (${contract.violations
+        .map((violation) => violation.field)
+        .join(", ")})`,
+    };
+  }
+
+  const bodyOk =
+    expectation.kind === "full"
+      ? normalizeBody(parsed.body) === normalizeBody(expectation.body)
+      : normalizeBody(persisted).endsWith(expectation.body.trim());
+  if (!bodyOk) {
+    return { ok: false, violations: [], detail: "persisted body does not match the staged content" };
+  }
+
+  return { ok: true, violations: [], detail: "" };
+}
+
 export async function writeNote(input: WriteNoteInput): Promise<WriteNoteResult> {
   const frontmatter = input.frontmatter ?? {};
   const strictZones = routingLawStrictFolders(input.ontology);
+
+  const targetRejection = await admitTarget(input.target);
+  if (targetRejection) {
+    return targetRejectedResult(input.mode, input, frontmatter, targetRejection);
+  }
 
   if (input.mode === "update") {
     return writeUpdate(input, frontmatter, strictZones);
@@ -430,9 +737,17 @@ async function writeCreate(
   let concept: Concept | undefined;
 
   if (input.notePath) {
-    const safe = trySafeNotePath(input.vault, input.notePath);
+    const safe = trySafeNotePath(input.target.vault, input.notePath);
     if (!safe.ok) {
-      return rejectedResult("create", input.notePath, undefined, frontmatter, [], safe.reason);
+      return rejectedResult(
+        "create",
+        input.notePath,
+        undefined,
+        frontmatter,
+        [],
+        safe.reason,
+        pathUnsafeRejection(safe.reason),
+      );
     }
     notePath = safe.normalized;
     concept = resolveConcept(input.ontology, notePath);
@@ -490,12 +805,26 @@ async function writeCreate(
       frontmatter,
       [],
       "create requires a body",
+      rejection(
+        "admission",
+        "body-missing",
+        "create requires a body",
+        "pass a non-empty `body` for the note, then retry",
+      ),
     );
   }
 
-  const safe = trySafeNotePath(input.vault, notePath);
+  const safe = trySafeNotePath(input.target.vault, notePath);
   if (!safe.ok) {
-    return rejectedResult("create", notePath, concept, frontmatter, [], safe.reason);
+    return rejectedResult(
+      "create",
+      notePath,
+      concept,
+      frontmatter,
+      [],
+      safe.reason,
+      pathUnsafeRejection(safe.reason),
+    );
   }
 
   if (await fileExists(safe.fullPath)) {
@@ -506,18 +835,73 @@ async function writeCreate(
       frontmatter,
       [],
       "Cannot create capture: target note already exists",
+      rejection(
+        "admission",
+        "note-exists",
+        "Cannot create capture: target note already exists",
+        "use mode `append` or `update` for an existing note, or choose a different filename",
+      ),
     );
   }
 
-  if (!input.dryRun) {
-    await mkdir(path.dirname(safe.fullPath), { recursive: true });
-    await writeFile(safe.fullPath, formatNote(frontmatter, input.body), {
-      encoding: "utf-8",
-      flag: "wx",
-    });
+  // Write Attempt: build the staged note in memory.
+  const staged = formatNote(frontmatter, input.body);
+
+  // Evaluation (pre-persist): the staged render is a second gate that only
+  // fires on divergence from the input evaluation, which already passed above.
+  const stagedEvaluation = evaluateStagedNote(staged, concept, notePath, strictZones);
+  if (!stagedEvaluation.ok && !sameViolationSet(stagedEvaluation.violations, contract.violations)) {
+    return stagedRejectedResult(
+      "create",
+      notePath,
+      concept,
+      frontmatter,
+      stagedEvaluation.violations,
+    );
+  }
+  if (stagedEvaluation.body.trim() === "") {
+    return stagedBodyMissingResult("create", notePath, concept, frontmatter);
   }
 
-  return writtenResult("create", notePath, concept, frontmatter);
+  if (input.dryRun) {
+    return writtenResult("create", notePath, concept, frontmatter);
+  }
+
+  // Persist.
+  await mkdir(path.dirname(safe.fullPath), { recursive: true });
+  await writeFile(safe.fullPath, staged, {
+    encoding: "utf-8",
+    flag: "wx",
+  });
+
+  // Postcondition.
+  const postcondition = await verifyPostcondition(
+    input,
+    safe.fullPath,
+    notePath,
+    concept,
+    strictZones,
+    { kind: "full", body: stagedEvaluation.body },
+  );
+  if (!postcondition.ok) {
+    return postconditionRejectedResult(
+      "create",
+      notePath,
+      safe.fullPath,
+      concept,
+      frontmatter,
+      postcondition.violations,
+      postcondition.detail,
+    );
+  }
+
+  return writtenResult(
+    "create",
+    notePath,
+    concept,
+    frontmatter,
+    receiptFor(input, "create", notePath, concept),
+  );
 }
 
 async function writeAppend(
@@ -526,7 +910,20 @@ async function writeAppend(
   strictZones: ReadonlySet<string>,
 ): Promise<WriteNoteResult> {
   if (!input.notePath) {
-    return rejectedResult("append", "", undefined, frontmatter, [], "append requires notePath");
+    return rejectedResult(
+      "append",
+      "",
+      undefined,
+      frontmatter,
+      [],
+      "append requires notePath",
+      rejection(
+        "admission",
+        "args-invalid",
+        "append requires notePath",
+        "pass the vault-relative `notePath` of the note to append to, then retry",
+      ),
+    );
   }
   if (input.body === undefined) {
     return rejectedResult(
@@ -536,19 +933,33 @@ async function writeAppend(
       frontmatter,
       [],
       "append requires a body",
+      rejection(
+        "admission",
+        "body-missing",
+        "append requires a body",
+        "pass a non-empty `body` to append, then retry",
+      ),
     );
   }
 
-  const safe = trySafeNotePath(input.vault, input.notePath);
+  const safe = trySafeNotePath(input.target.vault, input.notePath);
   if (!safe.ok) {
-    return rejectedResult("append", input.notePath, undefined, frontmatter, [], safe.reason);
+    return rejectedResult(
+      "append",
+      input.notePath,
+      undefined,
+      frontmatter,
+      [],
+      safe.reason,
+      pathUnsafeRejection(safe.reason),
+    );
   }
 
   const exists = await fileExists(safe.fullPath);
   if (!exists) {
     const created = await writeCreate(
       {
-        vault: input.vault,
+        target: input.target,
         ontology: input.ontology,
         mode: "create",
         dryRun: input.dryRun,
@@ -565,6 +976,7 @@ async function writeAppend(
     return writeResult({
       ...created,
       mode: "append",
+      ...(created.receipt ? { receipt: { ...created.receipt, mode: "append" as const } } : {}),
     });
   }
 
@@ -579,6 +991,7 @@ async function writeAppend(
       parsed.frontmatter,
       [],
       "Cannot commit capture: notePath does not resolve to a concept binding",
+      conceptUnboundRejection(),
     );
   }
 
@@ -594,11 +1007,58 @@ async function writeAppend(
     );
   }
 
-  if (!input.dryRun) {
-    await appendFile(safe.fullPath, `\n\n${input.body.trim()}\n`, "utf-8");
+  // Write Attempt: the staged note is exactly what the file will hold after the
+  // append (current content + the appended block).
+  const appended = `\n\n${input.body.trim()}\n`;
+  const staged = `${raw}${appended}`;
+
+  // Evaluation (pre-persist).
+  const stagedEvaluation = evaluateStagedNote(staged, concept, safe.normalized, strictZones);
+  if (!stagedEvaluation.ok && !sameViolationSet(stagedEvaluation.violations, contract.violations)) {
+    return stagedRejectedResult(
+      "append",
+      safe.normalized,
+      concept,
+      parsed.frontmatter,
+      stagedEvaluation.violations,
+    );
   }
 
-  return writtenResult("append", safe.normalized, concept, parsed.frontmatter);
+  if (input.dryRun) {
+    return writtenResult("append", safe.normalized, concept, parsed.frontmatter);
+  }
+
+  // Persist.
+  await appendFile(safe.fullPath, appended, "utf-8");
+
+  // Postcondition.
+  const postcondition = await verifyPostcondition(
+    input,
+    safe.fullPath,
+    safe.normalized,
+    concept,
+    strictZones,
+    { kind: "suffix", body: input.body },
+  );
+  if (!postcondition.ok) {
+    return postconditionRejectedResult(
+      "append",
+      safe.normalized,
+      safe.fullPath,
+      concept,
+      parsed.frontmatter,
+      postcondition.violations,
+      postcondition.detail,
+    );
+  }
+
+  return writtenResult(
+    "append",
+    safe.normalized,
+    concept,
+    parsed.frontmatter,
+    receiptFor(input, "append", safe.normalized, concept),
+  );
 }
 
 async function writeUpdate(
@@ -607,7 +1067,20 @@ async function writeUpdate(
   strictZones: ReadonlySet<string>,
 ): Promise<WriteNoteResult> {
   if (!input.notePath) {
-    return rejectedResult("update", "", undefined, frontmatter, [], "update requires notePath");
+    return rejectedResult(
+      "update",
+      "",
+      undefined,
+      frontmatter,
+      [],
+      "update requires notePath",
+      rejection(
+        "admission",
+        "args-invalid",
+        "update requires notePath",
+        "pass the vault-relative `notePath` of the note to update, then retry",
+      ),
+    );
   }
   if (input.frontmatter === undefined && input.body === undefined) {
     return rejectedResult(
@@ -617,12 +1090,26 @@ async function writeUpdate(
       frontmatter,
       [],
       "update requires frontmatter or body",
+      rejection(
+        "admission",
+        "args-invalid",
+        "update requires frontmatter or body",
+        "pass `frontmatter`, `body`, or both, then retry",
+      ),
     );
   }
 
-  const safe = trySafeNotePath(input.vault, input.notePath);
+  const safe = trySafeNotePath(input.target.vault, input.notePath);
   if (!safe.ok) {
-    return rejectedResult("update", input.notePath, undefined, frontmatter, [], safe.reason);
+    return rejectedResult(
+      "update",
+      input.notePath,
+      undefined,
+      frontmatter,
+      [],
+      safe.reason,
+      pathUnsafeRejection(safe.reason),
+    );
   }
 
   if (!(await fileExists(safe.fullPath))) {
@@ -633,6 +1120,12 @@ async function writeUpdate(
       frontmatter,
       [],
       "Cannot update capture: target note does not exist",
+      rejection(
+        "admission",
+        "note-missing",
+        "Cannot update capture: target note does not exist",
+        "create the note first (mode `create`) or correct `notePath`, then retry",
+      ),
     );
   }
 
@@ -649,6 +1142,7 @@ async function writeUpdate(
       merged,
       [],
       "Cannot commit capture: notePath does not resolve to a concept binding",
+      conceptUnboundRejection(),
     );
   }
 
@@ -664,16 +1158,55 @@ async function writeUpdate(
     );
   }
 
-  if (!input.dryRun) {
-    await writeFile(safe.fullPath, formatNote(merged, body), "utf-8");
+  // Write Attempt: build the staged note in memory.
+  const staged = formatNote(merged, body);
+
+  // Evaluation (pre-persist).
+  const stagedEvaluation = evaluateStagedNote(staged, concept, safe.normalized, strictZones);
+  if (!stagedEvaluation.ok && !sameViolationSet(stagedEvaluation.violations, contract.violations)) {
+    return stagedRejectedResult("update", safe.normalized, concept, merged, stagedEvaluation.violations);
   }
 
-  return writtenResult("update", safe.normalized, concept, merged);
+  if (input.dryRun) {
+    return writtenResult("update", safe.normalized, concept, merged);
+  }
+
+  // Persist.
+  await writeFile(safe.fullPath, staged, "utf-8");
+
+  // Postcondition.
+  const postcondition = await verifyPostcondition(
+    input,
+    safe.fullPath,
+    safe.normalized,
+    concept,
+    strictZones,
+    { kind: "full", body: stagedEvaluation.body },
+  );
+  if (!postcondition.ok) {
+    return postconditionRejectedResult(
+      "update",
+      safe.normalized,
+      safe.fullPath,
+      concept,
+      merged,
+      postcondition.violations,
+      postcondition.detail,
+    );
+  }
+
+  return writtenResult(
+    "update",
+    safe.normalized,
+    concept,
+    merged,
+    receiptFor(input, "update", safe.normalized, concept),
+  );
 }
 
 export async function commitCapture(input: CaptureCommitInput): Promise<CaptureCommitResult> {
   const result = await writeNote({
-    vault: input.vault,
+    target: { vault: input.vault, source: input.source },
     ontology: input.ontology,
     mode: input.mode,
     dryRun: false,

--- a/src/cli/global-writeback.test.ts
+++ b/src/cli/global-writeback.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readGlobalConfig } from "../link/global-config.js";
+import { backfillGlobalVaultFromEnv, nonFatalGlobalWriteback, registerGlobalVault } from "./global-writeback.js";
+
+describe("global-writeback", () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(path.join(os.tmpdir(), "oms-global-writeback-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("registerGlobalVault writes a config readable by readGlobalConfig", async () => {
+    const homeDir = path.join(tmpRoot, "home1");
+    const vault = path.join(tmpRoot, "vault1");
+    await mkdir(vault, { recursive: true });
+
+    const result = await registerGlobalVault({ vault, homeDir, overwrite: false });
+    expect(result.wrote).toBe(true);
+
+    const config = await readGlobalConfig(homeDir);
+    expect(config).not.toBeNull();
+    expect(config?.vault).toBe(vault);
+  });
+
+  it("register with overwrite=true replaces an existing different vault", async () => {
+    const homeDir = path.join(tmpRoot, "home2");
+    const vaultA = path.join(tmpRoot, "vaultA");
+    const vaultB = path.join(tmpRoot, "vaultB");
+    await mkdir(vaultA, { recursive: true });
+    await mkdir(vaultB, { recursive: true });
+
+    await registerGlobalVault({ vault: vaultA, homeDir, overwrite: false });
+    const result = await registerGlobalVault({ vault: vaultB, homeDir, overwrite: true });
+    expect(result.wrote).toBe(true);
+
+    const config = await readGlobalConfig(homeDir);
+    expect(config?.vault).toBe(vaultB);
+  });
+
+  it("backfill writes when config absent and OMS_VAULT points at an existing dir", async () => {
+    const homeDir = path.join(tmpRoot, "home3");
+    const vault = path.join(tmpRoot, "vault3");
+    await mkdir(vault, { recursive: true });
+
+    const result = await backfillGlobalVaultFromEnv({ env: { OMS_VAULT: vault }, homeDir });
+    expect(result.wrote).toBe(true);
+
+    const config = await readGlobalConfig(homeDir);
+    expect(config?.vault).toBe(vault);
+  });
+
+  it("backfill does NOT overwrite an existing config", async () => {
+    const homeDir = path.join(tmpRoot, "home4");
+    const originalVault = path.join(tmpRoot, "vault4-original");
+    const otherVault = path.join(tmpRoot, "vault4-other");
+    await mkdir(originalVault, { recursive: true });
+    await mkdir(otherVault, { recursive: true });
+
+    await registerGlobalVault({ vault: originalVault, homeDir, overwrite: false });
+    const result = await backfillGlobalVaultFromEnv({ env: { OMS_VAULT: otherVault }, homeDir });
+    expect(result.wrote).toBe(false);
+
+    const config = await readGlobalConfig(homeDir);
+    expect(config?.vault).toBe(originalVault);
+  });
+
+  it("backfill no-ops when OMS_VAULT unset or points at a missing dir", async () => {
+    const homeDir = path.join(tmpRoot, "home5");
+
+    const unset = await backfillGlobalVaultFromEnv({ env: {}, homeDir });
+    expect(unset.wrote).toBe(false);
+    expect(await readGlobalConfig(homeDir)).toBeNull();
+
+    const missing = await backfillGlobalVaultFromEnv({
+      env: { OMS_VAULT: path.join(tmpRoot, "does-not-exist") },
+      homeDir,
+    });
+    expect(missing.wrote).toBe(false);
+    expect(await readGlobalConfig(homeDir)).toBeNull();
+  });
+
+  it("backfill treats a corrupt existing config as present and does not touch it", async () => {
+    const homeDir = path.join(tmpRoot, "home6");
+    const otherVault = path.join(tmpRoot, "vault6-other");
+    await mkdir(otherVault, { recursive: true });
+    await mkdir(path.join(homeDir, ".oms"), { recursive: true });
+    await writeFile(path.join(homeDir, ".oms", "config.yaml"), "not: [valid", "utf-8");
+
+    const result = await backfillGlobalVaultFromEnv({ env: { OMS_VAULT: otherVault }, homeDir });
+    expect(result.wrote).toBe(false);
+  });
+
+  it("nonFatalGlobalWriteback does not throw when homeDir/.oms cannot be created (a file occupies that path)", async () => {
+    const homeDir = path.join(tmpRoot, "home7");
+    await mkdir(homeDir, { recursive: true });
+    // Create a FILE at <home>/.oms so mkdir(recursive) inside writeGlobalConfig fails.
+    await writeFile(path.join(homeDir, ".oms"), "not a directory", "utf-8");
+    const vault = path.join(tmpRoot, "vault7");
+    await mkdir(vault, { recursive: true });
+
+    const result = await nonFatalGlobalWriteback(() =>
+      registerGlobalVault({ vault, homeDir, overwrite: true }),
+    );
+    expect(result.wrote).toBe(false);
+  });
+});

--- a/src/cli/global-writeback.ts
+++ b/src/cli/global-writeback.ts
@@ -1,0 +1,92 @@
+import { stat } from "node:fs/promises";
+import { readGlobalConfig, writeGlobalConfig } from "../link/global-config.js";
+
+export interface RegisterGlobalVaultOptions {
+  readonly vault: string;
+  readonly homeDir?: string;
+  readonly overwrite: boolean;
+}
+
+export interface GlobalWritebackResult {
+  readonly wrote: boolean;
+  readonly reason?: string;
+}
+
+/**
+ * Register `vault` in the global config (`<homeDir>/.oms/config.yaml`).
+ * When `overwrite` is false, does nothing if a global config already exists
+ * (including when reading the existing config throws, e.g. a corrupt file -
+ * a corrupt-but-present config is treated as "config exists, do not touch").
+ */
+export async function registerGlobalVault(options: RegisterGlobalVaultOptions): Promise<GlobalWritebackResult> {
+  const { vault, homeDir, overwrite } = options;
+  if (!overwrite) {
+    let existing;
+    try {
+      existing = await readGlobalConfig(homeDir);
+    } catch {
+      return { wrote: false, reason: "existing global config is present but unreadable" };
+    }
+    if (existing !== null) {
+      return { wrote: false, reason: "existing global config present" };
+    }
+  }
+  await writeGlobalConfig({ version: 1, vault }, homeDir);
+  return { wrote: true };
+}
+
+export interface BackfillGlobalVaultOptions {
+  readonly env: NodeJS.ProcessEnv;
+  readonly homeDir?: string;
+}
+
+/**
+ * Migration backfill: when no global config exists yet and `OMS_VAULT` points
+ * at an existing directory, register it. Never overwrites an existing config
+ * (including a corrupt-but-present one).
+ */
+export async function backfillGlobalVaultFromEnv(options: BackfillGlobalVaultOptions): Promise<GlobalWritebackResult> {
+  const { env, homeDir } = options;
+  const omsVault = env["OMS_VAULT"];
+  if (omsVault === undefined || omsVault.trim().length === 0) {
+    return { wrote: false, reason: "OMS_VAULT not set" };
+  }
+
+  let existing;
+  try {
+    existing = await readGlobalConfig(homeDir);
+  } catch {
+    return { wrote: false, reason: "existing global config is present but unreadable" };
+  }
+  if (existing !== null) {
+    return { wrote: false, reason: "existing global config present" };
+  }
+
+  try {
+    const stats = await stat(omsVault);
+    if (!stats.isDirectory()) {
+      return { wrote: false, reason: "OMS_VAULT does not point at a directory" };
+    }
+  } catch {
+    return { wrote: false, reason: "OMS_VAULT does not point at an existing directory" };
+  }
+
+  await writeGlobalConfig({ version: 1, vault: omsVault }, homeDir);
+  return { wrote: true };
+}
+
+/**
+ * Run a global write-back action, swallowing any failure into a single
+ * `[oms] warning:` line on stderr. Never throws.
+ */
+export async function nonFatalGlobalWriteback(
+  action: () => Promise<GlobalWritebackResult>,
+): Promise<GlobalWritebackResult> {
+  try {
+    return await action();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[oms] warning: could not update global vault registry (${message})`);
+    return { wrote: false, reason: message };
+  }
+}

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -9,6 +9,7 @@ import {
   formatHostOperationResultsJson,
   runHostOperation,
 } from "../install/hosts.js";
+import type { WriteTargetSource } from "../conventions/write-protocol.js";
 import { resolveEffectiveVault } from "../link/link.js";
 import { runMcpServer } from "../mcp/server.js";
 import { resolveBundledAssetPaths } from "../core/runtime/assets.js";
@@ -19,6 +20,11 @@ import {
 import { parseCliArgs } from "./args.js";
 import { runAudit } from "./audit.js";
 import { runDoctor, runLint } from "./doctor-lint.js";
+import {
+  backfillGlobalVaultFromEnv,
+  nonFatalGlobalWriteback,
+  registerGlobalVault,
+} from "./global-writeback.js";
 import { runLink } from "./link-command.js";
 import { isSemanticCliCommand, runSemanticCli } from "./semantic.js";
 import { runSetup } from "./setup-command.js";
@@ -85,12 +91,23 @@ async function main(): Promise<void> {
     unknownFlags,
   } = parsedArgs;
 
-  if (shouldResolveBridgeVault(command, vaultExplicit)) {
+  // `mcp` keeps the FULL resolution result: the write surface trusts every
+  // source except `cwd`, so the server needs the source, not just the path.
+  let mcpTarget: { vault: string; scope: string[] | null; source: WriteTargetSource } | undefined;
+  if (command === "mcp") {
+    mcpTarget = vaultExplicit
+      ? { vault, scope: null, source: "explicit" }
+      : await resolveEffectiveVault(process.cwd(), process.env);
+    vault = mcpTarget.vault;
+  } else if (shouldResolveBridgeVault(command, vaultExplicit)) {
     vault = (await resolveEffectiveVault(process.cwd(), process.env)).vault;
   }
 
   if (command === "setup") {
     await runSetup({ vault, yes, installClaude, suggestFields });
+    await nonFatalGlobalWriteback(() =>
+      registerGlobalVault({ vault: path.resolve(vault), homeDir: undefined, overwrite: true }),
+    );
     await maybePrintUpdateNotice();
   } else if (command === "link") {
     process.exitCode = await runLink({
@@ -119,6 +136,15 @@ async function main(): Promise<void> {
       adapterRoot: bundledAdapterRoot(),
     });
     console.log(json ? formatHostOperationResultsJson(results, dryRun) : formatHostOperationResults(results, dryRun));
+    if (command === "install" && !dryRun) {
+      if (vaultExplicit) {
+        await nonFatalGlobalWriteback(() =>
+          registerGlobalVault({ vault: path.resolve(vault), homeDir: undefined, overwrite: true }),
+        );
+      } else {
+        await nonFatalGlobalWriteback(() => backfillGlobalVaultFromEnv({ env: process.env, homeDir: undefined }));
+      }
+    }
     await maybePrintUpdateNotice();
   } else if (command === "update") {
     if (unknownFlags.length > 0) {
@@ -182,7 +208,10 @@ async function main(): Promise<void> {
     });
     await maybePrintUpdateNotice();
   } else if (command === "mcp") {
-    await runMcpServer({ vault });
+    await runMcpServer({
+      vault,
+      source: mcpTarget?.source ?? "explicit",
+    });
   } else if (command === "hook") {
     const subcommand = argv[1];
     if (subcommand === "pre-tool-use") {

--- a/src/conventions/write-protocol.test.ts
+++ b/src/conventions/write-protocol.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { rejection } from "./write-protocol.js";
+import type { WriteRejectionCode } from "./write-protocol.js";
+
+describe("write-protocol", () => {
+  describe("rejection()", () => {
+    it("stamps recoverable=true for target-unverified", () => {
+      const result = rejection(
+        "admission",
+        "target-unverified",
+        "no verified target",
+        "run oms setup"
+      );
+      expect(result.recoverable).toBe(true);
+      expect(result.stage).toBe("admission");
+      expect(result.code).toBe("target-unverified");
+      expect(result.message).toBe("no verified target");
+      expect(result.remediation).toBe("run oms setup");
+    });
+
+    it("stamps recoverable=true for contract-violation", () => {
+      const result = rejection(
+        "acceptance",
+        "contract-violation",
+        "missing required field",
+        "add the field"
+      );
+      expect(result.recoverable).toBe(true);
+      expect(result.code).toBe("contract-violation");
+    });
+
+    it("stamps recoverable=true for body-missing", () => {
+      const result = rejection(
+        "admission",
+        "body-missing",
+        "body required",
+        "provide body"
+      );
+      expect(result.recoverable).toBe(true);
+      expect(result.code).toBe("body-missing");
+    });
+
+    it("stamps recoverable=true for args-invalid", () => {
+      const result = rejection(
+        "admission",
+        "args-invalid",
+        "invalid args",
+        "check args"
+      );
+      expect(result.recoverable).toBe(true);
+      expect(result.code).toBe("args-invalid");
+    });
+
+    it("stamps recoverable=true for path-unsafe", () => {
+      const result = rejection(
+        "admission",
+        "path-unsafe",
+        "path is unsafe",
+        "use safe path"
+      );
+      expect(result.recoverable).toBe(true);
+      expect(result.code).toBe("path-unsafe");
+    });
+
+    it("stamps recoverable=false for note-exists", () => {
+      const result = rejection(
+        "admission",
+        "note-exists",
+        "note already exists",
+        "use different path"
+      );
+      expect(result.recoverable).toBe(false);
+      expect(result.code).toBe("note-exists");
+    });
+
+    it("stamps recoverable=false for note-missing", () => {
+      const result = rejection(
+        "acceptance",
+        "note-missing",
+        "note not found",
+        "create note first"
+      );
+      expect(result.recoverable).toBe(false);
+      expect(result.code).toBe("note-missing");
+    });
+
+    it("stamps recoverable=false for concept-unbound", () => {
+      const result = rejection(
+        "admission",
+        "concept-unbound",
+        "concept not bound",
+        "bind concept"
+      );
+      expect(result.recoverable).toBe(false);
+      expect(result.code).toBe("concept-unbound");
+    });
+
+    it("stamps recoverable=false for target-invalid", () => {
+      const result = rejection(
+        "admission",
+        "target-invalid",
+        "target invalid",
+        "register valid target"
+      );
+      expect(result.recoverable).toBe(false);
+      expect(result.code).toBe("target-invalid");
+    });
+
+    it("stamps recoverable=false for postcondition-failed", () => {
+      const result = rejection(
+        "acceptance",
+        "postcondition-failed",
+        "postcondition failed",
+        "inspect file"
+      );
+      expect(result.recoverable).toBe(false);
+      expect(result.code).toBe("postcondition-failed");
+    });
+
+    it("passes through stage, code, message, and remediation verbatim", () => {
+      const stage = "acceptance";
+      const code: WriteRejectionCode = "body-missing";
+      const message = "body is missing";
+      const remediation = "provide a body";
+
+      const result = rejection(stage, code, message, remediation);
+
+      expect(result.stage).toBe(stage);
+      expect(result.code).toBe(code);
+      expect(result.message).toBe(message);
+      expect(result.remediation).toBe(remediation);
+    });
+
+    it("rejects unknown code at compile time", () => {
+      // @ts-expect-error intentional - testing that unknown code is rejected
+      rejection("admission", "not-a-code", "x", "y");
+    });
+  });
+});

--- a/src/conventions/write-protocol.ts
+++ b/src/conventions/write-protocol.ts
@@ -1,0 +1,86 @@
+/**
+ * Write Protocol: Admission & Acceptance contract with explicit rejection & receipt.
+ *
+ * Response Shape Contract:
+ * - `written` results carry `receipt` (persisted, postcondition-verified) and no `rejection`.
+ * - `rejected` results (and contract-fixable `ask` results) carry `rejection` and no `receipt`.
+ * - `inbox` results carry NEITHER (inbox is a routing plan; nothing is persisted).
+ * - `dryRun` results carry NO receipt (a receipt attests a persisted, postcondition-verified write).
+ *
+ * Rejection Model (gajae-code reference: error{code, message, recoverable} + remediation):
+ * Each rejection carries a stage (admission or acceptance), code, message, and recoverable flag
+ * derived exhaustively from a per-code table. This ensures adding a code without a recoverable
+ * entry is a compile error.
+ */
+
+import type { VaultSource } from "../link/link.js";
+import type { WriteMode } from "../capture/safe.js";
+
+export type WriteStage = "admission" | "acceptance";
+
+export type WriteTargetSource = VaultSource | "explicit";
+
+export type WriteRejectionCode =
+  | "target-unverified"
+  | "target-invalid"
+  | "path-unsafe"
+  | "note-exists"
+  | "note-missing"
+  | "concept-unbound"
+  | "contract-violation"
+  | "body-missing"
+  | "args-invalid"
+  | "postcondition-failed";
+
+export interface WriteRejection {
+  stage: WriteStage;
+  code: WriteRejectionCode;
+  message: string;
+  recoverable: boolean;
+  remediation: string;
+}
+
+export interface WriteReceipt {
+  resolvedVault: string;
+  resolutionSource: WriteTargetSource;
+  notePath: string;
+  mode: WriteMode;
+  concept: string | null;
+  postconditionVerified: boolean;
+}
+
+/**
+ * Exhaustive recovery table: maps each rejection code to its recoverable flag.
+ * Adding a code without an entry is a compile error.
+ */
+const RECOVERABLE_BY_CODE: Record<WriteRejectionCode, boolean> = {
+  "target-unverified": true,
+  "contract-violation": true,
+  "body-missing": true,
+  "args-invalid": true,
+  "path-unsafe": true,
+  "note-exists": false,
+  "note-missing": false,
+  "concept-unbound": false,
+  "target-invalid": false,
+  "postcondition-failed": false,
+};
+
+/**
+ * Create a WriteRejection with stage, code, message, and remediation.
+ * The recoverable flag is derived exhaustively from the per-code table.
+ */
+export function rejection(
+  stage: WriteStage,
+  code: WriteRejectionCode,
+  message: string,
+  remediation: string
+): WriteRejection {
+  return {
+    stage,
+    code,
+    message,
+    remediation,
+    recoverable: RECOVERABLE_BY_CODE[code],
+  };
+}

--- a/src/link/global-config.test.ts
+++ b/src/link/global-config.test.ts
@@ -1,0 +1,113 @@
+import { rmSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { readGlobalConfig, writeGlobalConfig } from "./global-config.js";
+
+let tmpHomeDir: string;
+
+// Fresh tmpHomeDir for each test to avoid flakiness
+function freshTmpHome(): string {
+  return mkdtempSync(path.join(os.tmpdir(), "oms-global-config-test-"));
+}
+
+describe("global-config", () => {
+  it("returns null when config file is missing", async () => {
+    const homeDir = freshTmpHome();
+    try {
+      const result = await readGlobalConfig(homeDir);
+      expect(result).toBeNull();
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips a valid config with ~ expanded vault", async () => {
+    const homeDir = freshTmpHome();
+    try {
+      const vaultDir = mkdtempSync(path.join(os.tmpdir(), "oms-vault-"));
+      try {
+        // Write config with ~ prefix
+        const configPath = await writeGlobalConfig(
+          { version: 1, vault: `~${path.sep}vault-test` },
+          homeDir,
+        );
+        expect(configPath).toBe(path.join(homeDir, ".oms", "config.yaml"));
+
+        // Read it back
+        const config = await readGlobalConfig(homeDir);
+        expect(config).not.toBeNull();
+        expect(config!.version).toBe(1);
+        // vault should be expanded to absolute path
+        expect(path.isAbsolute(config!.vault)).toBe(true);
+        expect(config!.vault).toContain("vault-test");
+      } finally {
+        rmSync(vaultDir, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws with config path in message when YAML is invalid", async () => {
+    const homeDir = freshTmpHome();
+    try {
+      const omsDir = path.join(homeDir, ".oms");
+      await mkdir(omsDir, { recursive: true });
+      const configPath = path.join(omsDir, "config.yaml");
+      await writeFile(configPath, "invalid: [yaml\n", "utf-8");
+
+      await expect(readGlobalConfig(homeDir)).rejects.toThrow(configPath);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when vault field is missing", async () => {
+    const homeDir = freshTmpHome();
+    try {
+      const omsDir = path.join(homeDir, ".oms");
+      await mkdir(omsDir, { recursive: true });
+      const configPath = path.join(omsDir, "config.yaml");
+      await writeFile(configPath, "version: 1\n", "utf-8");
+
+      await expect(readGlobalConfig(homeDir)).rejects.toThrow(configPath);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when vault is a bare relative path", async () => {
+    const homeDir = freshTmpHome();
+    try {
+      const omsDir = path.join(homeDir, ".oms");
+      await mkdir(omsDir, { recursive: true });
+      const configPath = path.join(omsDir, "config.yaml");
+      await writeFile(configPath, "version: 1\nvault: ../notes\n", "utf-8");
+
+      await expect(readGlobalConfig(homeDir)).rejects.toThrow(/relative/);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("write-then-read round-trip returns identical vault expansion", async () => {
+    const homeDir = freshTmpHome();
+    const vaultDir = mkdtempSync(path.join(os.tmpdir(), "oms-vault-rtrip-"));
+    try {
+      const config = { version: 1, vault: vaultDir };
+      const writePath = await writeGlobalConfig(config, homeDir);
+      expect(writePath).toBe(path.join(homeDir, ".oms", "config.yaml"));
+
+      const readBack = await readGlobalConfig(homeDir);
+      expect(readBack).not.toBeNull();
+      expect(readBack!.vault).toBe(vaultDir); // absolute path, so identical
+      expect(readBack!.version).toBe(1);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+      rmSync(vaultDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/link/global-config.ts
+++ b/src/link/global-config.ts
@@ -1,0 +1,90 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+import { expandHome } from "./link.js";
+
+export interface GlobalConfig {
+  version: number;
+  vault: string;
+}
+
+/**
+ * Read the global Obsidian vault target config from `<homeDir>/.oms/config.yaml`.
+ * Returns `null` only when the file is missing (ENOENT).
+ * A present-but-invalid file throws a loud actionable error naming the config file path:
+ *   - bad YAML syntax
+ *   - not a mapping
+ *   - missing or empty `vault` string
+ *   - bare relative `vault` value (would resolve against process cwd)
+ * The `vault` value is expanded if it starts with `~`, using the existing `expandHome`.
+ * `version` defaults to 1 when absent or non-number.
+ */
+export async function readGlobalConfig(homeDir?: string): Promise<GlobalConfig | null> {
+  const home = homeDir ?? os.homedir();
+  const configPath = path.join(home, ".oms", "config.yaml");
+
+  let raw: string;
+  try {
+    raw = await readFile(configPath, "utf-8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  let parsed: Record<string, unknown> | null;
+  try {
+    parsed = yamlParse(raw) as Record<string, unknown> | null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `[oms] Invalid global config at ${configPath}: config.yaml is not valid YAML (${message}). Run oms setup to repair it.`,
+    );
+  }
+
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `[oms] Invalid global config at ${configPath}: expected a YAML mapping with vault and version.`,
+    );
+  }
+
+  const vault = parsed["vault"];
+  if (typeof vault !== "string" || vault.trim().length === 0) {
+    throw new Error(
+      `[oms] Invalid global config at ${configPath}: missing required string field "vault". Run oms setup to register a vault.`,
+    );
+  }
+
+  const vaultTrimmed = vault.trim();
+  // Reject bare relative paths (e.g. ../notes). Must be absolute or ~/...
+  if (!path.isAbsolute(vaultTrimmed) && !vaultTrimmed.startsWith("~")) {
+    throw new Error(
+      `[oms] Invalid global config at ${configPath}: vault must be an absolute path or ~/..., not a relative path like "${vaultTrimmed}". Run oms setup to register an absolute vault path.`,
+    );
+  }
+
+  const expandedVault = expandHome(vaultTrimmed);
+
+  return {
+    version: typeof parsed["version"] === "number" ? parsed["version"] : 1,
+    vault: expandedVault,
+  };
+}
+
+/**
+ * Write the global Obsidian vault target config to `<homeDir>/.oms/config.yaml`.
+ * Creates the `.oms` directory recursively if needed.
+ * Returns the absolute path to the written config file.
+ */
+export async function writeGlobalConfig(config: GlobalConfig, homeDir?: string): Promise<string> {
+  const home = homeDir ?? os.homedir();
+  const omsDir = path.join(home, ".oms");
+  const configPath = path.join(omsDir, "config.yaml");
+
+  await mkdir(omsDir, { recursive: true });
+  await writeFile(configPath, yamlStringify(config), "utf-8");
+
+  return configPath;
+}

--- a/src/link/link.test.ts
+++ b/src/link/link.test.ts
@@ -14,6 +14,7 @@ import {
   resolveEffectiveVault,
   writeLinkRecord,
 } from "./link.js";
+import { readGlobalConfig, writeGlobalConfig } from "./global-config.js";
 
 let tmp: string;
 let vault: string;
@@ -135,8 +136,14 @@ describe("resolveEffectiveVault", () => {
   });
 
   it("falls back to the start dir when nothing else resolves", async () => {
-    const resolved = await resolveEffectiveVault(repo, {});
-    expect(resolved).toEqual({ vault: path.resolve(repo), scope: null, source: "cwd" });
+    // Inject a tmp homeDir with no config to avoid leaking the developer's real ~/.oms/config.yaml
+    const tmpHome = mkdtempSync(path.join(os.tmpdir(), "oms-home-test-"));
+    try {
+      const resolved = await resolveEffectiveVault(repo, {}, { homeDir: tmpHome });
+      expect(resolved).toEqual({ vault: path.resolve(repo), scope: null, source: "cwd" });
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
   });
 
   it("prefers a local vault ontology over a bridge record", async () => {
@@ -173,6 +180,66 @@ describe("resolveEffectiveVault", () => {
     await writeLinkRecord(omsDir, { version: 1, vault: path.join(tmp, "deleted-vault"), scope: ["notes"] });
 
     await expect(resolveEffectiveVault(repo, { OMS_VAULT: vault })).rejects.toThrow(/Linked vault path does not exist/);
+  });
+
+  it("resolves global config when no local vault, bridge, or env", async () => {
+    const tmpHome = mkdtempSync(path.join(os.tmpdir(), "oms-home-test-"));
+    try {
+      await writeGlobalConfig({ version: 1, vault: path.resolve(vault) }, tmpHome);
+      const resolved = await resolveEffectiveVault(repo, {}, { homeDir: tmpHome });
+      expect(resolved).toEqual({ vault: path.resolve(vault), scope: null, source: "global" });
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers env over global config", async () => {
+    const tmpHome = mkdtempSync(path.join(os.tmpdir(), "oms-home-test-"));
+    const envVault = path.join(tmp, "env-vault");
+    await mkdir(envVault, { recursive: true });
+    try {
+      await writeGlobalConfig({ version: 1, vault: path.resolve(vault) }, tmpHome);
+      const resolved = await resolveEffectiveVault(repo, { OMS_VAULT: envVault }, { homeDir: tmpHome });
+      expect(resolved.source).toBe("env");
+      expect(resolved.vault).toBe(path.resolve(envVault));
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers bridge over global config", async () => {
+    const tmpHome = mkdtempSync(path.join(os.tmpdir(), "oms-home-test-"));
+    try {
+      const omsDir = path.join(repo, ".oms");
+      await writeLinkRecord(omsDir, { version: 1, vault: path.resolve(vault), scope: ["notes"] });
+      await writeGlobalConfig({ version: 1, vault: path.join(tmp, "other") }, tmpHome);
+      const resolved = await resolveEffectiveVault(repo, {}, { homeDir: tmpHome });
+      expect(resolved.source).toBe("bridge");
+      expect(resolved.vault).toBe(path.resolve(vault));
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("throws an actionable error when global config points at a non-directory", async () => {
+    const tmpHome = mkdtempSync(path.join(os.tmpdir(), "oms-home-test-"));
+    const nonExistentVault = path.join(tmp, "does-not-exist");
+    try {
+      await writeGlobalConfig({ version: 1, vault: nonExistentVault }, tmpHome);
+      await expect(resolveEffectiveVault(repo, {}, { homeDir: tmpHome })).rejects.toThrow(/does not exist or is not a directory/);
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to cwd when global config is absent (tmp homeDir)", async () => {
+    const tmpHome = mkdtempSync(path.join(os.tmpdir(), "oms-home-test-"));
+    try {
+      const resolved = await resolveEffectiveVault(repo, {}, { homeDir: tmpHome });
+      expect(resolved).toEqual({ vault: path.resolve(repo), scope: null, source: "cwd" });
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/link/link.ts
+++ b/src/link/link.ts
@@ -38,7 +38,7 @@ export interface LinkRecord {
   scope: string[];
 }
 
-export type VaultSource = "vault" | "bridge" | "env" | "cwd";
+export type VaultSource = "vault" | "bridge" | "env" | "global" | "cwd";
 
 export interface ResolvedVault {
   /** Effective vault root — where the `.oms/` ontology lives. */
@@ -168,11 +168,13 @@ export async function writeLinkRecord(omsDir: string, record: LinkRecord): Promi
  *   1. Local vault ontology (`.oms/concepts` or `.oms/taxonomy.yaml`) → vault.
  *   2. Local bridge (`.oms/links.yaml`)                              → bridge.
  *   3. `OMS_VAULT` environment variable                             → env.
- *   4. Fallback to `startDir`                                       → cwd.
+ *   4. Global vault target registry (`~/.oms/config.yaml`)          → global.
+ *   5. Fallback to `startDir`                                       → cwd.
  */
 export async function resolveEffectiveVault(
   startDir: string,
   env: Readonly<Record<string, string | undefined>> = process.env,
+  opts?: { homeDir?: string },
 ): Promise<ResolvedVault> {
   const omsDir = path.join(startDir, ".oms");
 
@@ -194,6 +196,16 @@ export async function resolveEffectiveVault(
   const envVault = env["OMS_VAULT"];
   if (envVault && envVault.trim().length > 0) {
     return { vault: expandHome(envVault), scope: null, source: "env" };
+  }
+
+  const { readGlobalConfig } = await import("./global-config.js");
+  const globalConfig = await readGlobalConfig(opts?.homeDir);
+  if (globalConfig) {
+    const resolvedVault = globalConfig.vault;
+    if ((await pathKind(resolvedVault)) !== "directory") {
+      throw new Error(`[oms] Global vault target does not exist or is not a directory: ${resolvedVault}. Update ~/.oms/config.yaml with a valid vault path, or run oms setup to register your vault.`);
+    }
+    return { vault: resolvedVault, scope: null, source: "global" };
   }
 
   return { vault: path.resolve(startDir), scope: null, source: "cwd" };

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -64,9 +64,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
 
       const status = await client.callTool({ name: "oms_graph_status", arguments: {} });
       const parsedStatus = textPayload(status);
-      expect(parsedStatus.writeTools).toBe(
-        "write-gated-by-vault-confinement-and-contract-validation",
-      );
+      expect(parsedStatus.writeTools).toBe("write-gated-by-verified-target-and-contract");
       const writeTool = tools.tools.find((tool) => tool.name === "write");
       expect(writeTool?.annotations?.readOnlyHint).toBe(false);
       expect(JSON.stringify(writeTool?.inputSchema)).toContain("update");
@@ -337,6 +335,17 @@ Malformed frontmatter must not block retrieve.
       );
       expect(created.status).toBe("written");
       expect(created.notePath).toBe("references/kernel-note.md");
+      expect(created.resolvedVault).toBe(tmpVault);
+      expect(created.resolutionSource).toBe("explicit");
+      expect(created.receipt).toMatchObject({
+        resolvedVault: tmpVault,
+        resolutionSource: "explicit",
+        notePath: "references/kernel-note.md",
+        mode: "create",
+        postconditionVerified: true,
+      });
+      expect(asked.resolvedVault).toBe(tmpVault);
+      expect(asked.resolutionSource).toBe("explicit");
 
       const broken = textPayload(
         await client.callTool({
@@ -353,6 +362,126 @@ Malformed frontmatter must not block retrieve.
     } finally {
       await client.close();
       await rm(tmpVault, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects writes and reports an unverified posture when the target came from cwd", async () => {
+    // No --vault, a non-vault cwd, an empty HOME (no ~/.oms/config.yaml) and no
+    // OMS_VAULT: resolution falls all the way through to the `cwd` source, which
+    // is unverified for the write surface (issue #58).
+    const tmpHome = await mkdtemp(path.join(tmpdir(), "oms-mcp-cwd-home-"));
+    // realpath: a spawned process reports the canonical cwd (macOS /tmp is a symlink),
+    // and the server resolves its target from that cwd.
+    const tmpCwd = await realpath(await mkdtemp(path.join(tmpdir(), "oms-mcp-cwd-")));
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [distCli, "mcp"],
+      cwd: tmpCwd,
+      env: { HOME: tmpHome, PATH: process.env["PATH"] ?? "" },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "oms-test-client", version: "0.0.0" });
+
+    try {
+      await client.connect(transport);
+
+      const status = textPayload(await client.callTool({ name: "oms_graph_status", arguments: {} }));
+      expect(status.writeTools).toBe("write-disabled-target-unverified");
+
+      const write = textPayload(
+        await client.callTool({
+          name: "write",
+          arguments: {
+            mode: "create",
+            notePath: "references/misrouted.md",
+            frontmatter: {
+              title: "Misrouted Note",
+              "source-url": "https://example.com/misrouted",
+            },
+            body: "Must not land in the booting directory.",
+          },
+        }),
+      );
+      expect(write.status).toBe("rejected");
+      expect(write.rejection).toMatchObject({
+        stage: "admission",
+        code: "target-unverified",
+        recoverable: true,
+      });
+      expect(write.receipt).toBeUndefined();
+      expect(write.resolvedVault).toBe(tmpCwd);
+      expect(write.resolutionSource).toBe("cwd");
+      expect(await readdir(tmpCwd)).toEqual([]);
+    } finally {
+      await client.close();
+      await rm(tmpCwd, { recursive: true, force: true });
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps writing normally when `oms mcp` boots inside a real vault", async () => {
+    // Regression guard: local `.oms` resolution (source "vault") stays a trusted
+    // write target even though `cwd` resolution is now rejected.
+    const tmpHome = await mkdtemp(path.join(tmpdir(), "oms-mcp-vault-home-"));
+    const tmpVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-mcp-local-vault-")));
+    await mkdir(path.join(tmpVault, ".oms", "concepts"), { recursive: true });
+    await writeFile(
+      path.join(tmpVault, ".oms", "taxonomy.yaml"),
+      "version: 1\nfolders:\n  references:\n    concept: literature\n",
+      "utf-8",
+    );
+    await writeFile(
+      path.join(tmpVault, ".oms", "concepts", "literature.yaml"),
+      `concept: literature
+intent: External sources worth revisiting.
+folder: references
+fields:
+  - name: title
+    type: string
+    required: true
+    intent: Human-readable title.
+`,
+      "utf-8",
+    );
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [distCli, "mcp"],
+      cwd: tmpVault,
+      env: { HOME: tmpHome, PATH: process.env["PATH"] ?? "" },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "oms-test-client", version: "0.0.0" });
+
+    try {
+      await client.connect(transport);
+
+      const status = textPayload(await client.callTool({ name: "oms_graph_status", arguments: {} }));
+      expect(status.writeTools).toBe("write-gated-by-verified-target-and-contract");
+
+      const created = textPayload(
+        await client.callTool({
+          name: "write",
+          arguments: {
+            mode: "create",
+            notePath: "references/local-vault-note.md",
+            frontmatter: { title: "Local Vault Note" },
+            body: "Written from inside the vault.",
+          },
+        }),
+      );
+      expect(created.status).toBe("written");
+      expect(created.resolutionSource).toBe("vault");
+      expect(created.resolvedVault).toBe(tmpVault);
+      expect(created.receipt).toMatchObject({
+        resolutionSource: "vault",
+        postconditionVerified: true,
+      });
+      expect(await readdir(path.join(tmpVault, "references"))).toEqual(["local-vault-note.md"]);
+    } finally {
+      await client.close();
+      await rm(tmpVault, { recursive: true, force: true });
+      await rm(tmpHome, { recursive: true, force: true });
     }
   });
 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,6 +24,7 @@ import {
   graphCachePath,
   lazyLoadNoteBody,
 } from "../graph/cache.js";
+import type { WriteTargetSource } from "../conventions/write-protocol.js";
 import { resolveActiveOntology } from "../ontology/active.js";
 import { resolveConcept } from "../core/ontology/resolver.js";
 import { retrieveMorningContext } from "../retrieve/morning.js";
@@ -289,10 +290,16 @@ export const omsMcpTools: Tool[] = [
 
 export interface OMSMcpServerOptions {
   vault: string;
+  /**
+   * How the vault was resolved. The write surface trusts every source except
+   * `cwd` (the server may have booted in an arbitrary directory - issue #58).
+   */
+  source: WriteTargetSource;
 }
 
 export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
   const vault = path.resolve(opts.vault);
+  const source = opts.source;
 
   // Native engine — graph layer (boot): assembled model-free via deferred
   // (throw-on-use) embedding primitives. Axis-first retrieval and the derived
@@ -351,7 +358,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     {
       capabilities: { tools: {}, resources: {} },
       instructions:
-        "Oh My Second Brain exposes ontology/status/cache/retrieval tools and the write tool. write is gated by vault confinement and contract validation.",
+        "Oh My Second Brain exposes ontology/status/cache/retrieval tools and the write tool. write is gated by a verified vault target (a vault inferred from the current directory is refused), vault confinement, and contract validation.",
     },
   );
 
@@ -416,11 +423,11 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       // throw escape ALL inner catch branches and break the MCP handler.
       const engineGraph = await engine.adapter.graphStatus(vault).catch(() => null);
       try {
-        const { ontology, source } = await resolveActiveOntology(vault);
+        const { ontology, source: ontologySource } = await resolveActiveOntology(vault);
         const cacheStatus = await graphCacheStatus(vault, ontology);
         return jsonText({
           vault,
-          ontologySource: source,
+          ontologySource,
           sourceOfTruth: ["markdown notes", ".oms/taxonomy.yaml", ".oms/concepts/*.yaml"],
           counts: {
             concepts: ontology.concepts.size,
@@ -428,7 +435,10 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
           },
           derivedState: cacheStatus,
           engineGraph,
-          writeTools: "write-gated-by-vault-confinement-and-contract-validation",
+          writeTools:
+            source === "cwd"
+              ? "write-disabled-target-unverified"
+              : "write-gated-by-verified-target-and-contract",
           readTools: omsMcpTools.map((tool) => tool.name),
         });
       } catch (error) {
@@ -637,12 +647,12 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     }
 
     if (request.params.name === "write") {
-      const { ontology, source } = await resolveActiveOntology(vault);
+      const { ontology, source: ontologySource } = await resolveActiveOntology(vault);
       const modeArg = stringArg(args, "mode");
       const mode: WriteMode = isWriteMode(modeArg) ? modeArg : "create";
       const frontmatterArg = args?.["frontmatter"];
       const result = await writeNote({
-        vault,
+        target: { vault, source },
         ontology,
         mode,
         dryRun: false,
@@ -655,8 +665,10 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       });
       return jsonText({
         vault,
-        ontologySource: source,
+        ontologySource,
         ...result,
+        resolvedVault: vault,
+        resolutionSource: source,
       });
     }
 

--- a/src/mcp/verified-target.test.ts
+++ b/src/mcp/verified-target.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, afterEach } from "vitest";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { resolveEffectiveVault } from "../link/link.js";
+import { writeGlobalConfig } from "../link/global-config.js";
+import { writeNote } from "../capture/safe.js";
+import { resolveActiveOntology } from "../ontology/active.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../");
+const distCli = path.join(repoRoot, "dist", "cli", "oms.js");
+
+// Minimal ontology fixture matching server.test.ts / link.test.ts patterns
+async function createMinimalOntology(vaultPath: string): Promise<void> {
+  await mkdir(path.join(vaultPath, ".oms", "concepts"), { recursive: true });
+  await writeFile(
+    path.join(vaultPath, ".oms", "taxonomy.yaml"),
+    "version: 1\nfolders:\n  references:\n    concept: literature\n",
+    "utf-8",
+  );
+  await writeFile(
+    path.join(vaultPath, ".oms", "concepts", "literature.yaml"),
+    `concept: literature
+intent: External sources worth revisiting.
+folder: references
+fields:
+  - name: title
+    type: string
+    required: true
+    intent: Human-readable title.
+  - name: source-url
+    type: string
+    required: true
+    intent: Source URL.
+`,
+    "utf-8",
+  );
+}
+
+function textPayload(result: Awaited<ReturnType<Client["callTool"]>>): Record<string, unknown> {
+  const block = result.content[0];
+  expect(block?.type).toBe("text");
+  return JSON.parse(block.type === "text" ? block.text : "{}") as Record<string, unknown>;
+}
+
+describe("Issue #58: Verified-target write kernel", () => {
+  let tmpHome: string;
+  let tmpDocuments: string;
+  let tmpVault: string;
+
+  afterEach(async () => {
+    if (tmpHome) {
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+    if (tmpDocuments) {
+      await rm(tmpDocuments, { recursive: true, force: true });
+    }
+    if (tmpVault) {
+      await rm(tmpVault, { recursive: true, force: true });
+    }
+  });
+
+  it("(1) resolveEffectiveVault from fake Documents cwd with global config returns vault + source:global", async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), "oms-test-home-"));
+    tmpDocuments = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-docs-")));
+    tmpVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-vault-")));
+
+    // Create minimal ontology in vault
+    await createMinimalOntology(tmpVault);
+
+    // Write global config pointing to vault
+    await writeGlobalConfig({ version: 1, vault: tmpVault }, tmpHome);
+
+    // Resolve from Documents cwd (has no .oms) with tmp homeDir
+    const resolved = await resolveEffectiveVault(tmpDocuments, {}, { homeDir: tmpHome });
+
+    expect(resolved.vault).toBe(tmpVault);
+    expect(resolved.source).toBe("global");
+    expect(resolved.scope).toBeNull();
+  });
+
+  it("(2) MCP write via server with global config lands note in vault, zero files in Documents", async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), "oms-test-home-"));
+    tmpDocuments = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-docs-")));
+    tmpVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-vault-")));
+
+    // Create minimal ontology in vault
+    await createMinimalOntology(tmpVault);
+
+    // Write global config pointing to vault
+    await writeGlobalConfig({ version: 1, vault: tmpVault }, tmpHome);
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [distCli, "mcp"],
+      cwd: tmpDocuments,
+      env: { HOME: tmpHome, PATH: process.env.PATH ?? "" },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "oms-test-client", version: "0.0.0" });
+
+    try {
+      const docsBefore = await readdir(tmpDocuments);
+      expect(docsBefore.length).toBe(0);
+
+      await client.connect(transport);
+
+      const write = textPayload(
+        await client.callTool({
+          name: "write",
+          arguments: {
+            mode: "create",
+            notePath: "references/verified-note.md",
+            frontmatter: {
+              title: "Verified Global Route",
+              "source-url": "https://example.com/verified",
+            },
+            body: "Written via global config, lands in vault, not Documents.",
+          },
+        }),
+      );
+
+      expect(write.status).toBe("written");
+      expect(write.resolvedVault).toBe(tmpVault);
+      expect(write.resolutionSource).toBe("global");
+      expect(write.receipt).toBeDefined();
+      expect((write.receipt as Record<string, unknown>).postconditionVerified).toBe(true);
+
+      // Assert note exists in vault
+      const noteInVault = path.join(tmpVault, "references", "verified-note.md");
+      const vaultRefs = await readdir(path.join(tmpVault, "references"));
+      expect(vaultRefs).toContain("verified-note.md");
+
+      // Assert Documents dir gained zero files
+      const docsAfter = await readdir(tmpDocuments);
+      expect(docsAfter.length).toBe(0);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("(3) no global config + Documents cwd: write rejected with target-unverified, zero files", async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), "oms-test-home-"));
+    tmpDocuments = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-docs-")));
+
+    // No vault, no global config, empty HOME
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [distCli, "mcp"],
+      cwd: tmpDocuments,
+      env: { HOME: tmpHome, PATH: process.env.PATH ?? "" },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "oms-test-client", version: "0.0.0" });
+
+    try {
+      const docsBefore = await readdir(tmpDocuments);
+      expect(docsBefore.length).toBe(0);
+
+      await client.connect(transport);
+
+      const write = textPayload(
+        await client.callTool({
+          name: "write",
+          arguments: {
+            mode: "create",
+            notePath: "references/rejected-note.md",
+            frontmatter: {
+              title: "Should Be Rejected",
+              "source-url": "https://example.com/rejected",
+            },
+            body: "Must not be written.",
+          },
+        }),
+      );
+
+      expect(write.status).toBe("rejected");
+      expect(write.rejection).toBeDefined();
+      expect((write.rejection as Record<string, unknown>).stage).toBe("admission");
+      expect((write.rejection as Record<string, unknown>).code).toBe("target-unverified");
+      expect((write.rejection as Record<string, unknown>).recoverable).toBe(true);
+      expect((write.rejection as Record<string, unknown>).remediation).toContain("oms setup");
+      expect(write.receipt).toBeUndefined();
+
+      // Assert Documents dir gained zero files
+      const docsAfter = await readdir(tmpDocuments);
+      expect(docsAfter.length).toBe(0);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("(3b) global config pointing at directory WITHOUT .oms ontology: rejected with target-invalid", async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), "oms-test-home-"));
+    tmpDocuments = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-docs-")));
+    tmpVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-vault-")));
+
+    // Create vault directory WITHOUT .oms ontology (stale registry pointer)
+    // tmpVault exists but has no .oms/
+
+    // Write global config pointing to vault without .oms
+    await writeGlobalConfig({ version: 1, vault: tmpVault }, tmpHome);
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [distCli, "mcp"],
+      cwd: tmpDocuments,
+      env: { HOME: tmpHome, PATH: process.env.PATH ?? "" },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "oms-test-client", version: "0.0.0" });
+
+    try {
+      const docsBefore = await readdir(tmpDocuments);
+      expect(docsBefore.length).toBe(0);
+
+      await client.connect(transport);
+
+      const write = textPayload(
+        await client.callTool({
+          name: "write",
+          arguments: {
+            mode: "create",
+            notePath: "references/invalid-target.md",
+            frontmatter: {
+              title: "Invalid Target",
+              "source-url": "https://example.com/invalid",
+            },
+            body: "Must not be written.",
+          },
+        }),
+      );
+
+      expect(write.status).toBe("rejected");
+      expect(write.rejection).toBeDefined();
+      expect((write.rejection as Record<string, unknown>).stage).toBe("admission");
+      expect((write.rejection as Record<string, unknown>).code).toBe("target-invalid");
+      expect((write.rejection as Record<string, unknown>).recoverable).toBe(false);
+      expect(write.receipt).toBeUndefined();
+
+      // Assert zero files created anywhere
+      const docsAfter = await readdir(tmpDocuments);
+      expect(docsAfter.length).toBe(0);
+      const vaultAfter = await readdir(tmpVault);
+      expect(vaultAfter.length).toBe(0);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("(4) precedence: OMS_VAULT env beats global; explicit source passthrough via writeNote", async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), "oms-test-home-"));
+    tmpDocuments = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-docs-")));
+    const globalVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-global-")));
+    const envVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-env-")));
+
+    // Create ontologies in both
+    await createMinimalOntology(globalVault);
+    await createMinimalOntology(envVault);
+
+    // Write global config pointing to globalVault
+    await writeGlobalConfig({ version: 1, vault: globalVault }, tmpHome);
+
+    // Case A: Env beats global via resolveEffectiveVault
+    const envResolved = await resolveEffectiveVault(tmpDocuments, { OMS_VAULT: envVault }, { homeDir: tmpHome });
+    expect(envResolved.source).toBe("env");
+    expect(envResolved.vault).toBe(envVault);
+
+    // Case B: Explicit source passthrough in writeNote accepts bare tmpdir with source:explicit
+    const bareDir = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-bare-")));
+    const activeOntology = await resolveActiveOntology(envVault);
+    const result = await writeNote({
+      target: { vault: bareDir, source: "explicit" },
+      ontology: activeOntology.ontology,
+      mode: "create",
+      dryRun: false,
+      notePath: "references/explicit-note.md",
+      frontmatter: {
+        title: "Explicit Vault",
+        "source-url": "https://example.com/explicit",
+      },
+      body: "Written with explicit source.",
+    });
+
+    expect(result.status).toBe("written");
+    expect(result.receipt).toBeDefined();
+    expect((result.receipt as Record<string, unknown>).resolutionSource).toBe("explicit");
+
+    // Cleanup extra vaults
+    await rm(globalVault, { recursive: true, force: true });
+    await rm(bareDir, { recursive: true, force: true });
+    tmpVault = envVault;
+  });
+
+  it("(5) every write response exposes resolvedVault + resolutionSource in written and rejected shapes", async () => {
+    tmpHome = await mkdtemp(path.join(tmpdir(), "oms-test-home-"));
+    tmpDocuments = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-docs-")));
+    tmpVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-test-vault-")));
+
+    // Create minimal ontology in vault
+    await createMinimalOntology(tmpVault);
+
+    // Write global config pointing to vault
+    await writeGlobalConfig({ version: 1, vault: tmpVault }, tmpHome);
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [distCli, "mcp"],
+      cwd: tmpDocuments,
+      env: { HOME: tmpHome, PATH: process.env.PATH ?? "" },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "oms-test-client", version: "0.0.0" });
+
+    try {
+      await client.connect(transport);
+
+      // Case A: Written response with receipt
+      const written = textPayload(
+        await client.callTool({
+          name: "write",
+          arguments: {
+            mode: "create",
+            notePath: "references/response-test.md",
+            frontmatter: {
+              title: "Response Test",
+              "source-url": "https://example.com/response",
+            },
+            body: "Testing response shape.",
+          },
+        }),
+      );
+
+      expect(written.status).toBe("written");
+      expect(written.resolvedVault).toBe(tmpVault);
+      expect(written.resolutionSource).toBe("global");
+      expect(written.receipt).toBeDefined();
+      expect((written.receipt as Record<string, unknown>).resolvedVault).toBe(tmpVault);
+      expect((written.receipt as Record<string, unknown>).resolutionSource).toBe("global");
+
+      // Case B: Rejected response (ask status - contract violation)
+      const rejected = textPayload(
+        await client.callTool({
+          name: "write",
+          arguments: {
+            mode: "create",
+            notePath: "references/incomplete.md",
+            frontmatter: {
+              title: "Incomplete",
+              // Missing source-url - required field
+            },
+            body: "Body present",
+          },
+        }),
+      );
+
+      expect(rejected.status).toBe("ask");
+      expect(rejected.resolvedVault).toBe(tmpVault);
+      expect(rejected.resolutionSource).toBe("global");
+      expect(rejected.missingFields).toContain("source-url");
+    } finally {
+      await client.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the MCP write surface silently writing into whatever directory the server booted from (e.g. `~/Documents`). OMS now runs anywhere, but `write` only creates knowledge inside the contract of an identified, verified target vault.

- **Global vault registry**: `~/.oms/config.yaml` (`{version, vault}`), written back by `oms setup` / `oms install`, with a one-time `OMS_VAULT` migration backfill for existing installs (never overwrites an existing config).
- **New `global` resolution source** in `resolveEffectiveVault`, between `OMS_VAULT` env and the cwd fallback. Existing precedence (`--vault` explicit > local vault `.oms` > bridge > env) unchanged.
- **Write kernel restructured** as Prepare -> Write Attempt -> Evaluation -> Receipt with a two-part contract:
  - **Admission Rules** (pre-IO): `cwd`-sourced target -> `target-unverified` rejection with zero fs calls; stale global pointer -> `target-invalid`; path/mode/overwrite preconditions mapped to structured codes.
  - **Acceptance Criteria** (post): staged render evaluated against the concept contract before persist; post-persist re-read postcondition -> `receipt.postconditionVerified`.
- **Explicit rejection payloads** `{stage, code, recoverable, remediation}` (10-code registry) and every write response now exposes `resolvedVault` + `resolutionSource`. `WriteNoteResult` changes are additive-only.
- **Docs**: `docs/verified-target.md` (loop, precedence, code table, migration note, adapter parity - no adapter file changes needed).

Closes #58

## Verification

- `npm run lint && npm run build && npm test` -> exit 0, **528 passed / 0 failed** (59 files)
- `src/mcp/verified-target.test.ts` maps 1:1 to the issue #58 acceptance criteria (cwd-independent routing, zero-file rejection without a verified target, precedence preservation, resolved vault/source diagnosability)
- Real-surface manual QA: raw stdio JSON-RPC against `dist/cli/oms.js mcp` from a non-vault cwd - global routing lands the note in the registered vault with a receipt; empty home yields a structured `target-unverified` rejection and zero files; cross-process overwrite safety (`note-exists`) and `ask`/`contract-violation` shapes verified.