### PR TITLE
feat(release): adopt gajae-code release principles - changelog-first, tag-driven npm publish

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 ## Verification evidence
 - [ ] npm run build
 - [ ] npm test
+- [ ] User-facing change? Added an entry under `## [Unreleased]` in CHANGELOG.md
 - [ ] Additional focused checks documented below
 
 ## Risks / follow-ups

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,12 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+      - run: node scripts/changelog-history-guard.mjs
       - run: npm ci
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,123 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "oms-v*"
   workflow_dispatch:
     inputs:
+      rehearsal:
+        description: "Rehearsal run: full pipeline with a dry-run publish and no GitHub Release"
+        required: false
+        default: true
+        type: boolean
       plugin_validation_attestation:
-        description: "Required JSON attestation when Claude CLI validation cannot run in the workflow"
-        required: true
+        description: "Emergency fallback: JSON attestation (or path) used when the Claude CLI cannot run here"
+        required: false
         type: string
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
-  publish-npm:
+  release:
     runs-on: ubuntu-latest
     env:
       OMS_REQUIRE_PLUGIN_VALIDATION: "1"
       OMS_PLUGIN_VALIDATION_ATTESTATION: ${{ inputs.plugin_validation_attestation }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-      - run: npm ci
-      - name: Verify version is release-ready
+
+      - name: Guard tag matches every version carrier
+        if: github.ref_type == 'tag'
         run: |
-          node -e "const p=require('./package.json'); if (p.version === '0.0.0') { throw new Error('Bump package.json version before publishing'); }"
-      - run: npm run release:check
-      - name: Publish to npm with provenance
+          set -euo pipefail
+          PKG=$(node -p "require('./package.json').version")
+          CLAUDE=$(node -p "require('./adapters/claude-code/.claude-plugin/plugin.json').version")
+          CODEX=$(node -p "require('./adapters/codex/.codex-plugin/plugin.json').version")
+          HERMES=$(node -p "require('./adapters/hermes/manifest.json').version")
+          echo "tag=$GITHUB_REF_NAME package.json=$PKG claude=$CLAUDE codex=$CODEX hermes=$HERMES"
+          if [ "$GITHUB_REF_NAME" != "oms-v$PKG" ] \
+            || [ "$CLAUDE" != "$PKG" ] \
+            || [ "$CODEX" != "$PKG" ] \
+            || [ "$HERMES" != "$PKG" ]; then
+            echo "::error::version carriers are out of lockstep with the tag"
+            echo "  tag                                          = $GITHUB_REF_NAME (expected oms-v$PKG)"
+            echo "  package.json                                 = $PKG"
+            echo "  adapters/claude-code/.claude-plugin/plugin.json = $CLAUDE"
+            echo "  adapters/codex/.codex-plugin/plugin.json       = $CODEX"
+            echo "  adapters/hermes/manifest.json                  = $HERMES"
+            exit 1
+          fi
+
+      - run: npm ci
+
+      - name: Install Claude CLI for plugin validation
+        run: |
+          set -uo pipefail
+          if npm install -g @anthropic-ai/claude-code && claude --version; then
+            echo "claude CLI available; release:check will run the real plugin validation"
+            exit 0
+          fi
+          if [ -n "${ATTESTATION:-}" ]; then
+            echo "::warning::Claude CLI unavailable; falling back to the provided plugin_validation_attestation input"
+            exit 0
+          fi
+          echo "::error::ENVIRONMENT failure: could not install or run the Claude CLI (@anthropic-ai/claude-code)."
+          echo "Remediation: run 'claude plugin validate adapters/claude-code' locally and either"
+          echo "  (a) commit the attestation file at .oms-release/plugin-validation.json, or"
+          echo "  (b) re-run this workflow via workflow_dispatch with the plugin_validation_attestation input set."
+          echo "Do NOT disable OMS_REQUIRE_PLUGIN_VALIDATION."
+          exit 1
         env:
-          # Optional: token auth for classic npm publishing. If this secret is absent,
-          # npm can still publish through trusted publishing/OIDC when the package is configured for it.
+          ATTESTATION: ${{ inputs.plugin_validation_attestation }}
+
+      - run: npm run release:check
+
+      - name: Publish to npm with provenance
+        if: github.ref_type == 'tag'
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
+        run: |
+          set -euo pipefail
+          V=$(node -p "require('./package.json').version")
+          rc=0
+          node scripts/npm-version-exists.mjs "$V" || rc=$?
+          case "$rc" in
+            0)
+              echo "oh-my-second-brain@$V already published - idempotent re-run, skipping publish"
+              ;;
+            1)
+              npm publish --provenance --access public
+              ;;
+            *)
+              echo "::error::registry check failed (exit $rc); refusing to publish on an inconclusive result"
+              exit "$rc"
+              ;;
+          esac
+
+      - name: Dry-run publish (rehearsal)
+        if: github.event_name == 'workflow_dispatch'
+        run: npm publish --dry-run --access public
+
+      - name: Create GitHub Release
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          V=$(node -p "require('./package.json').version")
+          node scripts/extract-release-notes.mjs "$V" > /tmp/notes.md
+          gh release view "$GITHUB_REF_NAME" \
+            || gh release create "$GITHUB_REF_NAME" \
+              --title "oms v$V" \
+              --notes-file /tmp/notes.md \
+              --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,29 @@ jobs:
 
       - name: Dry-run publish (rehearsal)
         if: github.event_name == 'workflow_dispatch'
-        run: npm publish --dry-run --access public
+        run: |
+          set -uo pipefail
+          # A rehearsal runs on the CURRENT version, which is normally already on the
+          # registry. `npm publish --dry-run` still performs the server-side
+          # "cannot publish over previously published versions" precondition check, so
+          # that one specific error is the expected rehearsal outcome, not a failure.
+          # Every other error (packing, auth, manifest) must still fail the job.
+          set +e
+          out=$(npm publish --dry-run --access public 2>&1)
+          rc=$?
+          set -e
+          echo "$out"
+          if [ "$rc" -eq 0 ]; then
+            echo "[rehearsal] npm publish --dry-run succeeded"
+            exit 0
+          fi
+          V=$(node -p "require('./package.json').version")
+          if echo "$out" | grep -qF "You cannot publish over the previously published versions: $V"; then
+            echo "[rehearsal] npm publish --dry-run reached the registry precondition for the already-published version $V - packaging verified, publish correctly refused"
+            exit 0
+          fi
+          echo "::error::rehearsal dry-run publish failed for a reason other than the already-published guard"
+          exit "$rc"
 
       - name: Create GitHub Release
         if: github.ref_type == 'tag'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,16 @@ after editing imports.
 
 ---
 
+## Commit, changelog, release
+
+- **Changelog entries first.** Every user-facing change goes under `## [Unreleased]` in CHANGELOG.md in the same PR as the code change. Write prose describing what changed and why it matters—not a copy-paste of the commit message.
+- **NEVER edit or remove released sections.** Released `## [X.Y.Z]` sections are immutable. CI enforces this via `scripts/changelog-history-guard.mjs`. If you need to correct a past release's notes, fix forward by shipping a patch version.
+- **Rebase conflicts in [Unreleased].** When merging PRs cause conflicts in the [Unreleased] section, resolve by keeping BOTH entries. Do not discard either contributor's changelog entry.
+- **Release flow.** Run `npm run release -- <X.Y.Z>` on main to coordinate version bumps, changelog rollover, and tag creation. See [docs/release.md](./docs/release.md) for full details.
+- **Published versions are immutable.** Once a version is published to npm and its tag exists on GitHub, the tag cannot be re-pushed or deleted. Fix forward by releasing a newer patch, minor, or major version instead. Never use `git push --force` or `npm unpublish`.
+
+---
+
 ## core/AGENTS.md vs. AGENTS.md
 
 | File | Purpose | Owner |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.1.9] - 2026-08-14
+
+### Added
+- MCP `write` is now the single vault write window, with `mode: create | append | update`, returning `ask`, `inbox`, `written`, or `rejected` so the agent always knows what happened to a note (#52).
+- A contract gate validates required fields, types, enums, and routing law before anything touches the vault. Extra keys survive the round trip (`additionalProperties: preserve`).
+- Thin write skills for each host: `/oms-write` on Claude, `$oms-write` on Codex, and `write` on Hermes.
+
+### Changed
+- **Breaking:** capture skills are gone (`/oms-capture`, `$oms-capture`, Hermes `capture`), along with the MCP aliases `oms_capture_prepare` and `oms_capture_commit`. After upgrading, reinstall the host adapters with `oms update --yes` or `oms install --runtime <host> --vault <path> --yes`.
+
+### Fixed
+- Transitive production advisories cleared through same-major overrides for `hono`, `@hono/node-server`, `body-parser`, `fast-uri`, `ip-address`, `nanoid`, and `tar`. No new runtime dependencies were added.
+
+## [0.1.8] - 2026-06-17
+
+### Fixed
+- Upstage Solar embeddings work again: the model id `solar-embedding-1-passage` didn't exist, so every embedding call returned HTTP 400. It's now `embedding-passage` (4096d).
+- `embed()` guards its inputs. Empty input becomes a zero vector, and input over 4000 tokens is shrunk and retried, so one oversized or empty chunk no longer fails a whole vault sync.
+- Transitive high-severity advisory in `hono` (pulled in by `@modelcontextprotocol/sdk`) resolved via `overrides: hono ^4.12.25`.
+
+### Changed
+- Claude Code, Codex, and Hermes adapter manifests are synced to 0.1.8.
+
+## [0.1.7] - 2026-06-05
+
+> No GitHub Release was published for the `oms-v0.1.7` tag. This section is reconstructed from the commits between `oms-v0.1.6` and `oms-v0.1.7`.
+
+### Added
+- Live graph retrieval plus fail-soft qmd fusion, so retrieval keeps working when the optional qmd side is unavailable.
+- MCP retrieval context surfaced to hosts.
+
+### Changed
+- The npm package root is the runtime asset root: built releases resolve `core/` and `adapters/` from the package root, matching the source layout.
+- `oh-my-second-brain` becomes the canonical repository, npm package, and installed command, with `oms` kept as a compatibility alias for existing MCP, skill, and vault `.oms` surfaces.
+- Install docs point at 0.1.7 so the one-line and npm install examples resolve to the published version.
+- The release workflow no longer requires an `NPM_TOKEN` preflight, allowing npm trusted publishing over OIDC while still using `NODE_AUTH_TOKEN` when the secret exists.
+
+### Fixed
+- Frontmatter diagnostics are tolerant: malformed frontmatter no longer blocks retrieve or build paths.
+
+## [0.1.6] - 2026-06-02
+
+### Changed
+- The project is published to npm as `oh-my-second-brain`, while `oms` stays the CLI, MCP, skill, and repo slug.
+- The installer defaults to the published npm package instead of `npx` against GitHub release URLs.
+- Host MCP registration now points at the installed `oms mcp --vault ...` command.
+
+## [0.1.5] - 2026-06-02
+
+### Changed
+- Oh My Second Brain is the project and display name; `oms` remains the short technical slug for the package, CLI, MCP server, skills, and release assets.
+- Human-facing docs, adapter manifests, host shims, skills, CLI output, MCP tool titles, and installer text all use the Oh My Second Brain name.
+- Release package URLs point at `oms-v0.1.5` / `oms-0.1.5.tgz`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+- The npm package now ships `CHANGELOG.md`, so release notes are available offline and in version control.
+- Releases are published by CI from `oms-v*` tags with npm provenance and an auto-generated GitHub Release whose notes come from the CHANGELOG.
+- Maintainers release with a single command: `npm run release -- <X.Y.Z>` rolls the `[Unreleased]` section into a versioned entry, bumps all version carriers (package.json, plugin manifests), commits, tags, and pushes atomically.
+
 ## [0.1.9] - 2026-08-14
 
 ### Added

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,19 @@
 
 Oh My Second Brain releases are npm-first and Claude Code validated. The release process must prove the published tarball works, not merely the repository checkout.
 
+Releasing is one operator command. Everything after the tag push belongs to CI.
+
+## Principles
+
+Six rules shape this pipeline. They're adopted from [gajae-code](https://github.com/Yeachan-Heo/gajae-code), which the project owner picked as the reference release discipline.
+
+1. **CHANGELOG-first release messages.** Contributors write user-facing notes under `## [Unreleased]` in `CHANGELOG.md` in the same PR as the change. Release notes are never reconstructed from git log at release time. `scripts/changelog-history-guard.mjs` runs in `ci.yml` and fails the build if a released `## [X.Y.Z]` heading that exists on `origin/main` disappears from the working tree.
+2. **One-command operator release.** `npm run release -- <X.Y.Z>` does preflight, lockstep version bump, changelog roll, `release:check`, commit, tag, atomic push, and CI watch. There's no checklist to follow by hand.
+3. **Tag immutability and fix-forward.** An `oms-v*` tag is never retagged, deleted, or force-pushed. A bad release is corrected by committing the fix on `main` and releasing a newer version.
+4. **Tag equals version.** The tag `oms-vX.Y.Z` must match `package.json` and all three adapter manifests. CI checks this before anything else and refuses to publish when the carriers drift.
+5. **CI-only publish.** `npm publish` runs inside `.github/workflows/release.yml` and nowhere else. There is no local publish path, and the operator script never invokes npm publish.
+6. **Tested release logic.** All non-trivial release logic lives in `scripts/release-lib.mjs` as pure functions (changelog roll, notes extraction, version bump, lockstep comparison, semver checks) covered by vitest. The scripts around it stay thin.
+
 ## Release contract
 
 The npm package root is the runtime asset root. A releasable tarball must include:
@@ -17,6 +30,7 @@ The npm package root is the runtime asset root. A releasable tarball must includ
 - `docs/release.md`
 - `scripts/install.sh`
 - `scripts/uninstall.sh`
+- `CHANGELOG.md`
 
 `src/` is TypeScript source only. Bundled host/ontology assets intentionally stay
 at the package root so the built CLI can read the same package-root layout in
@@ -24,15 +38,45 @@ source checkouts and in published tarballs.
 
 Codex and Hermes adapter files are packaged as host-native skill/rule bundles plus MCP registrations; release notes must describe the exact installed paths and avoid claiming behavior beyond the shipped skills and MCP tools.
 
-## Local release gate
-
-Run this before tagging or publishing:
+## Operator flow
 
 ```bash
-npm run release:check
+npm run release -- 0.2.0
 ```
 
-`release:check` runs:
+That's the whole release. `scripts/release.mjs` runs these stages in order and aborts at the first failure.
+
+### 1. Preflight (nothing is mutated yet)
+
+Every check below runs before a single file or git ref changes, so a failed preflight leaves the tree exactly as it was:
+
+- `git status --porcelain` must be empty. A dirty tree aborts with the offending lines listed.
+- The current branch must be `main`. Any other branch aborts naming where you actually are.
+- `git fetch origin main` must succeed, and `HEAD` must equal `origin/main`. Being ahead or behind aborts with both SHAs.
+- `gh auth status` must exit 0. Otherwise: run `gh auth login` first.
+- The version argument must be a stable `X.Y.Z` (no prereleases, no `v` prefix).
+- The new version must be strictly greater than the current `package.json` version.
+- The tag `oms-v<version>` must not exist locally (`git tag -l`) or on origin (`git ls-remote --tags origin`). If it does, the abort message says tags are immutable and asks for a newer version.
+
+### 2. Lockstep version bump
+
+Five files get the new version: `package.json`, `package-lock.json` (root `version` plus `packages[""].version`), `adapters/claude-code/.claude-plugin/plugin.json`, `adapters/codex/.codex-plugin/plugin.json`, and `adapters/hermes/manifest.json`. The script then re-reads all of them and asserts consistency. If anything is off, it stops and tells you to run `git checkout -- .`, since nothing has been committed yet.
+
+### 3. Changelog roll
+
+In `CHANGELOG.md`, `## [Unreleased]` becomes `## [<version>] - <UTC date>`, and a fresh empty `## [Unreleased]` is reinstated on top. Released sections pass through byte-identical.
+
+An empty `## [Unreleased]` body is a hard error: *empty [Unreleased] - write release notes before releasing*. Write the notes, or pass the escape hatch when a release genuinely carries nothing user-facing:
+
+```bash
+npm run release -- 0.2.0 --allow-empty-changelog
+```
+
+With that flag the version heading is inserted below an intact empty `## [Unreleased]`, giving the GitHub Release an empty section. Use it sparingly; the flag exists for mechanical releases, not for skipping the write-up.
+
+### 4. Release gate
+
+`npm run release:check` runs with inherited stdio, so you see every child's output:
 
 1. `npm run lint`
 2. `npm run build`
@@ -44,17 +88,62 @@ npm run release:check
 
 `release:pack` inspects `npm pack --dry-run --json` and fails if required runtime assets are missing. `release:artifact-smoke` creates a real tarball, unpacks it into a temp directory, installs production dependencies there, and runs setup, host install dry-run, update dry-run, and MCP smoke from the extracted package root.
 
+If the gate fails, the bump and changelog roll are still sitting uncommitted in your working tree. Fix the failure and re-run, or `git checkout -- .` to restore.
+
+### 5. Commit, tag, atomic push
+
+`git add -u`, commit `chore(release): bump version to <version>`, `git tag oms-v<version>`, then `git push --atomic origin main oms-v<version>`. The push is atomic, so a rejected push moves neither ref and nothing is published. Fix the cause and re-run the push.
+
+### 6. CI watch
+
+The script polls `gh run list --workflow=release.yml` every 15 seconds for up to 30 minutes, matching runs by `headSha`, and reports the conclusion. On failure or timeout it prints fix-forward guidance: the tag is immutable, never retag or force-push, commit the fix on `main` and release a newer version, inspect the run with `gh run view <databaseId> --log-failed`.
+
+If you lose the terminal, reattach to the run for the current `HEAD`:
+
+```bash
+npm run release -- watch
+```
+
+## CI flow
+
+Pushing an `oms-v*` tag triggers `.github/workflows/release.yml`. Steps, in order:
+
+1. **Guard tag matches every version carrier** (tag runs only). Reads `package.json` plus all three adapter manifests and compares them against `$GITHUB_REF_NAME`. Any drift fails the job and prints each value, so you see exactly which carrier is out of lockstep.
+2. `npm ci`.
+3. **Install Claude CLI for plugin validation**. Installs `@anthropic-ai/claude-code` globally and runs `claude --version`. Success means the later gate performs real plugin validation. Failure is an environment failure and stops the job with remediation text, unless an attestation input was supplied on a dispatch run.
+4. `npm run release:check`. Same gate you ran locally, this time with `OMS_REQUIRE_PLUGIN_VALIDATION=1` set, so `release:plugin` cannot silently skip validation.
+5. **Publish to npm with provenance** (tag runs only). Calls `node scripts/npm-version-exists.mjs <version>` first: exit 1 (absent) leads to `npm publish --provenance --access public`; exit 0 (already published) logs an idempotent-re-run skip; any other exit means the registry check itself failed, and the job refuses to publish on an inconclusive result.
+6. **Create GitHub Release** (tag runs only). `node scripts/extract-release-notes.mjs <version>` reads `CHANGELOG.md` and writes that version's section body to `/tmp/notes.md`, then `gh release view "$GITHUB_REF_NAME" || gh release create ... --notes-file /tmp/notes.md --verify-tag`. An existing release is left untouched. An empty or missing changelog section fails the step rather than shipping blank notes.
+
+The job carries `contents: write` for the GitHub Release and `id-token: write` for npm provenance.
+
+### Idempotent re-runs
+
+Re-running a failed tag run is safe. The registry check keeps the publish step from double-publishing, and `gh release view` keeps the release step from recreating an existing release. Re-running the same tag after a partial failure completes the missing half.
+
+## Rehearsal
+
+The whole pipeline, including headless Claude CLI validation, is provable without publishing anything:
+
+```bash
+gh workflow run release.yml --ref <branch> -f rehearsal=true
+```
+
+A `workflow_dispatch` run has no tag ref, so the guard, publish, and GitHub Release steps are skipped by their `if:` conditions. What still runs: `npm ci`, the Claude CLI install and version check, the full `release:check` (real `claude plugin validate`), and the **Dry-run publish (rehearsal)** step, `npm publish --dry-run --access public`. No token, no registry write, no release page.
+
+Run a rehearsal on any branch that changes the release pipeline itself.
+
 ## Claude plugin validation
 
-Preferred validation:
+Validation is CI-first. The workflow installs the Claude CLI and `scripts/release-plugin.mjs` runs the real check:
 
 ```bash
 claude plugin validate adapters/claude-code
 ```
 
-If a release environment cannot run the Claude CLI, publishing is blocked unless an explicit validation attestation is provided through `OMS_PLUGIN_VALIDATION_ATTESTATION`.
+That's also the command to run locally when debugging an adapter failure. A `claude plugin validate` failure inside `release:check` is a plugin content error: fix `adapters/claude-code`, don't work around the pipeline. Never disable `OMS_REQUIRE_PLUGIN_VALIDATION`.
 
-Required attestation fields:
+Only when the CLI itself can't run (install or `claude --version` fails, an environment failure) does the attestation fallback apply. `release-plugin.mjs` reads `OMS_PLUGIN_VALIDATION_ATTESTATION` as inline JSON or as a path to a JSON file, requires `actor`, `timestamp`, `command`, `pluginPath`, and `exitCode`, and rejects anything with a non-zero `exitCode`.
 
 ```json
 {
@@ -69,18 +158,17 @@ Required attestation fields:
 }
 ```
 
-## GitHub release workflow
+## Emergency dispatch
 
-The v0 release workflow is **manual dispatch only** so the operator must provide the Claude plugin validation attestation explicitly when the GitHub runner cannot run Claude Code itself. It is credential-gated and uses npm provenance:
+`workflow_dispatch` is the emergency and rehearsal path, never the normal one. It's how you carry an attestation into a run whose environment can't host the Claude CLI:
 
-- It runs only through `workflow_dispatch`.
-- It requires `plugin_validation_attestation` input.
-- It runs the full release gate before publish.
-- It requires `NPM_TOKEN`.
-- It requires `id-token: write` for provenance.
-- It refuses to publish `0.0.0`; bump to a real semver first.
-- It runs `npm publish --provenance --access public` only in the publish job.
-- It blocks publish if Claude plugin validation was skipped without attestation.
+```bash
+gh workflow run release.yml --ref main \
+  -f rehearsal=true \
+  -f plugin_validation_attestation="$(cat plugin-validation.json)"
+```
+
+A dispatch run never publishes for real: the publish and GitHub Release steps are gated on `github.ref_type == 'tag'`. An emergency real release still goes out the normal way, by pushing a tag through `npm run release -- <X.Y.Z>`.
 
 ## Version and package-name preflight
 
@@ -91,6 +179,10 @@ Before the first public release:
 3. Keep `adapters/claude-code/.claude-plugin/plugin.json` version in sync with `package.json` unless a future ADR deliberately splits package/plugin versioning.
 4. Confirm release notes list Codex rules/skills and Hermes skill-bundle install paths, plus the MCP registration files that make capture/retrieve tools available.
 
+The operator script handles items 2 and 3 automatically on every release by bumping all version carriers in lockstep.
+
 ## Rollback posture
 
 Do not rely on npm unpublish as a normal rollback path. Prefer publishing a fixed patch release and documenting any broken version in release notes.
+
+Concretely: leave the bad tag and the bad npm version alone, commit the fix on `main`, add a note under `## [Unreleased]` saying what broke, and run `npm run release -- <next X.Y.Z>`. Fix-forward is the only rollback this project supports.

--- a/docs/release.md
+++ b/docs/release.md
@@ -129,7 +129,7 @@ The whole pipeline, including headless Claude CLI validation, is provable withou
 gh workflow run release.yml --ref <branch> -f rehearsal=true
 ```
 
-A `workflow_dispatch` run has no tag ref, so the guard, publish, and GitHub Release steps are skipped by their `if:` conditions. What still runs: `npm ci`, the Claude CLI install and version check, the full `release:check` (real `claude plugin validate`), and the **Dry-run publish (rehearsal)** step, `npm publish --dry-run --access public`. No token, no registry write, no release page.
+A `workflow_dispatch` run has no tag ref, so the guard, publish, and GitHub Release steps are skipped by their `if:` conditions. What still runs: `npm ci`, the Claude CLI install and version check, the full `release:check` (real `claude plugin validate`), and the **Dry-run publish (rehearsal)** step, `npm publish --dry-run --access public`. No token, no registry write, no release page. The dry-run step always runs against the current (normally already-published) version; `npm publish --dry-run` performs the server-side precondition check and rejects publishing over previously published versions. The rehearsal treats this specific rejection for the current version as the expected outcome, confirming the package is valid; any other error (packing, manifest, or already-published for a different version) still fails the step.
 
 Run a rehearsal on any branch that changes the release pipeline itself.
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "audit": "npm audit --omit=dev",
+    "release": "node scripts/release.mjs",
     "release:pack": "node scripts/release-pack.mjs",
     "release:setup-smoke": "node scripts/release-artifact-smoke.mjs --setup-only",
     "release:mcp-smoke": "node scripts/release-artifact-smoke.mjs --mcp-only",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "docs/install.md",
     "docs/release.md",
     "scripts/install.sh",
-    "scripts/uninstall.sh"
+    "scripts/uninstall.sh",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=20"

--- a/scripts/changelog-history-guard.mjs
+++ b/scripts/changelog-history-guard.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // Fails CI loudly if a previously-released CHANGELOG.md heading disappears
 // between the base ref and the working tree. A missing base ref is a CI
 // config failure (exit 2), never a silent pass.
@@ -5,13 +6,17 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { missingReleasedHeadings } from "./release-lib.mjs";
 
+function fail(message, code = 1) {
+  console.error(`changelog-history-guard: ${message}`);
+  process.exit(code);
+}
+
 const base = process.env.CHANGELOG_GUARD_BASE || "origin/main";
 
 try {
   execFileSync("git", ["rev-parse", "--verify", base], { stdio: "pipe" });
 } catch {
-  console.error(`changelog-history-guard: base ref '${base}' does not exist or is not fetched.`);
-  process.exit(2);
+  fail(`base ref '${base}' does not exist or is not fetched.`, 2);
 }
 
 let baseContent;
@@ -37,13 +42,8 @@ try {
 const missing = missingReleasedHeadings(baseContent, headContent);
 
 if (missing.length > 0) {
-  console.error(
-    `changelog-history-guard: ${missing.length} released heading(s) present at '${base}' are missing from the working tree CHANGELOG.md:`,
-  );
-  for (const heading of missing) {
-    console.error(`  - ${heading}`);
-  }
-  process.exit(1);
+  const message = `${missing.length} released heading(s) present at '${base}' are missing from the working tree CHANGELOG.md:\n${missing.map((h) => `  - ${h}`).join("\n")}`;
+  fail(message, 1);
 }
 
 console.log("changelog-history-guard: ok - no released headings were removed.");

--- a/scripts/changelog-history-guard.mjs
+++ b/scripts/changelog-history-guard.mjs
@@ -1,0 +1,50 @@
+// Fails CI loudly if a previously-released CHANGELOG.md heading disappears
+// between the base ref and the working tree. A missing base ref is a CI
+// config failure (exit 2), never a silent pass.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { missingReleasedHeadings } from "./release-lib.mjs";
+
+const base = process.env.CHANGELOG_GUARD_BASE || "origin/main";
+
+try {
+  execFileSync("git", ["rev-parse", "--verify", base], { stdio: "pipe" });
+} catch {
+  console.error(`changelog-history-guard: base ref '${base}' does not exist or is not fetched.`);
+  process.exit(2);
+}
+
+let baseContent;
+try {
+  baseContent = execFileSync("git", ["show", `${base}:CHANGELOG.md`], {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+} catch {
+  console.log(
+    `changelog-history-guard: CHANGELOG.md does not exist at '${base}' yet - treating as first introduction. ok.`,
+  );
+  process.exit(0);
+}
+
+let headContent;
+try {
+  headContent = readFileSync("CHANGELOG.md", "utf8");
+} catch {
+  headContent = "";
+}
+
+const missing = missingReleasedHeadings(baseContent, headContent);
+
+if (missing.length > 0) {
+  console.error(
+    `changelog-history-guard: ${missing.length} released heading(s) present at '${base}' are missing from the working tree CHANGELOG.md:`,
+  );
+  for (const heading of missing) {
+    console.error(`  - ${heading}`);
+  }
+  process.exit(1);
+}
+
+console.log("changelog-history-guard: ok - no released headings were removed.");
+process.exit(0);

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Print the CHANGELOG.md section body for a version (used by release.yml for GitHub Release notes).
+// Usage: node scripts/extract-release-notes.mjs <X.Y.Z>
+import { readFileSync } from "node:fs";
+
+import { extractReleaseNotes } from "./release-lib.mjs";
+
+const version = process.argv[2];
+if (!version) {
+  console.error("[extract-release-notes] usage: node scripts/extract-release-notes.mjs <X.Y.Z>");
+  process.exit(1);
+}
+
+let content;
+try {
+  content = readFileSync("CHANGELOG.md", "utf-8");
+} catch (error) {
+  console.error(`[extract-release-notes] cannot read CHANGELOG.md: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}
+
+let notes;
+try {
+  notes = extractReleaseNotes(content, version);
+} catch (error) {
+  console.error(`[extract-release-notes] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}
+
+if (notes === "") {
+  console.error(`[extract-release-notes] changelog section for ${version} is empty`);
+  process.exit(1);
+}
+
+process.stdout.write(`${notes}\n`);

--- a/scripts/npm-version-exists.mjs
+++ b/scripts/npm-version-exists.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Registry presence check for idempotent re-runs of release.yml.
+// Usage: node scripts/npm-version-exists.mjs <X.Y.Z>
+// Exit 0 = version is published, 1 = version is absent, 2 = the check itself failed
+// (network/registry/auth error - NEVER report an unreachable registry as 'absent').
+import { execFileSync } from "node:child_process";
+
+const PACKAGE_NAME = "oh-my-second-brain";
+
+const version = process.argv[2];
+if (!version) {
+  console.error("[npm-version-exists] usage: node scripts/npm-version-exists.mjs <X.Y.Z>");
+  process.exit(2);
+}
+
+const spec = `${PACKAGE_NAME}@${version}`;
+
+let stdout;
+try {
+  stdout = execFileSync("npm", ["view", spec, "version"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+} catch (error) {
+  const stderr = typeof error?.stderr === "string" ? error.stderr : "";
+  if (/E404|404 Not Found|is not in this registry|no such package available/i.test(stderr)) {
+    console.log(`[npm-version-exists] ${spec} is not published`);
+    process.exit(1);
+  }
+  process.stderr.write(stderr);
+  console.error(`[npm-version-exists] registry check failed for ${spec}: npm view exited ${error?.status ?? "unknown"}`);
+  process.exit(2);
+}
+
+const printed = stdout.trim();
+if (printed === "") {
+  // npm exits 0 with empty stdout when the name exists but the exact version does not.
+  console.log(`[npm-version-exists] ${spec} is not published`);
+  process.exit(1);
+}
+
+console.log(`[npm-version-exists] ${spec} is published (${printed})`);
+process.exit(0);

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -1,0 +1,197 @@
+// Pure release helpers shared by scripts/*.mjs and test/release-lib.test.ts.
+// No file I/O, no process.exit, no child_process: every function maps input to output.
+
+const STABLE_VERSION = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+const CHANGELOG_HEADER = "# Changelog";
+const UNRELEASED_HEADING = "## [Unreleased]";
+const RELEASED_HEADING = /^## \[(\d+\.\d+\.\d+)\]/gm;
+
+/**
+ * @param {string} version
+ * @returns {boolean} true when version is a stable X.Y.Z release (no prerelease/build metadata).
+ */
+export function isStableVersion(version) {
+  return typeof version === "string" && STABLE_VERSION.test(version);
+}
+
+/**
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean} true when a is strictly greater than b comparing X.Y.Z numerically.
+ */
+export function isVersionGreater(a, b) {
+  const left = versionSegments(a);
+  const right = versionSegments(b);
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] > right[index];
+  }
+  return false;
+}
+
+/**
+ * @param {string} version
+ * @returns {number[]}
+ */
+function versionSegments(version) {
+  if (!isStableVersion(version)) {
+    throw new Error(`invalid version: ${String(version)} (expected X.Y.Z)`);
+  }
+  return version.split(".").map((segment) => Number(segment));
+}
+
+/**
+ * Roll `## [Unreleased]` into a dated release section, keeping released sections byte-identical.
+ *
+ * @param {string} content CHANGELOG.md text
+ * @param {string} version release version (X.Y.Z)
+ * @param {string} date release date (YYYY-MM-DD)
+ * @param {{ allowEmpty?: boolean }} [options] allowEmpty inserts an empty release section instead of throwing
+ * @returns {string} rolled changelog text
+ */
+export function rolledChangelog(content, version, date, options = {}) {
+  const allowEmpty = options.allowEmpty === true;
+  if (typeof content !== "string" || !content.startsWith(`${CHANGELOG_HEADER}\n`)) {
+    throw new Error(`malformed changelog: missing '${CHANGELOG_HEADER}' header on the first line`);
+  }
+  const unreleasedStart = content.indexOf(`\n${UNRELEASED_HEADING}`);
+  if (unreleasedStart === -1) {
+    throw new Error(`malformed changelog: missing '${UNRELEASED_HEADING}' section`);
+  }
+
+  const headingEnd = content.indexOf("\n", unreleasedStart + 1);
+  const bodyStart = headingEnd === -1 ? content.length : headingEnd + 1;
+  const nextSection = content.indexOf("\n## [", bodyStart - 1);
+  const bodyEnd = nextSection === -1 ? content.length : nextSection + 1;
+  const body = content.slice(bodyStart, bodyEnd);
+  const rest = content.slice(bodyEnd);
+  const releaseHeading = `## [${version}] - ${date}`;
+
+  if (body.trim() === "") {
+    if (!allowEmpty) {
+      throw new Error("empty [Unreleased] - write release notes before releasing");
+    }
+    return `${CHANGELOG_HEADER}\n\n${UNRELEASED_HEADING}\n\n${releaseHeading}\n\n${rest}`;
+  }
+
+  return `${CHANGELOG_HEADER}\n\n${UNRELEASED_HEADING}\n\n${releaseHeading}\n${body}${rest}`;
+}
+
+/**
+ * @param {string} content CHANGELOG.md text
+ * @param {string} version release version (X.Y.Z)
+ * @returns {string} trimmed body of the release section
+ */
+export function extractReleaseNotes(content, version) {
+  const heading = new RegExp(`^## \\[${escapeRegExp(version)}\\] - .*$`, "m");
+  const match = heading.exec(content ?? "");
+  if (!match) {
+    throw new Error(`missing changelog section for version ${version}`);
+  }
+  const bodyStart = match.index + match[0].length;
+  const nextSection = content.indexOf("\n## [", bodyStart);
+  const body = nextSection === -1 ? content.slice(bodyStart) : content.slice(bodyStart, nextSection);
+  return body.trim();
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Replace only the first `"version": "..."` pair, preserving all other formatting.
+ *
+ * @param {string} jsonText
+ * @param {string} version
+ * @returns {string}
+ */
+export function bumpedJsonVersion(jsonText, version) {
+  if (!isStableVersion(version)) {
+    throw new Error(`invalid version: ${String(version)} (expected X.Y.Z)`);
+  }
+  const pattern = /"version"(\s*:\s*)"[^"]*"/;
+  if (!pattern.test(jsonText ?? "")) {
+    throw new Error('malformed json: no "version" field found');
+  }
+  return jsonText.replace(pattern, (_match, separator) => `"version"${separator}"${version}"`);
+}
+
+/**
+ * Set both package-lock version carriers (root and packages[""]).
+ *
+ * @param {string} jsonText
+ * @param {string} version
+ * @returns {string} re-stringified lockfile with 2-space indent and trailing newline
+ */
+export function bumpedPackageLock(jsonText, version) {
+  if (!isStableVersion(version)) {
+    throw new Error(`invalid version: ${String(version)} (expected X.Y.Z)`);
+  }
+  const lock = JSON.parse(jsonText);
+  if (!lock || typeof lock !== "object" || !lock.packages || typeof lock.packages !== "object" || !lock.packages[""]) {
+    throw new Error('malformed package-lock: missing packages[""] entry');
+  }
+  lock.version = version;
+  lock.packages[""].version = version;
+  return `${JSON.stringify(lock, null, 2)}\n`;
+}
+
+/**
+ * @param {{
+ *   version: string,
+ *   packageJson: { version?: string },
+ *   packageLock: { version?: string, packages?: Record<string, { version?: string }> },
+ *   claudePluginJson: { version?: string },
+ *   codexPluginJson: { version?: string },
+ *   hermesManifestJson: { version?: string },
+ * }} carriers
+ * @returns {string[]} human-readable mismatch descriptions; empty when every carrier matches
+ */
+export function versionMismatches({
+  version,
+  packageJson,
+  packageLock,
+  claudePluginJson,
+  codexPluginJson,
+  hermesManifestJson,
+}) {
+  const checks = [
+    ["package.json", packageJson?.version],
+    ["package-lock.json", packageLock?.version],
+    ['package-lock.json packages[""]', packageLock?.packages?.[""]?.version],
+    ["adapters/claude-code/.claude-plugin/plugin.json", claudePluginJson?.version],
+    ["adapters/codex/.codex-plugin/plugin.json", codexPluginJson?.version],
+    ["adapters/hermes/manifest.json", hermesManifestJson?.version],
+  ];
+  return checks
+    .filter(([, actual]) => actual !== version)
+    .map(([name, actual]) => `${name}=${actual === undefined ? "missing" : actual} (expected ${version})`);
+}
+
+/**
+ * @param {string} baseContent CHANGELOG.md at the merge base
+ * @param {string} headContent CHANGELOG.md at HEAD
+ * @returns {string[]} released headings present in base but absent in head
+ */
+export function missingReleasedHeadings(baseContent, headContent) {
+  const headHeadings = new Set(releasedHeadings(headContent));
+  return releasedHeadings(baseContent).filter((heading) => !headHeadings.has(heading));
+}
+
+/**
+ * @param {string} content
+ * @returns {string[]} `## [X.Y.Z]` headings in document order (never `## [Unreleased]`)
+ */
+function releasedHeadings(content) {
+  const headings = [];
+  const pattern = new RegExp(RELEASED_HEADING.source, RELEASED_HEADING.flags);
+  let match = pattern.exec(content ?? "");
+  while (match !== null) {
+    headings.push(`## [${match[1]}]`);
+    match = pattern.exec(content);
+  }
+  return headings;
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+// One-command operator release: preflight -> lockstep bump -> changelog roll -> release:check
+// -> commit -> tag -> atomic push -> CI watch. Publishing itself is CI-only (release.yml).
+import { execFileSync, spawnSync } from "node:child_process";
+import { realpathSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  bumpedJsonVersion,
+  bumpedPackageLock,
+  isStableVersion,
+  isVersionGreater,
+  rolledChangelog,
+  versionMismatches,
+} from "./release-lib.mjs";
+
+const TAG_PREFIX = "oms-v";
+const RELEASE_BRANCH = "main";
+const WATCH_POLL_MS = 15_000;
+const WATCH_TIMEOUT_MS = 30 * 60 * 1000;
+const USAGE = "usage: npm run release -- <X.Y.Z> [--allow-empty-changelog] | npm run release -- watch";
+
+const JSON_CARRIERS = {
+  packageJson: "package.json",
+  claudePluginJson: "adapters/claude-code/.claude-plugin/plugin.json",
+  codexPluginJson: "adapters/codex/.codex-plugin/plugin.json",
+  hermesManifestJson: "adapters/hermes/manifest.json",
+};
+const PACKAGE_LOCK = "package-lock.json";
+const CHANGELOG = "CHANGELOG.md";
+
+const FIX_FORWARD = [
+  "fix-forward guidance:",
+  `  - the tag is immutable: never retag, delete, or force-push ${TAG_PREFIX}<version>.`,
+  "  - commit the fix on main and release a NEWER version (npm run release -- <next X.Y.Z>).",
+  "  - inspect the failing run with: gh run view <databaseId> --log-failed",
+].join("\n");
+
+/**
+ * Parse operator CLI arguments. Pure: no I/O, throws on anything invalid.
+ *
+ * @param {string[]} argv arguments after the script path
+ * @returns {{ mode: "watch" } | { mode: "release", version: string, allowEmptyChangelog: boolean }}
+ */
+export function parseReleaseCli(argv) {
+  const args = Array.isArray(argv) ? argv : [];
+  if (args.length === 1 && args[0] === "watch") {
+    return { mode: "watch" };
+  }
+  const [version, ...rest] = args;
+  if (!isStableVersion(version)) {
+    throw new Error(`invalid version: ${version === undefined ? "(none)" : String(version)}\n${USAGE}`);
+  }
+  let allowEmptyChangelog = false;
+  for (const arg of rest) {
+    if (arg === "--allow-empty-changelog") {
+      if (allowEmptyChangelog) {
+        throw new Error(`duplicate flag: ${arg}\n${USAGE}`);
+      }
+      allowEmptyChangelog = true;
+      continue;
+    }
+    throw new Error(`unexpected argument: ${String(arg)}\n${USAGE}`);
+  }
+  return { mode: "release", version, allowEmptyChangelog };
+}
+
+function fail(message) {
+  console.error(`[release] ${message}`);
+  process.exit(1);
+}
+
+/**
+ * Run a command, inheriting stderr so no child output is swallowed.
+ *
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {string} trimmed stdout
+ */
+function capture(command, args) {
+  return execFileSync(command, args, { encoding: "utf-8", stdio: ["ignore", "pipe", "inherit"] }).trim();
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {{ status: number | null, stdout: string }}
+ */
+function tryCapture(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf-8", stdio: ["ignore", "pipe", "inherit"] });
+  return { status: result.status, stdout: (result.stdout ?? "").trim() };
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {number} exit status
+ */
+function runInherit(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+  return result.status ?? 1;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function utcDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Every check aborts before any file or git state is mutated.
+ *
+ * @param {string} version
+ */
+function preflight(version) {
+  const status = tryCapture("git", ["status", "--porcelain"]);
+  if (status.status !== 0) {
+    fail("preflight: `git status --porcelain` failed; run the release from a git working tree.");
+  }
+  if (status.stdout !== "") {
+    const changes = status.stdout
+      .split("\n")
+      .map((line) => `  ${line}`)
+      .join("\n");
+    fail(`preflight: working tree is not clean. Commit or stash these changes before releasing:\n${changes}`);
+  }
+
+  const branch = tryCapture("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (branch.status !== 0) {
+    fail("preflight: could not resolve the current branch.");
+  }
+  if (branch.stdout !== RELEASE_BRANCH) {
+    fail(`preflight: must run on ${RELEASE_BRANCH}, currently on ${branch.stdout}.`);
+  }
+
+  const fetch = tryCapture("git", ["fetch", "origin", RELEASE_BRANCH]);
+  if (fetch.status !== 0) {
+    fail(`preflight: \`git fetch origin ${RELEASE_BRANCH}\` failed; check network access to origin.`);
+  }
+  const head = capture("git", ["rev-parse", "HEAD"]);
+  const upstream = tryCapture("git", ["rev-parse", `origin/${RELEASE_BRANCH}`]);
+  if (upstream.status !== 0) {
+    fail(`preflight: could not resolve origin/${RELEASE_BRANCH}.`);
+  }
+  if (head !== upstream.stdout) {
+    fail(
+      `preflight: HEAD (${head}) is not origin/${RELEASE_BRANCH} (${upstream.stdout}); pull or push before releasing.`,
+    );
+  }
+
+  const auth = spawnSync("gh", ["auth", "status"], { stdio: "inherit" });
+  if (auth.status !== 0) {
+    fail("preflight: `gh auth status` failed; run `gh auth login` before releasing.");
+  }
+
+  if (!isStableVersion(version)) {
+    fail(`preflight: invalid version ${version} (expected stable X.Y.Z).\n${USAGE}`);
+  }
+  const current = readJson(JSON_CARRIERS.packageJson).version;
+  if (!isVersionGreater(version, current)) {
+    fail(`preflight: version ${version} must be greater than the current version ${current}.`);
+  }
+
+  const tag = `${TAG_PREFIX}${version}`;
+  const localTag = tryCapture("git", ["tag", "-l", tag]);
+  if (localTag.status !== 0) {
+    fail("preflight: `git tag -l` failed.");
+  }
+  if (localTag.stdout !== "") {
+    fail(`preflight: tag ${tag} already exists locally; tags are immutable - release a newer version.`);
+  }
+  const remoteTag = tryCapture("git", ["ls-remote", "--tags", "origin", `refs/tags/${tag}`]);
+  if (remoteTag.status !== 0) {
+    fail("preflight: `git ls-remote --tags origin` failed; check network access to origin.");
+  }
+  if (remoteTag.stdout !== "") {
+    fail(`preflight: tag ${tag} already exists on origin; tags are immutable - release a newer version.`);
+  }
+
+  console.log(`[release] preflight ok: ${current} -> ${version} on ${RELEASE_BRANCH}.`);
+}
+
+/**
+ * @param {string} version
+ */
+function bumpVersionCarriers(version) {
+  for (const path of Object.values(JSON_CARRIERS)) {
+    writeFileSync(path, bumpedJsonVersion(readFileSync(path, "utf-8"), version));
+  }
+  writeFileSync(PACKAGE_LOCK, bumpedPackageLock(readFileSync(PACKAGE_LOCK, "utf-8"), version));
+
+  const mismatches = versionMismatches({
+    version,
+    packageJson: readJson(JSON_CARRIERS.packageJson),
+    packageLock: readJson(PACKAGE_LOCK),
+    claudePluginJson: readJson(JSON_CARRIERS.claudePluginJson),
+    codexPluginJson: readJson(JSON_CARRIERS.codexPluginJson),
+    hermesManifestJson: readJson(JSON_CARRIERS.hermesManifestJson),
+  });
+  if (mismatches.length > 0) {
+    fail(
+      `version bump left carriers inconsistent (nothing committed; run \`git checkout -- .\` to restore):\n${mismatches
+        .map((item) => `  - ${item}`)
+        .join("\n")}`,
+    );
+  }
+  console.log(`[release] bumped all version carriers to ${version}.`);
+}
+
+/**
+ * @param {string} version
+ * @param {boolean} allowEmpty
+ */
+function rollChangelog(version, allowEmpty) {
+  const content = readFileSync(CHANGELOG, "utf-8");
+  let rolled;
+  try {
+    rolled = rolledChangelog(content, version, utcDate(), { allowEmpty });
+  } catch (error) {
+    fail(
+      `changelog roll failed (nothing committed; run \`git checkout -- .\` to restore): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  writeFileSync(CHANGELOG, rolled);
+  console.log(`[release] rolled ${CHANGELOG} into [${version}].`);
+}
+
+/**
+ * Poll release.yml runs for the given commit until one reaches a terminal conclusion.
+ *
+ * @param {string} sha
+ * @returns {never}
+ */
+function watchRelease(sha) {
+  console.log(`[release] watching release.yml runs for ${sha} (poll ${WATCH_POLL_MS / 1000}s, timeout ${WATCH_TIMEOUT_MS / 60000}min).`);
+  const deadline = Date.now() + WATCH_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const listed = tryCapture("gh", [
+      "run",
+      "list",
+      "--workflow=release.yml",
+      "--json",
+      "databaseId,status,conclusion,headSha",
+      "--limit",
+      "10",
+    ]);
+    if (listed.status !== 0) {
+      console.error("[release] `gh run list` failed; retrying after the poll interval.");
+    } else {
+      let runs = [];
+      try {
+        runs = JSON.parse(listed.stdout);
+      } catch (error) {
+        console.error(`[release] could not parse gh run list JSON: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      const run = runs.find((candidate) => candidate.headSha === sha);
+      if (run && run.status === "completed") {
+        if (run.conclusion === "success") {
+          console.log(`[release] ok: release run ${run.databaseId} for ${sha} concluded success.`);
+          process.exit(0);
+        }
+        console.error(`[release] release run ${run.databaseId} for ${sha} concluded ${run.conclusion}.`);
+        console.error(FIX_FORWARD);
+        process.exit(1);
+      }
+      console.log(
+        run
+          ? `[release] run ${run.databaseId} status=${run.status}; waiting.`
+          : `[release] no release.yml run for ${sha} yet; waiting.`,
+      );
+    }
+    sleep(WATCH_POLL_MS);
+  }
+  console.error(`[release] timed out after ${WATCH_TIMEOUT_MS / 60000}min waiting for a release.yml run for ${sha}.`);
+  console.error(FIX_FORWARD);
+  process.exit(1);
+}
+
+/**
+ * Block the operator CLI without busy-waiting (no timers: this script is strictly sequential).
+ *
+ * @param {number} ms
+ */
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * @param {string[]} argv
+ */
+function main(argv) {
+  let parsed;
+  try {
+    parsed = parseReleaseCli(argv);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+
+  if (parsed.mode === "watch") {
+    watchRelease(capture("git", ["rev-parse", "HEAD"]));
+  }
+
+  const { version, allowEmptyChangelog } = parsed;
+  const tag = `${TAG_PREFIX}${version}`;
+
+  preflight(version);
+  bumpVersionCarriers(version);
+  rollChangelog(version, allowEmptyChangelog);
+
+  const checkStatus = runInherit("npm", ["run", "release:check"]);
+  if (checkStatus !== 0) {
+    fail(
+      `npm run release:check failed with exit ${checkStatus}. The version bump and changelog roll are still UNCOMMITTED in your working tree; run \`git checkout -- .\` to restore, or fix the failure and re-run.`,
+    );
+  }
+
+  if (runInherit("git", ["add", "-u"]) !== 0) {
+    fail("`git add -u` failed; the bump and changelog roll remain in the working tree.");
+  }
+  if (runInherit("git", ["commit", "-m", `chore(release): bump version to ${version}`]) !== 0) {
+    fail("`git commit` failed; the bump is staged but uncommitted.");
+  }
+  if (runInherit("git", ["tag", tag]) !== 0) {
+    fail(`\`git tag ${tag}\` failed; the release commit is local-only.`);
+  }
+  if (runInherit("git", ["push", "--atomic", "origin", RELEASE_BRANCH, tag]) !== 0) {
+    fail(
+      `\`git push --atomic origin ${RELEASE_BRANCH} ${tag}\` failed; nothing was published (the push is atomic, so neither ref moved). Fix the push and re-run \`git push --atomic origin ${RELEASE_BRANCH} ${tag}\`.`,
+    );
+  }
+
+  console.log(`[release] pushed ${RELEASE_BRANCH} and ${tag}; CI (release.yml) owns publishing from here.`);
+  watchRelease(capture("git", ["rev-parse", "HEAD"]));
+}
+
+// Run the flow only when executed directly; importing for tests must be inert.
+// realpathSync keeps the comparison honest when the invoked path goes through a symlink
+// (e.g. macOS /tmp -> /private/tmp, or npm bin links).
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(entry);
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
+  main(process.argv.slice(2));
+}

--- a/src/harness/registry.test.ts
+++ b/src/harness/registry.test.ts
@@ -129,4 +129,89 @@ describe("validateHarnessRegistry", () => {
       ]),
     );
   });
+
+  it("reports rootShippedFiles entries with path separators", () => {
+    const base = cloneRegistry();
+    const registry: HarnessSurfaceRegistry = {
+      ...base,
+      packageAssets: {
+        ...base.packageAssets,
+        rootShippedFiles: [...base.packageAssets.rootShippedFiles, "docs/x.md"],
+        npmFiles: [...base.packageAssets.npmFiles, "docs/x.md"],
+      },
+    };
+
+    expect(validateHarnessRegistry(registry)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "forbidden_path",
+          surface: "packageAssets.rootShippedFiles.docs/x.md",
+          value: "docs/x.md",
+        }),
+      ]),
+    );
+  });
+
+  it("reports rootShippedFiles entries with parent directory traversal", () => {
+    const base = cloneRegistry();
+    const registry: HarnessSurfaceRegistry = {
+      ...base,
+      packageAssets: {
+        ...base.packageAssets,
+        rootShippedFiles: [...base.packageAssets.rootShippedFiles, ".."],
+        npmFiles: [...base.packageAssets.npmFiles, ".."],
+      },
+    };
+
+    expect(validateHarnessRegistry(registry)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "forbidden_path",
+          surface: "packageAssets.rootShippedFiles...",
+          value: "..",
+        }),
+      ]),
+    );
+  });
+
+  it("reports rootShippedFiles entries not present in npmFiles", () => {
+    const base = cloneRegistry();
+    const registry: HarnessSurfaceRegistry = {
+      ...base,
+      packageAssets: {
+        ...base.packageAssets,
+        rootShippedFiles: [...base.packageAssets.rootShippedFiles, "MISSING_FILE.txt"],
+      },
+    };
+
+    expect(validateHarnessRegistry(registry)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "missing_path",
+          surface: "packageAssets.rootShippedFiles.MISSING_FILE.txt",
+        }),
+      ]),
+    );
+  });
+
+  it("reports duplicate rootShippedFiles entries", () => {
+    const base = cloneRegistry();
+    const registry: HarnessSurfaceRegistry = {
+      ...base,
+      packageAssets: {
+        ...base.packageAssets,
+        rootShippedFiles: [...base.packageAssets.rootShippedFiles, "package.json", "package.json"],
+      },
+    };
+
+    expect(validateHarnessRegistry(registry)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "duplicate_path",
+          surface: "packageAssets.rootShippedFiles",
+          value: "package.json",
+        }),
+      ]),
+    );
+  });
 });

--- a/src/harness/surface-registry.ts
+++ b/src/harness/surface-registry.ts
@@ -400,6 +400,7 @@ export const harnessSurfaceRegistry: HarnessSurfaceRegistry = {
       "docs/release.md",
       "scripts/install.sh",
       "scripts/uninstall.sh",
+      "CHANGELOG.md",
     ],
     runtimeAssetRoots: [
       { id: "ontology", path: "core/ontology", owner: "core" },

--- a/src/harness/surface-registry.ts
+++ b/src/harness/surface-registry.ts
@@ -58,6 +58,7 @@ export interface HarnessRuntimeAssetRoot {
 
 export interface HarnessPackageAssetSurface {
   readonly npmFiles: readonly string[];
+  readonly rootShippedFiles: readonly string[];
   readonly runtimeAssetRoots: readonly HarnessRuntimeAssetRoot[];
   readonly releaseRequiredPaths: readonly string[];
 }
@@ -400,6 +401,9 @@ export const harnessSurfaceRegistry: HarnessSurfaceRegistry = {
       "docs/release.md",
       "scripts/install.sh",
       "scripts/uninstall.sh",
+      "CHANGELOG.md",
+    ],
+    rootShippedFiles: [
       "CHANGELOG.md",
     ],
     runtimeAssetRoots: [

--- a/src/harness/validation.ts
+++ b/src/harness/validation.ts
@@ -158,6 +158,27 @@ function validatePackagePath(
   }
 }
 
+function validateRootShippedFile(
+  violations: HarnessRegistryViolation[],
+  surface: string,
+  fileName: unknown,
+): void {
+  if (typeof fileName !== "string" || fileName.length === 0) {
+    violations.push({ code: "missing_path", surface, message: `${surface} is missing a file name.` });
+    return;
+  }
+
+  if (fileName.includes("/") || fileName.includes("\\") || fileName === ".." || fileName === ".") {
+    violations.push({
+      code: "forbidden_path",
+      surface,
+      value: fileName,
+      message: `${surface} contains an unsafe root file name: ${fileName}`,
+    });
+    return;
+  }
+}
+
 function validateRuntime(
   violations: HarnessRegistryViolation[],
   surface: string,
@@ -229,8 +250,11 @@ export function validateHarnessRegistry(registry: HarnessSurfaceRegistry): Harne
     registry.packageAssets.npmFiles,
     "duplicate_path",
   );
+  const rootShippedFilesSet = new Set(registry.packageAssets.rootShippedFiles);
   for (const npmFile of registry.packageAssets.npmFiles) {
-    validatePackagePath(violations, `packageAssets.npmFiles.${npmFile}`, npmFile);
+    if (!rootShippedFilesSet.has(npmFile)) {
+      validatePackagePath(violations, `packageAssets.npmFiles.${npmFile}`, npmFile);
+    }
   }
   pushDuplicateViolations(
     violations,
@@ -248,6 +272,23 @@ export function validateHarnessRegistry(registry: HarnessSurfaceRegistry): Harne
     validateOwner(violations, `packageAssets.runtimeAssetRoots.${asset.id}`, asset.owner);
     validatePackagePath(violations, `packageAssets.runtimeAssetRoots.${asset.id}`, asset.path);
   }
+  pushDuplicateViolations(
+    violations,
+    "packageAssets.rootShippedFiles",
+    registry.packageAssets.rootShippedFiles,
+    "duplicate_path",
+  );
+  for (const rootFile of registry.packageAssets.rootShippedFiles) {
+    validateRootShippedFile(violations, `packageAssets.rootShippedFiles.${rootFile}`, rootFile);
+    if (!registry.packageAssets.npmFiles.includes(rootFile)) {
+      violations.push({
+        code: "missing_path",
+        surface: `packageAssets.rootShippedFiles.${rootFile}`,
+        message: `${rootFile} declared in rootShippedFiles must also be in npmFiles`,
+      });
+    }
+  }
+
   pushDuplicateViolations(
     violations,
     "packageAssets.releaseRequiredPaths",

--- a/test/release-cli.test.ts
+++ b/test/release-cli.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error - release.mjs is plain ESM JavaScript shared with scripts/*.mjs (no .d.ts by design)
+import * as releaseCliModule from "../scripts/release.mjs";
+
+type ParsedRelease =
+  | { mode: "watch" }
+  | { mode: "release"; version: string; allowEmptyChangelog: boolean };
+
+interface ReleaseCli {
+  parseReleaseCli(argv: string[]): ParsedRelease;
+}
+
+const { parseReleaseCli } = releaseCliModule as ReleaseCli;
+
+describe("parseReleaseCli", () => {
+  it("parses a stable version into release mode", () => {
+    expect(parseReleaseCli(["1.2.3"])).toEqual({
+      mode: "release",
+      version: "1.2.3",
+      allowEmptyChangelog: false,
+    });
+  });
+
+  it("parses the watch subcommand", () => {
+    expect(parseReleaseCli(["watch"])).toEqual({ mode: "watch" });
+  });
+
+  it("parses --allow-empty-changelog", () => {
+    expect(parseReleaseCli(["0.2.0", "--allow-empty-changelog"])).toEqual({
+      mode: "release",
+      version: "0.2.0",
+      allowEmptyChangelog: true,
+    });
+  });
+
+  it("throws on an invalid version", () => {
+    expect(() => parseReleaseCli(["not-a-version"])).toThrow(/invalid version: not-a-version/);
+    expect(() => parseReleaseCli(["v1.2.3"])).toThrow(/invalid version: v1\.2\.3/);
+    expect(() => parseReleaseCli(["1.2.3-rc.1"])).toThrow(/invalid version/);
+    expect(() => parseReleaseCli(["1.2"])).toThrow(/invalid version/);
+  });
+
+  it("throws on unknown or extra arguments", () => {
+    expect(() => parseReleaseCli(["1.2.3", "--force"])).toThrow(/unexpected argument: --force/);
+    expect(() => parseReleaseCli(["1.2.3", "1.2.4"])).toThrow(/unexpected argument: 1\.2\.4/);
+    expect(() => parseReleaseCli(["watch", "1.2.3"])).toThrow(/invalid version: watch/);
+    expect(() => parseReleaseCli(["1.2.3", "--allow-empty-changelog", "--allow-empty-changelog"])).toThrow(
+      /duplicate flag: --allow-empty-changelog/,
+    );
+  });
+
+  it("throws with usage when no arguments are given", () => {
+    expect(() => parseReleaseCli([])).toThrow(/invalid version: \(none\)/);
+    expect(() => parseReleaseCli([])).toThrow(/usage: npm run release -- <X\.Y\.Z>/);
+  });
+
+  it("exports only the pure parser (main flow stays behind the import.meta guard)", () => {
+    // A non-guarded main would run preflight (git/gh) or exit during this import.
+    expect(Object.keys(releaseCliModule as object)).toEqual(["parseReleaseCli"]);
+  });
+});

--- a/test/release-lib.test.ts
+++ b/test/release-lib.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error - release-lib.mjs is plain ESM JavaScript shared with scripts/*.mjs (no .d.ts by design)
+import * as releaseLibModule from "../scripts/release-lib.mjs";
+
+interface VersionCarrier {
+  version?: string;
+}
+
+interface PackageLockShape extends VersionCarrier {
+  packages?: Record<string, VersionCarrier>;
+}
+
+interface VersionCarriers {
+  version: string;
+  packageJson: VersionCarrier;
+  packageLock: PackageLockShape;
+  claudePluginJson: VersionCarrier;
+  codexPluginJson: VersionCarrier;
+  hermesManifestJson: VersionCarrier;
+}
+
+interface ReleaseLib {
+  isStableVersion(version: string): boolean;
+  isVersionGreater(a: string, b: string): boolean;
+  rolledChangelog(content: string, version: string, date: string, options?: { allowEmpty?: boolean }): string;
+  extractReleaseNotes(content: string, version: string): string;
+  bumpedJsonVersion(jsonText: string, version: string): string;
+  bumpedPackageLock(jsonText: string, version: string): string;
+  versionMismatches(carriers: VersionCarriers): string[];
+  missingReleasedHeadings(baseContent: string, headContent: string): string[];
+}
+
+const {
+  isStableVersion,
+  isVersionGreater,
+  rolledChangelog,
+  extractReleaseNotes,
+  bumpedJsonVersion,
+  bumpedPackageLock,
+  versionMismatches,
+  missingReleasedHeadings,
+} = releaseLibModule as ReleaseLib;
+
+const RELEASED_0_1_9 = "## [0.1.9] - 2026-08-14\n\n### Added\n\n- hermes adapter (#59)\n";
+const RELEASED_0_1_8 = "## [0.1.8] - 2026-06-17\n\n- codex parity fixes\n";
+const CHANGELOG = `# Changelog\n\n## [Unreleased]\n\n- something new\n\n${RELEASED_0_1_9}\n${RELEASED_0_1_8}`;
+const EMPTY_UNRELEASED_CHANGELOG = `# Changelog\n\n## [Unreleased]\n\n${RELEASED_0_1_9}\n${RELEASED_0_1_8}`;
+
+// package-lock.json in this repo carries the version twice: root .version and .packages[""].version.
+const PACKAGE_LOCK = JSON.stringify(
+  {
+    name: "oh-my-second-brain",
+    version: "0.1.9",
+    lockfileVersion: 3,
+    requires: true,
+    packages: {
+      "": { name: "oh-my-second-brain", version: "0.1.9", license: "MIT" },
+      "node_modules/yaml": { version: "2.5.0" },
+    },
+  },
+  null,
+  2,
+);
+
+describe("isStableVersion", () => {
+  it("accepts stable X.Y.Z versions including 0.x", () => {
+    expect(isStableVersion("0.1.9")).toBe(true);
+    expect(isStableVersion("1.0.0")).toBe(true);
+    expect(isStableVersion("10.20.30")).toBe(true);
+  });
+
+  it("rejects prereleases, leading zeros, and garbage", () => {
+    expect(isStableVersion("1.0.0-rc.1")).toBe(false);
+    expect(isStableVersion("01.0.0")).toBe(false);
+    expect(isStableVersion("1.0")).toBe(false);
+    expect(isStableVersion("v1.0.0")).toBe(false);
+    expect(isStableVersion("not-a-version")).toBe(false);
+  });
+});
+
+describe("isVersionGreater", () => {
+  it("compares segments numerically, not lexicographically", () => {
+    expect(isVersionGreater("0.1.10", "0.1.9")).toBe(true);
+    expect(isVersionGreater("0.1.9", "0.1.10")).toBe(false);
+    expect(isVersionGreater("0.2.0", "0.1.9")).toBe(true);
+    expect(isVersionGreater("1.0.0", "0.99.99")).toBe(true);
+  });
+
+  it("returns false for equal versions and throws on malformed input", () => {
+    expect(isVersionGreater("0.1.9", "0.1.9")).toBe(false);
+    expect(() => isVersionGreater("1.0", "0.1.9")).toThrow(/expected X\.Y\.Z/);
+  });
+});
+
+describe("rolledChangelog", () => {
+  it("rolls a non-empty [Unreleased] into a dated section and reinstates an empty [Unreleased]", () => {
+    const rolled = rolledChangelog(CHANGELOG, "0.2.0", "2026-08-17");
+    expect(rolled).toBe(
+      `# Changelog\n\n## [Unreleased]\n\n## [0.2.0] - 2026-08-17\n\n- something new\n\n${RELEASED_0_1_9}\n${RELEASED_0_1_8}`,
+    );
+    expect(extractReleaseNotes(rolled, "0.2.0")).toBe("- something new");
+  });
+
+  it("passes released sections through byte-identically", () => {
+    const rolled = rolledChangelog(CHANGELOG, "0.2.0", "2026-08-17");
+    expect(rolled).toContain(RELEASED_0_1_9);
+    expect(rolled).toContain(RELEASED_0_1_8);
+    expect(rolled.slice(rolled.indexOf("## [0.1.9]"))).toBe(CHANGELOG.slice(CHANGELOG.indexOf("## [0.1.9]")));
+  });
+
+  it("throws when [Unreleased] is empty and allowEmpty is not set", () => {
+    expect(() => rolledChangelog(EMPTY_UNRELEASED_CHANGELOG, "0.2.0", "2026-08-17")).toThrow(/empty \[Unreleased\]/);
+  });
+
+  it("inserts an empty release section below an intact [Unreleased] when allowEmpty is set", () => {
+    const rolled = rolledChangelog(EMPTY_UNRELEASED_CHANGELOG, "0.2.0", "2026-08-17", { allowEmpty: true });
+    expect(rolled).toBe(
+      `# Changelog\n\n## [Unreleased]\n\n## [0.2.0] - 2026-08-17\n\n${RELEASED_0_1_9}\n${RELEASED_0_1_8}`,
+    );
+    expect(extractReleaseNotes(rolled, "0.2.0")).toBe("");
+  });
+
+  it("throws when rolled twice for the same version because [Unreleased] is empty again", () => {
+    const once = rolledChangelog(CHANGELOG, "0.2.0", "2026-08-17");
+    expect(() => rolledChangelog(once, "0.2.0", "2026-08-17")).toThrow(/empty \[Unreleased\]/);
+  });
+
+  it("throws when the '# Changelog' header is missing or malformed", () => {
+    expect(() => rolledChangelog("no header\n\n## [Unreleased]\n\n- x\n", "1.0.0", "2026-01-01")).toThrow(
+      /# Changelog/,
+    );
+    expect(() => rolledChangelog("## Changelog\n\n## [Unreleased]\n\n- x\n", "1.0.0", "2026-01-01")).toThrow(
+      /# Changelog/,
+    );
+    expect(() => rolledChangelog("", "1.0.0", "2026-01-01")).toThrow(/# Changelog/);
+  });
+
+  it("throws when the [Unreleased] section is absent", () => {
+    expect(() => rolledChangelog(`# Changelog\n\n${RELEASED_0_1_9}`, "1.0.0", "2026-01-01")).toThrow(
+      /\[Unreleased\]/,
+    );
+  });
+
+  it("rolls a changelog whose only section is [Unreleased]", () => {
+    expect(rolledChangelog("# Changelog\n\n## [Unreleased]\n\n- first release\n", "0.1.0", "2026-01-01")).toBe(
+      "# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2026-01-01\n\n- first release\n",
+    );
+  });
+});
+
+describe("extractReleaseNotes", () => {
+  it("extracts a middle section trimmed of surrounding blank lines", () => {
+    expect(extractReleaseNotes(CHANGELOG, "0.1.9")).toBe("### Added\n\n- hermes adapter (#59)");
+  });
+
+  it("extracts the last section up to EOF", () => {
+    expect(extractReleaseNotes(CHANGELOG, "0.1.8")).toBe("- codex parity fixes");
+  });
+
+  it("throws when the requested version has no section", () => {
+    expect(() => extractReleaseNotes(CHANGELOG, "9.9.9")).toThrow(/9\.9\.9/);
+    expect(() => extractReleaseNotes("garbage content", "0.1.9")).toThrow(/missing changelog section/);
+  });
+});
+
+describe("bumpedJsonVersion", () => {
+  it("replaces only the first top-level version and preserves formatting", () => {
+    const source = [
+      "{",
+      '  "name": "oh-my-second-brain",',
+      '  "version": "0.1.9",',
+      '  "engines": { "node": ">=20" },',
+      '  "nested": { "version": "0.0.1" }',
+      "}",
+      "",
+    ].join("\n");
+    const bumped = bumpedJsonVersion(source, "0.2.0");
+    expect(bumped).toBe(source.replace('"version": "0.1.9"', '"version": "0.2.0"'));
+    expect(bumped).toContain('"nested": { "version": "0.0.1" }');
+  });
+
+  it("throws on malformed input and invalid versions", () => {
+    expect(() => bumpedJsonVersion('{"name":"x"}', "0.2.0")).toThrow(/no "version" field/);
+    expect(() => bumpedJsonVersion('{"version":"0.1.9"}', "0.2.0-rc.1")).toThrow(/expected X\.Y\.Z/);
+  });
+});
+
+describe("bumpedPackageLock", () => {
+  it("sets both the root version and packages[''] version with a trailing newline", () => {
+    const bumped = bumpedPackageLock(PACKAGE_LOCK, "0.2.0");
+    const parsed = JSON.parse(bumped) as PackageLockShape;
+    expect(parsed.version).toBe("0.2.0");
+    expect(parsed.packages?.[""]?.version).toBe("0.2.0");
+    expect(parsed.packages?.["node_modules/yaml"]?.version).toBe("2.5.0");
+    expect(bumped.endsWith("\n")).toBe(true);
+    expect(bumped).toContain('\n  "version": "0.2.0",');
+  });
+
+  it("throws when the lockfile has no packages[''] entry", () => {
+    expect(() => bumpedPackageLock('{"name":"x","version":"0.1.9"}', "0.2.0")).toThrow(/packages\[""\]/);
+  });
+});
+
+describe("versionMismatches", () => {
+  const consistent = (): VersionCarriers => ({
+    version: "0.2.0",
+    packageJson: { version: "0.2.0" },
+    packageLock: { version: "0.2.0", packages: { "": { version: "0.2.0" } } },
+    claudePluginJson: { version: "0.2.0" },
+    codexPluginJson: { version: "0.2.0" },
+    hermesManifestJson: { version: "0.2.0" },
+  });
+
+  it("returns an empty array when every carrier matches", () => {
+    expect(versionMismatches(consistent())).toEqual([]);
+  });
+
+  it("names each mismatching carrier", () => {
+    const carriers = consistent();
+    carriers.packageJson = { version: "0.1.9" };
+    carriers.packageLock = { version: "0.1.9", packages: { "": { version: "0.1.8" } } };
+    carriers.claudePluginJson = {};
+    carriers.codexPluginJson = { version: "0.1.9" };
+    carriers.hermesManifestJson = { version: "0.1.9" };
+
+    const mismatches = versionMismatches(carriers);
+    expect(mismatches).toHaveLength(6);
+    expect(mismatches[0]).toBe("package.json=0.1.9 (expected 0.2.0)");
+    expect(mismatches[1]).toBe("package-lock.json=0.1.9 (expected 0.2.0)");
+    expect(mismatches[2]).toBe('package-lock.json packages[""]=0.1.8 (expected 0.2.0)');
+    expect(mismatches[3]).toBe("adapters/claude-code/.claude-plugin/plugin.json=missing (expected 0.2.0)");
+    expect(mismatches[4]).toBe("adapters/codex/.codex-plugin/plugin.json=0.1.9 (expected 0.2.0)");
+    expect(mismatches[5]).toBe("adapters/hermes/manifest.json=0.1.9 (expected 0.2.0)");
+  });
+});
+
+describe("missingReleasedHeadings", () => {
+  it("detects a removed released heading", () => {
+    expect(missingReleasedHeadings(CHANGELOG, `# Changelog\n\n## [Unreleased]\n\n${RELEASED_0_1_9}`)).toEqual([
+      "## [0.1.8]",
+    ]);
+  });
+
+  it("returns [] for identical content, added sections, and edited bodies", () => {
+    expect(missingReleasedHeadings(CHANGELOG, CHANGELOG)).toEqual([]);
+    const withNewRelease = rolledChangelog(CHANGELOG, "0.2.0", "2026-08-17");
+    expect(missingReleasedHeadings(CHANGELOG, withNewRelease)).toEqual([]);
+    expect(missingReleasedHeadings(CHANGELOG, CHANGELOG.replace("- codex parity fixes", "- reworded"))).toEqual([]);
+  });
+
+  it("ignores [Unreleased] and treats a missing base changelog as no removals", () => {
+    expect(missingReleasedHeadings("# Changelog\n\n## [Unreleased]\n", "# Changelog\n")).toEqual([]);
+    expect(missingReleasedHeadings("", CHANGELOG)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Ports gajae-code's release discipline to this repo (six principles: CHANGELOG-first release messages, one-command operator release, tag immutability + fix-forward, tag==version binding, CI-only publish, tested release logic).

- **CHANGELOG.md** (new, ships in the tarball): `[Unreleased]` discipline + backfilled 0.1.5-0.1.9 history from published GitHub Releases (0.1.7 reconstructed from its commit range with an inline provenance note). `scripts/changelog-history-guard.mjs` fails CI if a released heading is ever removed.
- **`npm run release -- <X.Y.Z>`** (`scripts/release.mjs`): preflight (clean tree, main, HEAD==origin/main, gh auth, semver-greater, tag absent local+origin) -> lockstep bump of package.json + package-lock + all three adapter manifests -> changelog roll -> `release:check` -> commit, tag `oms-vX.Y.Z`, atomic push -> watches release.yml to a terminal conclusion with fix-forward guidance.
- **`release.yml` rewritten tag-driven**: tag==version guard across all four carriers, real `claude plugin validate` in CI (attestation input kept as emergency fallback), idempotent `npm publish --provenance` (skip if already published, fail-closed on inconclusive registry checks), auto GitHub Release with notes extracted from the CHANGELOG section. `workflow_dispatch` = rehearsal/emergency only; no real publish reachable from dispatch (step-level `if:` gating).
- **Docs**: docs/release.md rewritten around the principles; AGENTS.md gains a "Commit, changelog, release" section; PR template gains a changelog checklist item.
- Pure release logic lives in `scripts/release-lib.mjs` (zero imports) with 24 vitest tests; operator CLI parsing has 7 more; harness registry changes covered incl. negative paths.

## Verification evidence
- [x] npm run build
- [x] npm test (570 tests, 0 failed)
- [x] User-facing change? Added an entry under `## [Unreleased]` in CHANGELOG.md
- [x] Additional focused checks documented below

`npm run release:check` green end-to-end (audit, pack, artifact smoke, real local `claude plugin validate`). **Real CI rehearsal run green**: [run 32043613559](https://github.com/GoBeromsu/oh-my-second-brain/actions/runs/32043613559) - headless Claude CLI validated the plugin for real in CI, dry-run packaged 335 files incl. CHANGELOG.md, publish/GH-release steps correctly skipped, registry and tags untouched. Preflight failure paths exercised on the real CLI in disposable clones (branch, dirty-tree, HEAD-sync, not-greater, local/origin tag immutability) - all exit 1 with zero git mutation. Final verification wave: 4 independent audits (plan compliance, code quality, hands-on QA, scope fidelity) all APPROVE.

## Risks / follow-ups
- The attestation fallback path in release.yml is kept but unproven in CI (rehearsal proved the real-CLI path; fallback triggers only on Claude CLI environment failure).
- The true tag-push publish path is exercised for the first time on the next real release (`npm run release -- 0.1.10`); the rehearsal covers everything up to the registry write.
- Claude CLI version in CI is unpinned (2.1.233 at rehearsal time).
