### PR TITLE
fix: make oms_search genuinely read-only without losing first-search results

### DIFF
--- a/CHANGELOG-mcp.md
+++ b/CHANGELOG-mcp.md
@@ -6,6 +6,11 @@ MCP server tools and resources belong here.
 
 ### Changed
 
+- `oms_search` is genuinely read-only and is now annotated as such. It previously advertised `readOnlyHint: false`, and truthfully so: searching a vault with no index silently created `.oms/` and initialised an SQLite store, and the `embeddingSyncBeforeSearch` family of parameters let any caller turn a search into a write by passing a flag. Neither is possible now. This matters beyond tidiness, because MCP hosts may auto-approve tools that declare themselves read-only.
+
+  Searching an unindexed vault still returns results. Rather than refusing until you run a command, the server builds the lexical index in memory for the life of the session and answers from that, so a first search on a fresh vault behaves as it always did while leaving the vault byte-identical. Once a persistent index exists it is used as-is and a search never rewrites it; refreshing it is `oms semantic sync`'s job.
+
+  Preparing lexical or embedding data on disk is now exclusively `oms_doctor { op: "sync-embeddings" }`, which is annotated as writing and routes through the verified-target kernel. Asking for vector retrieval on a vault with no vectors still fails loudly rather than quietly degrading to lexical.
 - `oms_search` advertises `limit` (default 10), `minScore` (default 0) and `rerank` (default false). The first two are applied at the normalizer, so an options-free query is bounded rather than unlimited. `rerank` is opt-in per ADR-011: `true` reranks only when startup was given a real reranker and otherwise fails loudly with configuration guidance, rather than silently returning unreranked results as if the request had been honoured.
 
 - The public MCP surface is now five tools — `oms_write`, `oms_search`, `oms_link`, `oms_status`, `oms_doctor` — down from twenty-three. The eighteen detail tools are reachable through an `op` parameter on the tool that owns them; nothing was deleted, so no capability is lost, but any client calling a detail tool by its old name must switch to the owning tool plus `op`.

--- a/src/kernel/engine/assemble.ts
+++ b/src/kernel/engine/assemble.ts
@@ -11,7 +11,13 @@
  */
 
 import { requireRealEmbeddingProvider } from "./embed/provider.js";
-import { openEngineStore, openEngineStoreCore } from "./embed/store.js";
+import {
+  openEngineStore,
+  openEngineStoreCore,
+  openInMemoryEngineStoreCore,
+  openEngineStoreCoreReadOnly,
+  openEngineStoreReadOnly,
+} from "./embed/store.js";
 import { syncEngineStore } from "./embed/sync.js";
 import { McpEngineAdapter } from "./mcp/facade.js";
 import { makeDeferredProvider, makeDeferredStore } from "./embed/deferred.js";
@@ -61,6 +67,8 @@ export interface AssembledEngine {
   deps: DispatcherDeps;
   store: EngineStore;
   provider: EmbeddingProvider;
+  /** Whether lex-only queries refresh this engine's selected lexical store. */
+  implicitLexicalSync: boolean;
   syncVault(opts?: SyncVaultOptions): Promise<SyncVaultResult>;
   dispose(): Promise<void>;
 }
@@ -113,13 +121,14 @@ export function assembleEngine(config: AssembleConfig): AssembledEngine {
   const adapter = new McpEngineAdapter(deps, vault, {
     embeddingProvider: config.embeddingProvider,
     embeddingModel: config.embeddingModel,
-  }, config.reranker);
+  }, config.reranker, true);
 
   return {
     adapter,
     deps,
     store,
     provider,
+    implicitLexicalSync: true,
 
     async syncVault(opts: SyncVaultOptions = {}): Promise<SyncVaultResult> {
       const result = await syncEngineStore({
@@ -172,13 +181,14 @@ export function assembleCoreSemanticEngine(config: AssembleConfig): AssembledEng
   const adapter = new McpEngineAdapter(deps, vault, {
     embeddingProvider: config.embeddingProvider,
     embeddingModel: config.embeddingModel,
-  }, config.reranker);
+  }, config.reranker, true);
 
   return {
     adapter,
     deps,
     store,
     provider,
+    implicitLexicalSync: true,
 
     async syncVault(opts: SyncVaultOptions = {}): Promise<SyncVaultResult> {
       const result = await syncEngineStore({
@@ -208,6 +218,148 @@ export function assembleCoreSemanticEngine(config: AssembleConfig): AssembledEng
 }
 
 /**
+ * Assemble a core-only semantic engine whose lexical index is process-local.
+ * Lex-only queries populate this store on demand without touching the vault.
+ */
+export function assembleEphemeralCoreSemanticEngine(config: AssembleConfig): AssembledEngine {
+  const vault = config.vault;
+  const provider = makeDeferredProvider();
+  const store = openInMemoryEngineStoreCore();
+  const deps: DispatcherDeps = {
+    store,
+    embed: provider,
+    ...(config.rrfK !== undefined ? { rrfK: config.rrfK } : {}),
+    ...(config.graphDepth !== undefined ? { graphDepth: config.graphDepth } : {}),
+  };
+  const adapter = new McpEngineAdapter(deps, vault, {
+    embeddingProvider: config.embeddingProvider,
+    embeddingModel: config.embeddingModel,
+  }, config.reranker, true);
+
+  return {
+    adapter,
+    deps,
+    store,
+    provider,
+    implicitLexicalSync: true,
+    async syncVault(opts: SyncVaultOptions = {}): Promise<SyncVaultResult> {
+      const result = await syncEngineStore({
+        vault,
+        collectionPath: opts.collectionPath,
+        embed: false,
+        force: opts.force,
+        embeddingProvider: config.embeddingProvider,
+        embeddingModel: config.embeddingModel,
+        store,
+      });
+      return {
+        scanned: result.scanned,
+        added: result.added,
+        updated: result.updated,
+        skipped: result.skipped,
+        available: result.available,
+        reason: result.reason,
+      };
+    },
+    async dispose(): Promise<void> {
+      await provider.dispose().catch(() => undefined);
+      store.close();
+    },
+  };
+}
+
+/**
+ * Assemble an existing CORE-ONLY semantic engine without creating a store.
+ * Returns null when the semantic index is absent or cannot be read safely.
+ */
+export function assembleCoreSemanticEngineReadOnly(config: AssembleConfig): AssembledEngine | null {
+  const vault = config.vault;
+  const dbPath = config.dbPath ?? `${vault}/.oms/engine-store.sqlite`;
+  const provider = makeDeferredProvider();
+  const store = openEngineStoreCoreReadOnly(dbPath);
+  if (store === null) {
+    void provider.dispose().catch(() => undefined);
+    return null;
+  }
+
+  const deps: DispatcherDeps = {
+    store,
+    embed: provider,
+    ...(config.rrfK !== undefined ? { rrfK: config.rrfK } : {}),
+    ...(config.graphDepth !== undefined ? { graphDepth: config.graphDepth } : {}),
+  };
+  const adapter = new McpEngineAdapter(deps, vault, {
+    embeddingProvider: config.embeddingProvider,
+    embeddingModel: config.embeddingModel,
+  }, config.reranker, false);
+
+  return {
+    adapter,
+    deps,
+    store,
+    provider,
+    implicitLexicalSync: false,
+    async syncVault(): Promise<SyncVaultResult> {
+      throw new Error("AssembledEngine: syncVault is unavailable because the store is open read-only.");
+    },
+    async dispose(): Promise<void> {
+      await provider.dispose().catch(() => undefined);
+      store.close();
+    },
+  };
+}
+
+/**
+ * Assemble an existing vector-capable semantic engine without creating a store.
+ * Returns null when the semantic index is absent or cannot be read safely.
+ */
+export function assembleEngineReadOnly(config: AssembleConfig): AssembledEngine | null {
+  const vault = config.vault;
+  const dbPath = config.dbPath ?? `${vault}/.oms/engine-store.sqlite`;
+  // The readonly store opener does not use dimensions. Open it before loading
+  // the configured provider so an absent index is always an unavailable result.
+  const store = openEngineStoreReadOnly(dbPath, 0);
+  if (store === null) return null;
+
+  let provider: EmbeddingProvider;
+  try {
+    provider = requireRealEmbeddingProvider({
+      provider: config.embeddingProvider,
+      model: config.embeddingModel,
+    });
+  } catch (error) {
+    store.close();
+    throw error;
+  }
+
+  const deps: DispatcherDeps = {
+    store,
+    embed: provider,
+    ...(config.rrfK !== undefined ? { rrfK: config.rrfK } : {}),
+    ...(config.graphDepth !== undefined ? { graphDepth: config.graphDepth } : {}),
+  };
+  const adapter = new McpEngineAdapter(deps, vault, {
+    embeddingProvider: config.embeddingProvider,
+    embeddingModel: config.embeddingModel,
+  }, config.reranker, false);
+
+  return {
+    adapter,
+    deps,
+    store,
+    provider,
+    implicitLexicalSync: false,
+    async syncVault(): Promise<SyncVaultResult> {
+      throw new Error("AssembledEngine: syncVault is unavailable because the store is open read-only.");
+    },
+    async dispose(): Promise<void> {
+      await provider.dispose().catch(() => undefined);
+      store.close();
+    },
+  };
+}
+
+/**
  * Assemble a GRAPH-ONLY engine: graph ops run model-free; semantic store/embed
  * are throw-on-use guards.
  */
@@ -223,13 +375,14 @@ export function assembleGraphOnlyEngine(config: AssembleConfig): AssembledEngine
     ...(config.graphDepth !== undefined ? { graphDepth: config.graphDepth } : {}),
   };
 
-  const adapter = new McpEngineAdapter(deps, vault, undefined, config.reranker);
+  const adapter = new McpEngineAdapter(deps, vault, undefined, config.reranker, false);
 
   return {
     adapter,
     deps,
     store,
     provider,
+    implicitLexicalSync: false,
 
     async syncVault(): Promise<SyncVaultResult> {
       return {

--- a/src/kernel/engine/embed/store-read-only.test.ts
+++ b/src/kernel/engine/embed/store-read-only.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Write protection for the read-only engine store.
+ *
+ * The read-only opener deliberately uses a WRITABLE SQLite connection with
+ * `fileMustExist: true` rather than SQLite's `readonly: true`. The reason is in
+ * `openExistingCoreStore`: a read-only connection to a WAL database needs the
+ * `-shm` sidecar, creates it, and then cannot remove it on close, so every
+ * search left files behind in the user's vault.
+ *
+ * That trade means SQLite is no longer the thing stopping a write. These tests
+ * cover the guarantee that replaced it: the store refuses to create anything
+ * that is not already there, and every mutator on the returned handle throws.
+ * If someone later "simplifies" a mutator into a real statement, this fails.
+ */
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import {
+  openEngineStoreCore,
+  openEngineStoreCoreReadOnly,
+} from "./store.js";
+
+const roots: string[] = [];
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+function scratch(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "oms-store-ro-"));
+  roots.push(root);
+  return root;
+}
+
+describe("read-only engine store", () => {
+  it("creates nothing when the store is absent", () => {
+    const root = scratch();
+    const dbPath = path.join(root, ".oms", "engine-store.sqlite");
+
+    expect(openEngineStoreCoreReadOnly(dbPath)).toBeNull();
+
+    // Not just the database: the enclosing directory must not be conjured
+    // either. Creating `.oms/` on a read is the original defect.
+    expect(existsSync(path.join(root, ".oms"))).toBe(false);
+    expect(readdirSync(root)).toEqual([]);
+  });
+
+  it("reports an existing but foreign database as absent instead of adopting it", () => {
+    const root = scratch();
+    const dir = path.join(root, ".oms");
+    mkdirSync(dir, { recursive: true });
+    const dbPath = path.join(dir, "engine-store.sqlite");
+
+    // A real SQLite database that is not ours: it exists, it opens, and it has
+    // none of the engine tables. The opener must decline it rather than adopt
+    // it, and must not try to add the missing schema to someone else's file.
+    const foreign = new Database(dbPath);
+    foreign.exec("CREATE TABLE unrelated (a TEXT);");
+    foreign.close();
+    const before = readdirSync(dir).sort();
+
+    expect(openEngineStoreCoreReadOnly(dbPath)).toBeNull();
+    expect(readdirSync(dir).sort()).toEqual(before);
+
+    // Declining must be about the schema, not about the path: a genuine store
+    // at the same location still opens.
+    const real = openEngineStoreCore(path.join(dir, "real.sqlite"));
+    real.close();
+    const opened = openEngineStoreCoreReadOnly(path.join(dir, "real.sqlite"));
+    expect(opened).not.toBeNull();
+    // Close it: an open connection legitimately holds `-shm`/`-wal` on disk.
+    opened!.close();
+  });
+
+  it("rejects every mutation on a store that does exist", () => {
+    const root = scratch();
+    const dbPath = path.join(root, ".oms", "engine-store.sqlite");
+
+    // Build a real store through the creating path, then reopen it read-only.
+    const writable = openEngineStoreCore(dbPath);
+    writable.upsertLex([
+      { docPath: "notes/alpha.md", ordinal: 0, text: "alpha mentions retrieval", sha: "sha-alpha" },
+    ]);
+    writable.close();
+
+    const store = openEngineStoreCoreReadOnly(dbPath);
+    expect(store).not.toBeNull();
+
+    try {
+      // Reads still work, otherwise this proves nothing about writes.
+      expect(store!.queryLex("retrieval", 5).length).toBeGreaterThan(0);
+
+      expect(() =>
+        store!.upsertLex([
+          { docPath: "notes/beta.md", ordinal: 0, text: "beta", sha: "sha-beta" },
+        ]),
+      ).toThrow(/reading only/i);
+      expect(() => store!.clearDocument("notes/alpha.md")).toThrow(/reading only/i);
+      expect(() =>
+        store!.writeEmbeddingIdentity({
+          provider: "gguf",
+          model: "fake",
+          dimensions: 8,
+          fingerprint: "fp",
+        }),
+      ).toThrow(/reading only/i);
+    } finally {
+      store!.close();
+    }
+
+    // The rejected writes must not have landed by another route.
+    const reopened = openEngineStoreCoreReadOnly(dbPath);
+    try {
+      expect(reopened!.listDocPaths()).toEqual(["notes/alpha.md"]);
+    } finally {
+      reopened!.close();
+    }
+  });
+
+  it("leaves no WAL sidecars behind after a read", () => {
+    const root = scratch();
+    const dbPath = path.join(root, ".oms", "engine-store.sqlite");
+
+    const writable = openEngineStoreCore(dbPath);
+    writable.upsertLex([
+      { docPath: "notes/alpha.md", ordinal: 0, text: "alpha", sha: "sha-alpha" },
+    ]);
+    writable.close();
+
+    const before = readdirSync(path.join(root, ".oms")).sort();
+
+    const store = openEngineStoreCoreReadOnly(dbPath);
+    store!.queryLex("alpha", 5);
+    store!.close();
+
+    // This is the concrete reason `readonly: true` was rejected. A read-only
+    // connection creates `-shm`/`-wal` and cannot clean them up; if someone
+    // reintroduces it, these appear here.
+    expect(readdirSync(path.join(root, ".oms")).sort()).toEqual(before);
+  });
+});

--- a/src/kernel/engine/embed/store.ts
+++ b/src/kernel/engine/embed/store.ts
@@ -162,7 +162,9 @@ function createVecTable(db: Database.Database, dimensions: number): void {
  * - upsert() throws
  */
 export function openEngineStoreCore(dbPath: string): EngineStore {
-  mkdirSync(path.dirname(dbPath), { recursive: true });
+  if (dbPath !== ":memory:") {
+    mkdirSync(path.dirname(dbPath), { recursive: true });
+  }
   const db = new Database(dbPath);
 
   ensureCoreSchema(db);
@@ -348,6 +350,11 @@ export function openEngineStoreCore(dbPath: string): EngineStore {
       return stmtListDocPaths.all().map((r) => r.doc_path);
     },
   };
+}
+
+/** Open a core-only store held entirely in SQLite memory. */
+export function openInMemoryEngineStoreCore(): EngineStore {
+  return openEngineStoreCore(":memory:");
 }
 
 /**
@@ -621,4 +628,209 @@ export function openEngineStore(
       return stmtListDocPaths.all().map((r) => r.doc_path);
     },
   };
+}
+
+const REQUIRED_CORE_TABLES = [
+  "engine_meta",
+  "engine_chunk_meta",
+  "engine_chunk_fts",
+] as const;
+
+/**
+ * Open an engine store that already exists, creating nothing.
+ *
+ * `fileMustExist` is what enforces the read-only guarantee that matters: a
+ * search on a vault with no index must not bring one into being. The connection
+ * itself is writable, and that is deliberate.
+ *
+ * SQLite's `readonly: true` was tried first and rejected. The store runs in WAL
+ * mode, and a read-only connection to a WAL database still needs the `-shm`
+ * shared-memory index. SQLite creates it, and a read-only connection cannot
+ * check-point or remove it on close, so every search left `engine-store.sqlite-shm`
+ * and `-wal` behind in the user's vault. A writable connection creates the same
+ * sidecars transiently and cleans them up when it closes, so it leaves the vault
+ * genuinely untouched. Refusing to create beats being unable to tidy up.
+ *
+ * Write protection is therefore enforced above this line, not by SQLite: the
+ * store returned by `openReadOnlyStore` prepares only SELECT statements and every
+ * mutator throws.
+ */
+function openExistingCoreStore(dbPath: string): Database.Database | null {
+  let db: Database.Database;
+  try {
+    db = new Database(dbPath, { fileMustExist: true });
+  } catch {
+    return null;
+  }
+
+  try {
+    const rows = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?)",
+    ).all(...REQUIRED_CORE_TABLES) as Array<{ name: string }>;
+    if (rows.length !== REQUIRED_CORE_TABLES.length) {
+      db.close();
+      return null;
+    }
+    return db;
+  } catch {
+    // A store that exists but cannot be read (corrupt, truncated, or written by
+    // an incompatible build) is treated exactly like an absent index: search
+    // reports it as unavailable rather than crashing the caller's request.
+    db.close();
+    return null;
+  }
+}
+
+function readonlyMutation(method: string): never {
+  throw new Error(
+    `EngineStore: ${method} is unavailable because this store was opened for reading only.`,
+  );
+}
+
+function openReadOnlyStore(
+  dbPath: string,
+  opts: { readonly sqliteVecLoader?: SqliteVecLoader; readonly vectors?: boolean } = {},
+): EngineStore | null {
+  const db = openExistingCoreStore(dbPath);
+  if (db === null) return null;
+
+  const stmtQueryLex = db.prepare<[string, number], { doc_path: string; ordinal: number; rank: number }>(
+    `SELECT m.doc_path, m.ordinal, bm25(engine_chunk_fts) AS rank
+     FROM engine_chunk_fts
+     JOIN engine_chunk_meta m ON m.rowid = engine_chunk_fts.rowid
+     WHERE engine_chunk_fts MATCH ?
+     ORDER BY rank
+     LIMIT ?`,
+  );
+  const stmtQueryLexInCollection = db.prepare<[string, string, string, number], { doc_path: string; ordinal: number; rank: number }>(
+    `SELECT m.doc_path, m.ordinal, bm25(engine_chunk_fts) AS rank
+     FROM engine_chunk_fts
+     JOIN engine_chunk_meta m ON m.rowid = engine_chunk_fts.rowid
+     WHERE engine_chunk_fts MATCH ? AND (m.doc_path = ? OR m.doc_path LIKE ? ESCAPE '!')
+     ORDER BY rank
+     LIMIT ?`,
+  );
+  const stmtGetShas = db.prepare<[string], { ordinal: number; sha: string }>(
+    "SELECT ordinal, sha FROM engine_chunk_meta WHERE doc_path = ?",
+  );
+  const stmtListDocPaths = db.prepare<[], { doc_path: string }>(
+    "SELECT DISTINCT doc_path FROM engine_chunk_meta",
+  );
+  const stmtReadIdentity = db.prepare<[], {
+    embedding_provider: string | null;
+    embedding_model: string | null;
+    embedding_dimensions: number | null;
+    embedding_fingerprint: string | null;
+  }>(
+    "SELECT embedding_provider, embedding_model, embedding_dimensions, embedding_fingerprint FROM engine_meta WHERE id = 1",
+  );
+
+  // These carry their bound parameter and row types: the bare
+  // ReturnType<prepare> erases both generics, which makes `.get()` demand an
+  // argument it does not take and forces a cast on every row read.
+  let stmtQueryVec: Database.Statement<[Buffer, number], { doc_path: string; ordinal: number; distance: number }> | null = null;
+  let stmtCountChunks: Database.Statement<[], { count: number }> | null = null;
+  if (opts.vectors) {
+    try {
+      (opts.sqliteVecLoader ?? DEFAULT_SQLITE_VEC_LOADER)(db);
+      if (vecTableExists(db)) {
+        stmtQueryVec = db.prepare<[Buffer, number], { doc_path: string; ordinal: number; distance: number }>(
+          `SELECT m.doc_path, m.ordinal, v.distance
+           FROM engine_chunk_vec v
+           JOIN engine_chunk_meta m ON m.rowid = v.rowid
+           WHERE v.embedding MATCH ? AND k = ?
+           ORDER BY v.distance`,
+        );
+        stmtCountChunks = db.prepare<[], { count: number }>(
+          "SELECT COUNT(*) AS count FROM engine_chunk_meta",
+        );
+      }
+    } catch {
+      stmtQueryVec = null;
+      stmtCountChunks = null;
+    }
+  }
+
+  return {
+    capabilities(): EngineStoreCapabilities {
+      return { vecAvailable: stmtQueryVec !== null };
+    },
+    upsertLex(): void {
+      readonlyMutation("upsertLex");
+    },
+    upsert(): void {
+      readonlyMutation("upsert");
+    },
+    queryVec(vec: Float32Array, k: number, collection?: string): ScoredHit[] {
+      if (!stmtQueryVec || !stmtCountChunks) {
+        throw new Error("EngineStore: vector queries are unavailable (sqlite-vec not loaded).");
+      }
+      const candidateLimit = collection === undefined ? k : (stmtCountChunks.get()?.count ?? 0);
+      return stmtQueryVec.all(vecBuf(vec), candidateLimit)
+        .filter((row) => collection === undefined || row.doc_path === collection || row.doc_path.startsWith(`${collection}/`))
+        .slice(0, k)
+        .map((row): ScoredHit => ({
+          docPath: row.doc_path,
+          chunkOrdinal: row.ordinal,
+          score: 1 / (1 + Math.max(0, row.distance)),
+        }));
+    },
+    queryLex(text: string, k: number, collection?: string): ScoredHit[] {
+      const ftsQ = makeFtsQuery(text);
+      if (!ftsQ) return [];
+      try {
+        const rows = collection === undefined
+          ? stmtQueryLex.all(ftsQ, k)
+          : stmtQueryLexInCollection.all(ftsQ, collection, collectionDescendantLikePattern(collection), k);
+        return rows.map((row, index): ScoredHit => ({
+          docPath: row.doc_path,
+          chunkOrdinal: row.ordinal,
+          score: 1 / (1 + index),
+        }));
+      } catch {
+        return [];
+      }
+    },
+    close(): void {
+      db.close();
+    },
+    readEmbeddingIdentity(): EmbeddingIdentity | null {
+      const row = stmtReadIdentity.get();
+      if (!row || !row.embedding_provider || !row.embedding_model || row.embedding_dimensions === null || !row.embedding_fingerprint) {
+        return null;
+      }
+      return {
+        provider: row.embedding_provider,
+        model: row.embedding_model,
+        dimensions: row.embedding_dimensions,
+        fingerprint: row.embedding_fingerprint,
+      };
+    },
+    writeEmbeddingIdentity(): void {
+      readonlyMutation("writeEmbeddingIdentity");
+    },
+    getShas(docPath: string): Map<number, string> {
+      return new Map(stmtGetShas.all(docPath).map((row) => [row.ordinal, row.sha]));
+    },
+    clearDocument(): void {
+      readonlyMutation("clearDocument");
+    },
+    listDocPaths(): string[] {
+      return stmtListDocPaths.all().map((row) => row.doc_path);
+    },
+  };
+}
+
+/** Open an existing core store for reads without creating files or schema. */
+export function openEngineStoreCoreReadOnly(dbPath: string): EngineStore | null {
+  return openReadOnlyStore(dbPath);
+}
+
+/** Open an existing vector-capable store for reads without creating files or schema. */
+export function openEngineStoreReadOnly(
+  dbPath: string,
+  _dimensions: number,
+  opts: { readonly sqliteVecLoader?: SqliteVecLoader } = {},
+): EngineStore | null {
+  return openReadOnlyStore(dbPath, { ...opts, vectors: true });
 }

--- a/src/kernel/engine/embed/sync.ts
+++ b/src/kernel/engine/embed/sync.ts
@@ -41,6 +41,8 @@ export interface EngineSyncOptions {
   embeddingModel?: string;
   /** Chunker overrides (maxTokens, overlapRatio). */
   chunkerOpts?: Partial<ChunkerOptions>;
+  /** Pre-opened store to populate. The caller retains ownership of this handle. */
+  store?: EngineStore;
 }
 
 export interface EngineSyncResult {
@@ -223,7 +225,8 @@ export async function syncEngineStore(opts: EngineSyncOptions): Promise<EngineSy
   const warnings: string[] = [];
 
   let provider: EmbeddingProvider | null = null;
-  let store: EngineStore | null = null;
+  let store: EngineStore | null = opts.store ?? null;
+  const ownsStore = opts.store === undefined;
 
   let storedIdentity: EmbeddingIdentity | undefined;
   let configuredIdentity: EmbeddingIdentity | undefined;
@@ -231,7 +234,7 @@ export async function syncEngineStore(opts: EngineSyncOptions): Promise<EngineSy
   try {
     if (!shouldEmbed) {
       // Lex-only path: no embedding provider required.
-      store = openEngineStoreCore(dbPath);
+      store ??= openEngineStoreCore(dbPath);
       warnings.push("embed=false: lexical index updated; no vectors generated");
 
       const counters: SyncCounters = { scanned: 0, added: 0, updated: 0, skipped: 0 };
@@ -408,6 +411,6 @@ export async function syncEngineStore(opts: EngineSyncOptions): Promise<EngineSy
     };
   } finally {
     await provider?.dispose().catch(() => undefined);
-    store?.close();
+    if (ownsStore) store?.close();
   }
 }

--- a/src/kernel/engine/mcp/facade.ts
+++ b/src/kernel/engine/mcp/facade.ts
@@ -264,11 +264,10 @@ function enrichQueryHits(result: McpSemanticQueryResult, vault: string): McpSema
   });
   return { available: true, hits };
 }
+
 function isLexOnlySubQueries(subQueries: readonly { readonly type: string }[]): boolean {
   return subQueries.length > 0 && subQueries.every((subQuery) => subQuery.type === "lex");
 }
-
-
 // ---------------------------------------------------------------------------
 // Adapter facade
 // ---------------------------------------------------------------------------
@@ -294,6 +293,8 @@ export class McpEngineAdapter {
     private readonly vaultPath: string,
     private readonly config?: { readonly embeddingProvider?: string; readonly embeddingModel?: string },
     private readonly reranker?: Reranker,
+    /** Explicit assembly policy; read-only engines suppress this refresh. */
+    private readonly implicitLexicalSync = false,
   ) {}
 
   // -------------------------------------------------------------------------
@@ -329,11 +330,12 @@ export class McpEngineAdapter {
       return queryResultUnavailable("No sub-queries derived from options");
     }
     try {
-      if (isLexOnlySubQueries(subQueries)) {
+      if (this.implicitLexicalSync && isLexOnlySubQueries(subQueries)) {
         const syncResult = await syncEngineStore({
           vault: opts.vault ?? this.vaultPath,
           collection: opts.collection,
           embed: false,
+          store: this.deps.store as EngineStore,
         });
         if (!syncResult.available) {
           return queryResultUnavailable(syncResult.reason ?? "Lexical index sync unavailable");

--- a/src/kernel/harness/surface-registry.ts
+++ b/src/kernel/harness/surface-registry.ts
@@ -96,7 +96,7 @@ export const harnessSurfaceRegistry: HarnessSurfaceRegistry = {
   ],
   mcpTools: [
     { name: "oms_write", owner: "capture", posture: "write", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
-    { name: "oms_search", owner: "retrieval", posture: "write", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
+    { name: "oms_search", owner: "retrieval", posture: "read", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
     { name: "oms_link", owner: "capture", posture: "write", destructive: true, idempotent: false, openWorld: false, stability: "stable" },
     { name: "oms_status", owner: "mcp", posture: "read", destructive: false, idempotent: true, openWorld: false, stability: "stable" },
     { name: "oms_doctor", owner: "mcp", posture: "write", destructive: false, idempotent: false, openWorld: false, stability: "stable" },

--- a/src/kernel/search/morning.ts
+++ b/src/kernel/search/morning.ts
@@ -50,7 +50,7 @@ export interface MorningRetrieveOptions extends GraphExploreOptions {
     readonly hydrateMaxBytes?: number;
     readonly hydrateFromLine?: number;
     readonly hydrateLineCount?: number;
-    readonly syncBeforeSearch?: boolean;
+
     readonly syncEnsureCollection?: boolean;
     readonly syncUpdate?: boolean;
     readonly syncEmbed?: boolean;

--- a/src/kernel/semantic/semantic-retrieve-args.ts
+++ b/src/kernel/semantic/semantic-retrieve-args.ts
@@ -103,14 +103,6 @@ export function semanticOptionsFromArgs(
     hydrateMaxBytes: numberArg(args, "semanticHydrateMaxBytes"),
     hydrateFromLine: numberArg(args, "semanticHydrateFromLine"),
     hydrateLineCount: numberArg(args, "semanticHydrateLineCount"),
-    syncBeforeSearch: booleanArg(args, "embeddingSyncBeforeSearch"),
-    syncEnsureCollection: booleanArg(args, "embeddingSyncEnsureCollection"),
-    syncUpdate: booleanArg(args, "embeddingSyncUpdate"),
-    syncEmbed: booleanArg(args, "embeddingSyncEmbed"),
-    syncForce: booleanArg(args, "embeddingSyncForce"),
-    syncPull: booleanArg(args, "embeddingSyncPull"),
-    syncMaxDocsPerBatch: numberArg(args, "embeddingSyncMaxDocsPerBatch"),
-    syncMaxBatchMb: numberArg(args, "embeddingSyncMaxBatchMb"),
   };
 }
 

--- a/src/kernel/semantic/semantic-retrieve-schema.ts
+++ b/src/kernel/semantic/semantic-retrieve-schema.ts
@@ -35,12 +35,4 @@ export const retrieveContextSemanticInputProperties = {
   semanticHydrateMaxBytes: { type: "number" },
   semanticHydrateFromLine: { type: "number" },
   semanticHydrateLineCount: { type: "number" },
-  embeddingSyncBeforeSearch: { type: "boolean" },
-  embeddingSyncEnsureCollection: { type: "boolean" },
-  embeddingSyncUpdate: { type: "boolean" },
-  embeddingSyncEmbed: { type: "boolean" },
-  embeddingSyncForce: { type: "boolean" },
-  embeddingSyncPull: { type: "boolean" },
-  embeddingSyncMaxDocsPerBatch: { type: "number" },
-  embeddingSyncMaxBatchMb: { type: "number" },
 } as const;

--- a/src/mcp/engine-morning-backend.ts
+++ b/src/mcp/engine-morning-backend.ts
@@ -10,7 +10,7 @@
  *
  * After the src/search teardown the morning contract types are the engine
  * contract types (re-exported via src/kernel/search/semantic-contract.ts), so this
- * wrapper only threads the sync gate and the default vault — no type bridging.
+ * wrapper only threads the default vault — no type bridging.
  */
 
 import type { McpEngineAdapter } from "../kernel/engine/mcp/facade.js";
@@ -29,21 +29,8 @@ import type { MorningRetrieveOptions, MorningSemanticBackend } from "../kernel/s
  */
 export function makeEngineMorningBackend(adapter: McpEngineAdapter, vault: string): MorningSemanticBackend {
   return {
-    sync(opts: MorningRetrieveOptions) {
-      // Same R2 gate as before: never auto-sync unless the caller explicitly
-      // asked (syncBeforeSearch). Engine sync is incremental (SHA-256 diff), so
-      // even a forced re-sync skips unchanged chunks.
-      if (opts.semantic?.syncBeforeSearch !== true) return Promise.resolve(undefined);
-      return adapter.syncEmbeddings({
-        vault: opts.vault ?? vault,
-        collection: opts.semantic.collection,
-        index: opts.semantic.index,
-        embed: opts.semantic.syncEmbed,
-        force: opts.semantic.syncForce,
-        chunkStrategy: opts.semantic.chunkStrategy,
-        maxDocsPerBatch: opts.semantic.syncMaxDocsPerBatch,
-        maxBatchMb: opts.semantic.syncMaxBatchMb,
-      });
+    sync() {
+      return Promise.resolve(undefined);
     },
 
     status(opts) {

--- a/src/mcp/search-read-only.test.ts
+++ b/src/mcp/search-read-only.test.ts
@@ -1,0 +1,358 @@
+/**
+ * `oms_search` must not write.
+ *
+ * The tool is annotated `readOnlyHint: true`, which is a promise to every MCP
+ * host that calling it is safe on an untouched vault. This suite verifies the
+ * promise the only way that actually proves it: by snapshotting the whole vault
+ * tree, calling every advertised `oms_search` operation, and requiring the tree
+ * to come back byte-identical.
+ *
+ * It deliberately does NOT enumerate the specific writes we know about
+ * (`.oms/`, `engine-store.sqlite`, `-wal`, `-shm`). Naming them would only prove
+ * that the four writes we already found stopped, and would stay silent about a
+ * fifth. Comparing the entire tree catches any write, including one added later
+ * by a change that has nothing to do with this fix.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { omsMcpTools } from "./server.js";
+
+interface ToolResult {
+  readonly content: { type: string; text?: string }[];
+  readonly isError?: boolean;
+}
+
+function rawText(result: ToolResult): string {
+  return result.content[0]?.text ?? "";
+}
+
+function textPayload(result: ToolResult): Record<string, unknown> {
+  const block = result.content[0];
+  expect(block?.type).toBe("text");
+  return JSON.parse(block?.text ?? "{}") as Record<string, unknown>;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../");
+const distCli = path.join(repoRoot, "dist", "cli", "oms.js");
+
+/**
+ * Every operation the `oms_search` schema advertises, with arguments valid for
+ * each. Derived from the live tool schema rather than hand-listed, so an
+ * operation added later cannot quietly escape the read-only guarantee.
+ */
+function advertisedSearchOperations(): { op: string; args: Record<string, unknown> }[] {
+  const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+  const schema = search?.inputSchema as {
+    readonly oneOf?: readonly {
+      readonly properties?: Record<string, { readonly const?: string }>;
+    }[];
+  };
+  const ops = (schema.oneOf ?? [])
+    .map((branch) => branch.properties?.["op"]?.const)
+    .filter((op): op is string => typeof op === "string");
+
+  // Arguments that satisfy each operation's required fields. Anything not
+  // listed here takes the bare `{ op }` form.
+  const argsByOp: Record<string, Record<string, unknown>> = {
+    "lazy-load": { notePath: "notes/alpha.md" },
+    "semantic-query": { query: "alpha" },
+    "get-document": { docId: "notes/alpha.md" },
+    "multi-get-documents": { docIds: ["notes/alpha.md"] },
+    axis: { axis: "concept" },
+    context: { query: "alpha" },
+  };
+
+  return ops.map((op) => ({ op, args: { op, ...(argsByOp[op] ?? {}) } }));
+}
+
+/** Recursive content digest of every file under `root`, keyed by relative path. */
+async function snapshotTree(root: string): Promise<Map<string, string>> {
+  const snapshot = new Map<string, string>();
+
+  async function walk(dir: string): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      const rel = path.relative(root, full);
+      if (entry.isDirectory()) {
+        snapshot.set(`${rel}/`, "<dir>");
+        await walk(full);
+      } else {
+        const [body, meta] = await Promise.all([readFile(full), stat(full)]);
+        snapshot.set(rel, `${createHash("sha256").update(body).digest("hex")}:${meta.size}`);
+      }
+    }
+  }
+
+  await walk(root);
+  return snapshot;
+}
+
+function diff(before: Map<string, string>, after: Map<string, string>): string[] {
+  const changes: string[] = [];
+  for (const [rel, digest] of after) {
+    const previous = before.get(rel);
+    if (previous === undefined) changes.push(`created: ${rel}`);
+    else if (previous !== digest) changes.push(`modified: ${rel}`);
+  }
+  for (const rel of before.keys()) {
+    if (!after.has(rel)) changes.push(`deleted: ${rel}`);
+  }
+  return changes.sort();
+}
+
+async function makeVault(): Promise<string> {
+  const vault = await mkdtemp(path.join(tmpdir(), "oms-readonly-"));
+  await mkdir(path.join(vault, "notes"), { recursive: true });
+  await writeFile(
+    path.join(vault, "notes", "alpha.md"),
+    "---\nconcept: Project\nstatus: active\n---\n# Alpha\n\nAlpha links to [[beta]] and mentions retrieval.\n",
+    "utf-8",
+  );
+  await writeFile(
+    path.join(vault, "notes", "beta.md"),
+    "---\nconcept: Project\nstatus: active\n---\n# Beta\n\nBeta discusses semantic search and graphs.\n",
+    "utf-8",
+  );
+  return vault;
+}
+
+/**
+ * Runs the real `oms mcp` binary against `vault`.
+ *
+ * HOME is redirected to an empty directory so an operator's `~/.oms/config.yaml`
+ * cannot decide where this test points. Without it the server resolves a global
+ * vault from the developer's machine and refuses to boot, which would make every
+ * assertion below pass or fail for reasons unrelated to writing.
+ *
+ * `OMS_VAULT` makes the vault a verified write target. That is deliberate: it
+ * means the search path is permitted to write and still must not. A cwd-inferred
+ * target would have writes rejected by the admission layer anyway, so a clean
+ * tree would prove nothing about `oms_search`'s own behaviour.
+ */
+async function withClient<T>(vault: string, run: (client: Client) => Promise<T>): Promise<T> {
+  const emptyHome = await mkdtemp(path.join(tmpdir(), "oms-readonly-home-"));
+  homes.push(emptyHome);
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [distCli, "mcp"],
+    cwd: vault,
+    env: { HOME: emptyHome, OMS_VAULT: vault, PATH: process.env["PATH"] ?? "" },
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "oms-readonly-probe", version: "0.0.0" });
+  try {
+    await client.connect(transport);
+    return await run(client);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+const vaults: string[] = [];
+const homes: string[] = [];
+
+describe("oms_search read-only guarantee", () => {
+  beforeAll(() => () =>
+    Promise.all(
+      [...vaults, ...homes].map((dir) => rm(dir, { recursive: true, force: true })),
+    ));
+
+  it("declares itself read-only", () => {
+    const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+    expect(search?.annotations?.readOnlyHint).toBe(true);
+  });
+
+  /**
+   * `readOnlyHint: true` is a promise about what the tool CAN do, not about
+   * what a particular call happens to do. The search surface previously took
+   * `embeddingSyncBeforeSearch`, which routed through to `syncEmbeddings` and
+   * let any caller turn a read into a write by passing one flag.
+   *
+   * Removing it is the reason the annotation is allowed to be true, so the
+   * schema is pinned here. Re-adding a write knob to this tool must break a
+   * test rather than quietly invalidate the annotation above.
+   */
+  it("advertises no parameter that would let a caller trigger a write", () => {
+    const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+    const schema = JSON.stringify(search?.inputSchema ?? {});
+
+    for (const knob of [
+      "embeddingSyncBeforeSearch",
+      "embeddingSyncForce",
+      "embeddingSyncEmbed",
+      "syncBeforeSearch",
+    ]) {
+      expect(schema, `oms_search must not advertise ${knob}`).not.toContain(knob);
+    }
+
+    // Guard against a vacuous pass: the schema must still be the real one.
+    expect(schema).toContain("semantic-query");
+    expect(schema).toContain("get-document");
+
+    // The capability moved rather than vanished, so doctor must still offer it.
+    const doctor = omsMcpTools.find((tool) => tool.name === "oms_doctor");
+    expect(JSON.stringify(doctor?.inputSchema ?? {})).toContain("sync-embeddings");
+    expect(doctor?.annotations?.readOnlyHint).toBe(false);
+  });
+
+  it("leaves a vault with no .oms directory completely untouched", async () => {
+    const vault = await makeVault();
+    vaults.push(vault);
+
+    const operations = advertisedSearchOperations();
+    // Guard against a vacuous pass: if the schema stops advertising operations,
+    // an empty loop would trivially leave the tree unchanged.
+    expect(operations.length).toBeGreaterThanOrEqual(10);
+
+    const before = await snapshotTree(vault);
+
+    const failures: string[] = [];
+    await withClient(vault, async (client) => {
+      for (const { op, args } of operations) {
+        try {
+          await client.callTool({ name: "oms_search", arguments: args });
+        } catch (error) {
+          // A missing index must degrade to a structured unavailable result,
+          // not a transport-level throw.
+          failures.push(`${op}: ${(error as Error).message}`);
+        }
+      }
+    });
+
+    const after = await snapshotTree(vault);
+
+    expect(diff(before, after)).toEqual([]);
+    expect(failures).toEqual([]);
+
+  }, 120_000);
+
+  /**
+   * Writing nothing is only half the requirement. Before this change, a search
+   * on a fresh vault worked because it silently built the index on disk; the
+   * obvious way to stop the writing is to stop answering, which trades a
+   * correctness bug for a worse product.
+   *
+   * A user who installs, points a host at a vault and asks a question must get
+   * an answer, not an instruction to go run a command first. The whole vault
+   * snapshot above proves nothing was written; this proves the answer survived.
+   */
+  it("answers a first search on a vault that has never been indexed", async () => {
+    const vault = await makeVault();
+    vaults.push(vault);
+
+    const payload = await withClient(vault, async (client) =>
+      textPayload(
+        await client.callTool({
+          name: "oms_search",
+          arguments: { op: "semantic-query", query: "retrieval", limit: 5 },
+        }),
+      ),
+    );
+
+    expect(payload["available"]).toBe(true);
+    const hits = (payload["hits"] as { path?: string }[] | undefined) ?? [];
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits.some((hit) => hit.path === "notes/alpha.md")).toBe(true);
+
+    // And it still wrote nothing while doing it.
+    expect(await snapshotTree(vault).then((tree) => [...tree.keys()].sort())).toEqual([
+      "notes/",
+      "notes/alpha.md",
+      "notes/beta.md",
+    ]);
+  }, 120_000);
+
+  /**
+   * The read-only search engine and the creating doctor engine must not share
+   * a memoisation slot. If they do, whichever tool runs first decides what the
+   * other one gets: a search on an unindexed vault would poison the slot with a
+   * read-only engine and the repair that follows would refuse to build the
+   * index it exists to build.
+   *
+   * This ordering is the realistic one. A user points a host at a fresh vault,
+   * the assistant searches, finds nothing, and then runs the repair.
+   */
+  it("lets a repair build the index after a search has already been served", async () => {
+    const vault = await makeVault();
+    vaults.push(vault);
+
+    // Serve a search first. What matters is that the search path has resolved
+    // and memoised its engine, not what it returned: the defect being guarded
+    // is a read-only engine landing in a slot the repair then reuses.
+    const served = await withClient(vault, (client) =>
+      client.callTool({ name: "oms_search", arguments: { op: "semantic-query", query: "alpha" } }),
+    );
+    expect(textPayload(served)["available"]).toBe(true);
+
+    const repaired = await withClient(vault, (client) =>
+      client.callTool({ name: "oms_doctor", arguments: { op: "sync-embeddings", embed: false } }),
+    );
+    // Surface the server's own message on failure. Parsing first would throw on
+    // the error path, which reports a JSON syntax error instead of the reason
+    // the repair was refused.
+    expect(repaired.isError ?? false, rawText(repaired as ToolResult)).toBe(false);
+    expect(textPayload(repaired as ToolResult)["available"]).toBe(true);
+
+    const tree = await snapshotTree(vault);
+    expect([...tree.keys()].some((rel) => rel.includes("engine-store.sqlite"))).toBe(true);
+
+    const hits = await withClient(vault, (client) =>
+      client.callTool({ name: "oms_search", arguments: { op: "semantic-query", query: "alpha" } }),
+    );
+    const hitPayload = textPayload(hits);
+    expect(hitPayload["available"]).toBe(true);
+    expect((hitPayload["hits"] as unknown[] | undefined)?.length ?? 0).toBeGreaterThan(0);
+  }, 180_000);
+
+  it("still answers every operation once the index exists, and writes nothing then either", async () => {
+    const vault = await makeVault();
+    vaults.push(vault);
+
+    // Build the index through the write surface that is allowed to create it.
+    await withClient(vault, async (client) => {
+      await client.callTool({
+        name: "oms_doctor",
+        arguments: { op: "sync-embeddings", embed: false },
+      });
+    });
+
+    const before = await snapshotTree(vault);
+    // The index must actually exist, otherwise the read path below is being
+    // measured against the same absent-store case as the previous test.
+    expect([...before.keys()].some((rel) => rel.includes("engine-store.sqlite"))).toBe(true);
+
+    const hits = await withClient(vault, async (client) => {
+      for (const { args } of advertisedSearchOperations()) {
+        await client.callTool({ name: "oms_search", arguments: args });
+      }
+      return textPayload(
+        await client.callTool({
+          name: "oms_search",
+          arguments: { op: "semantic-query", query: "alpha" },
+        }),
+      );
+    });
+
+    const after = await snapshotTree(vault);
+    expect(diff(before, after)).toEqual([]);
+
+    // Without this, "make every search return unavailable" would satisfy both
+    // read-only tests while destroying the feature. Search must still answer.
+    expect(hits["available"]).toBe(true);
+    expect((hits["hits"] as unknown[] | undefined)?.length ?? 0).toBeGreaterThan(0);
+  }, 180_000);
+});

--- a/src/mcp/semantic-server.test.ts
+++ b/src/mcp/semantic-server.test.ts
@@ -76,6 +76,10 @@ Index note for graph neighborhoods and semantic lookup.
 
     try {
       await client.connect(transport);
+      await client.callTool({
+        name: "oms_doctor",
+        arguments: { op: "sync-embeddings", embed: false },
+      });
       const retrieve = textPayload(
         await client.callTool({
           name: "oms_search",
@@ -95,8 +99,6 @@ Index note for graph neighborhoods and semantic lookup.
             semanticVec: "semantic notes about retrieval integration",
             semanticHyde: "A note explaining how OMS semantic search is available from retrieve.",
             semanticMinScore: 0.01,
-            embeddingSyncBeforeSearch: true,
-            embeddingSyncForce: true,
           },
         }),
       );

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -220,7 +220,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
       // storage/modelPath knobs were removed from the schemas (engine uses explicit env config).
       expect(JSON.stringify(retrieveTool?.inputSchema)).not.toContain("semanticStorage");
       expect(JSON.stringify(retrieveTool?.inputSchema)).not.toContain("semanticModelPath");
-      expect(retrieveTool?.annotations?.readOnlyHint).toBe(false);
+      expect(retrieveTool?.annotations?.readOnlyHint).toBe(true);
       expect(JSON.stringify(retrieveTool?.inputSchema)).toContain("semantic-query");
       expect(JSON.stringify(retrieveTool?.inputSchema)).toContain("get-document");
       expect(JSON.stringify(retrieveTool?.inputSchema)).not.toContain("modelPath");

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -37,13 +37,23 @@ import {
   semanticOptionsFromArgs,
   retrieveContextSemanticInputProperties,
 } from "../kernel/semantic/semantic-retrieve.js";
-import { assembleCoreSemanticEngine, assembleGraphOnlyEngine, type AssembledEngine } from "../kernel/engine/assemble.js";
-import { assembleFullSemanticEngine, embeddingConfigPresent } from "../kernel/semantic/semantic-engine.js";
+import {
+  assembleEphemeralCoreSemanticEngine,
+  assembleCoreSemanticEngineReadOnly,
+  assembleCoreSemanticEngine,
+  assembleEngineReadOnly,
+  assembleGraphOnlyEngine,
+  type AssembledEngine,
+} from "../kernel/engine/assemble.js";
+import {
+  assembleFullSemanticEngine,
+  embeddingConfigPresent,
+} from "../kernel/semantic/semantic-engine.js";
 import { applyLinksForNote, linkApplyPayload, suggestLinksForNote } from "./link-tools.js";
 import type { McpEngineAdapter } from "../kernel/engine/mcp/facade.js";
 import type { McpSemanticTypedSearch } from "../kernel/engine/mcp/types.js";
 import type { Reranker } from "../kernel/engine/retrieval/reranker.js";
-import { EngineSearchBackend } from "../kernel/searchbackend/engine-search-backend.js";
+import { EngineSearchBackend, requiresEmbeddings } from "../kernel/searchbackend/engine-search-backend.js";
 import {
   buildServerInstructions,
   cachedUpdateNotice,
@@ -76,6 +86,12 @@ function errorText(message: string): CallToolResult {
       },
     ],
   };
+}
+
+class SemanticIndexUnavailableError extends Error {
+  constructor() {
+    super("The semantic index has not been built yet. Run `oms semantic sync` to build it.");
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -123,7 +139,7 @@ const searchProperties = {
   target: string, targets: stringArray, fromLine: number, lineCount: number, lineLimit: number, maxBytes: number, lineNumbers: boolean, fullPath: boolean,
 } as const;
 const contextProperties = { concept: string, folder: string, property: string, value: string, wikilink: string, query: string, limit: number, maxNeighbors: number, useCache: boolean,
-  semanticEnabled: boolean, semanticCollection: string, semanticLimit: number, semanticScope: { ...string, enum: ["global", "graph"] }, semanticMode: searchProperties.mode, semanticIntent: string, semanticSearches: searchProperties.searches, semanticLex: string, semanticVec: string, semanticHyde: string, semanticMinScore: number, semanticAll: boolean, semanticFormat: { ...string, enum: ["json", "files"] }, semanticFull: boolean, semanticLineNumbers: boolean, semanticFullPath: boolean, semanticIndex: string, semanticChunkStrategy: string, semanticCandidateLimit: number, semanticNoRerank: boolean, semanticHydrate: { ...string, enum: ["none", "top", "all", "targets"] }, semanticHydrateTargets: stringArray, semanticHydrateLineLimit: number, semanticHydrateMaxBytes: number, semanticHydrateFromLine: number, semanticHydrateLineCount: number, embeddingSyncBeforeSearch: boolean, embeddingSyncEnsureCollection: boolean, embeddingSyncUpdate: boolean, embeddingSyncEmbed: boolean, embeddingSyncForce: boolean, embeddingSyncPull: boolean, embeddingSyncMaxDocsPerBatch: number, embeddingSyncMaxBatchMb: number } as const;
+  semanticEnabled: boolean, semanticCollection: string, semanticLimit: number, semanticScope: { ...string, enum: ["global", "graph"] }, semanticMode: searchProperties.mode, semanticIntent: string, semanticSearches: searchProperties.searches, semanticLex: string, semanticVec: string, semanticHyde: string, semanticMinScore: number, semanticAll: boolean, semanticFormat: { ...string, enum: ["json", "files"] }, semanticFull: boolean, semanticLineNumbers: boolean, semanticFullPath: boolean, semanticIndex: string, semanticChunkStrategy: string, semanticCandidateLimit: number, semanticNoRerank: boolean, semanticHydrate: { ...string, enum: ["none", "top", "all", "targets"] }, semanticHydrateTargets: stringArray, semanticHydrateLineLimit: number, semanticHydrateMaxBytes: number, semanticHydrateFromLine: number, semanticHydrateLineCount: number } as const;
 // `folder` + `filename` is a supported addressing form that writeNote still
 // accepts. With `additionalProperties: false` a strict schema is only as
 // complete as its property list, so omitting them silently removed a real
@@ -161,7 +177,7 @@ function resolveOperation(tool: string, op: string | undefined): string | undefi
 }
 export const omsMcpTools: Tool[] = [
   { name: "oms_write", title: "Oh My Second Brain write", description: "Write a vault note through the kernel-owned .oms contract.", inputSchema: operationSchema("oms_write"), annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false } },
-  { name: "oms_search", title: "Oh My Second Brain search", description: "Retrieve vault context, semantic search, ontology, and selected documents. `op` selects the operation.", inputSchema: operationSchema("oms_search"), annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false } },
+  { name: "oms_search", title: "Oh My Second Brain search", description: "Retrieve vault context, semantic search, ontology, and selected documents. `op` selects the operation.", inputSchema: operationSchema("oms_search"), annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: false } },
   { name: "oms_link", title: "Oh My Second Brain link", description: "Suggest or apply wikilinks; `op` selects the operation.", inputSchema: operationSchema("oms_link"), annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false } },
   { name: "oms_status", title: "Oh My Second Brain status", description: "Read-only health and statistics for the active vault.", inputSchema: operationSchema("oms_status"), annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false } },
   { name: "oms_doctor", title: "Oh My Second Brain doctor", description: "Diagnose or repair the vault; `op` selects the operation.", inputSchema: operationSchema("oms_doctor"), annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false } },
@@ -192,13 +208,8 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
   // No model load, no SQLite store, no watcher: side-effect-free per boot (R2).
   const engine = assembleGraphOnlyEngine({ vault });
 
-  // Native engine — semantic layer (lazy): assembled on the FIRST semantic op,
-  // not at boot, so boot stays stateless (R2). The vec-capable engine opens the
-  // engine SQLite store on construction and loads the embedding model on first
-  // embed(). Embedding selection is canonical and explicit: OMS_EMBEDDING_PROVIDER
-  // (e.g. gguf | upstage) + OMS_EMBEDDING_MODEL (path or model id). Absent either,
-  // assembleFullSemanticEngine throws a loud, actionable error (ADR-007: no
-  // hash/fake fallback, no auto-detect) that surfaces via the dispatch catch.
+  // Creating semantic engines are shared by all non-search tools, including
+  // doctor repairs which must initialize a missing store.
   let semanticEngine: AssembledEngine | null = null;
   const getSemanticEngine = (): AssembledEngine => {
     if (semanticEngine === null) {
@@ -218,6 +229,43 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     return coreSemanticEngine;
   };
 
+  // Search owns independent read-only slots so it cannot poison doctor repair.
+  let readOnlySemanticEngine: AssembledEngine | null | undefined;
+  const getReadOnlySemanticEngine = (): AssembledEngine | null => {
+    if (readOnlySemanticEngine === undefined) {
+      readOnlySemanticEngine = assembleEngineReadOnly({
+        vault,
+        embeddingProvider: process.env["OMS_EMBEDDING_PROVIDER"],
+        embeddingModel: process.env["OMS_EMBEDDING_MODEL"],
+        reranker: opts.reranker,
+      });
+    }
+    return readOnlySemanticEngine;
+  };
+  let readOnlyCoreSemanticEngine: AssembledEngine | null | undefined;
+  const getReadOnlyCoreSemanticEngine = (): AssembledEngine | null => {
+    if (readOnlyCoreSemanticEngine === undefined) {
+      readOnlyCoreSemanticEngine = assembleCoreSemanticEngineReadOnly({ vault, reranker: opts.reranker });
+    }
+    return readOnlyCoreSemanticEngine;
+  };
+  let ephemeralCoreSemanticEngine: AssembledEngine | null = null;
+  let ephemeralCoreSemanticEnginePromise: Promise<AssembledEngine> | null = null;
+  const getEphemeralCoreSemanticEngine = async (): Promise<AssembledEngine> => {
+    if (ephemeralCoreSemanticEngine !== null) return ephemeralCoreSemanticEngine;
+    if (ephemeralCoreSemanticEnginePromise === null) {
+      ephemeralCoreSemanticEnginePromise = (async () => {
+        const assembled = assembleEphemeralCoreSemanticEngine({ vault, reranker: opts.reranker });
+        ephemeralCoreSemanticEngine = assembled;
+        return assembled;
+      })().catch((error: unknown) => {
+        ephemeralCoreSemanticEnginePromise = null;
+        throw error;
+      });
+    }
+    return ephemeralCoreSemanticEnginePromise;
+  };
+
   // A real embedding provider is configured iff the canonical pair is set
   // (ADR-007). The engine's model-OPTIONAL surface (document reads,
   // retrieve_context's semantic leg, ReadResource) keys off this to decide
@@ -235,12 +283,53 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
   // missing auth, store-open failure) must surface its error loudly rather than
   // silently masquerade as a model-less host (ADR-007). The core fallback is
   // strictly for the absent-config case.
-  const resolveDocumentAdapter = (): McpEngineAdapter =>
+  const resolveCreatingDocumentAdapter = (): McpEngineAdapter =>
     hasEmbeddingModel() ? getSemanticEngine().adapter : getCoreSemanticEngine().adapter;
+  const resolveReadOnlyDocumentAdapter = (): McpEngineAdapter =>
+    hasEmbeddingModel()
+      ? getReadOnlySemanticEngine()?.adapter ?? engine.adapter
+      : getReadOnlyCoreSemanticEngine()?.adapter ?? engine.adapter;
+  const resolveDocumentAdapter = (publicName: string): McpEngineAdapter => {
+    if (publicName === "oms_search") return resolveReadOnlyDocumentAdapter();
+    return resolveCreatingDocumentAdapter();
+  };
+  const resolveReadOnlyIndexAdapter = (): McpEngineAdapter => {
+    const adapter = hasEmbeddingModel()
+      ? getReadOnlySemanticEngine()?.adapter
+      : getReadOnlyCoreSemanticEngine()?.adapter;
+    if (adapter === undefined || adapter === null) throw new SemanticIndexUnavailableError();
+    return adapter;
+  };
+  const resolveReadOnlyLexicalAdapter = async (): Promise<McpEngineAdapter> => {
+    const adapter = hasEmbeddingModel()
+      ? getReadOnlySemanticEngine()?.adapter
+      : getReadOnlyCoreSemanticEngine()?.adapter;
+    return adapter ?? (await getEphemeralCoreSemanticEngine()).adapter;
+  };
+  const hasExplicitEmbeddingIntent = (args: Record<string, unknown> | undefined): boolean =>
+    requiresEmbeddings({
+      mode: args?.["mode"] === "vsearch" ? "vsearch" : undefined,
+      vec: stringArg(args, "vec"),
+      hyde: stringArg(args, "hyde"),
+      searches: Array.isArray(args?.["searches"])
+        ? args["searches"].flatMap((search) =>
+          isRecord(search) &&
+          (search["type"] === "lex" || search["type"] === "vec" || search["type"] === "hyde") &&
+          typeof search["query"] === "string"
+            ? [{ type: search["type"], query: search["query"] }]
+            : [])
+        : undefined,
+    });
   const searchBackend = new EngineSearchBackend(
     (requiresEmbeddings) => requiresEmbeddings
-      ? getSemanticEngine().adapter
-      : resolveDocumentAdapter(),
+      ? (() => {
+        // Validate ADR-007 configuration before probing the read-only store:
+        // vector intent is actionable only after its required provider/model
+        // pair is present, regardless of whether an index exists yet.
+        if (!hasEmbeddingModel()) return getSemanticEngine().adapter;
+        return resolveReadOnlyIndexAdapter();
+      })()
+      : resolveReadOnlyIndexAdapter(),
     vault,
   );
 
@@ -265,6 +354,15 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     if (coreSemanticEngine !== null) {
       void coreSemanticEngine.dispose().catch(() => undefined);
     }
+    if (readOnlySemanticEngine !== null && readOnlySemanticEngine !== undefined) {
+      void readOnlySemanticEngine.dispose().catch(() => undefined);
+    }
+    if (readOnlyCoreSemanticEngine !== null && readOnlyCoreSemanticEngine !== undefined) {
+      void readOnlyCoreSemanticEngine.dispose().catch(() => undefined);
+    }
+    if (ephemeralCoreSemanticEngine !== null) {
+      void ephemeralCoreSemanticEngine.dispose().catch(() => undefined);
+    }
   };
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -284,7 +382,6 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
         return errorText('Provide exactly one of "query" or "searches" for semantic-query.');
       }
     }
-
     if (name === "oms_graph_status") {
       // The src/graph derived-cache ledger (M3 5-state staleness) is the source
       // of truth for retrieve_context's optional warm cache and stays intact.
@@ -354,8 +451,10 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       const resolveRepairAdapter = operation === "build-graph"
         ? undefined
         : (): McpEngineAdapter =>
-            operation === "semantic-cleanup" || (operation === "sync-embeddings" && args?.["embed"] === false)
-              ? resolveDocumentAdapter()
+            publicName === "oms_search"
+              ? resolveReadOnlyDocumentAdapter()
+              : operation === "semantic-cleanup" || (operation === "sync-embeddings" && args?.["embed"] === false)
+              ? resolveCreatingDocumentAdapter()
               : getSemanticEngine().adapter;
 
       const repair = await repairDoctor({
@@ -407,7 +506,19 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       // configured (parity ranking, real-path docids) and core (lex; vec/HyDE fail
       // fast) otherwise. get/multi_get and ReadResource make the SAME choice, so a
       // docid emitted here always hydrates on the backend that produced it.
-      const semanticBackend = makeEngineMorningBackend(resolveDocumentAdapter(), vault);
+      const semantic = semanticOptionsFromArgs(args);
+      let contextAdapter = engine.adapter;
+      if (semantic?.enabled !== false) {
+        try {
+          contextAdapter = resolveDocumentAdapter(publicName);
+        } catch (error) {
+          if (!(error instanceof SemanticIndexUnavailableError)) throw error;
+        }
+      }
+      const semanticBackend = makeEngineMorningBackend(
+        contextAdapter,
+        vault,
+      );
       const { ontology, source } = await resolveActiveOntology(vault);
       const limitValue = args?.["limit"];
       const maxNeighborsValue = args?.["maxNeighbors"];
@@ -425,7 +536,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
           limit: typeof limitValue === "number" ? limitValue : undefined,
           maxNeighbors: typeof maxNeighborsValue === "number" ? maxNeighborsValue : undefined,
           useCache: typeof useCacheValue === "boolean" ? useCacheValue : undefined,
-          semantic: semanticOptionsFromArgs(args),
+          semantic,
         },
         semanticBackend,
       );
@@ -446,6 +557,25 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     // Every other tool never touches the engine here.
     if (isEngineSemanticOp(name) || isEngineDocumentOp(name)) {
       if (name === "oms_semantic_query") {
+        const query = stringArg(args, "query");
+        const vec = stringArg(args, "vec");
+        const hyde = stringArg(args, "hyde");
+        const noPersistentReadOnlyIndex = hasEmbeddingModel()
+          ? getReadOnlySemanticEngine() === null
+          : getReadOnlyCoreSemanticEngine() === null;
+        if (query !== undefined && !hasExplicitEmbeddingIntent(args) && noPersistentReadOnlyIndex) {
+          const result = await (await getEphemeralCoreSemanticEngine()).adapter.semanticQuery({
+            vault,
+            query,
+            lex: stringArg(args, "lex") ?? query,
+            limit: typeof args?.["limit"] === "number" ? args["limit"] : undefined,
+            minScore: typeof args?.["minScore"] === "number" ? args["minScore"] : undefined,
+            intent: stringArg(args, "intent"),
+            collection: stringArg(args, "collection"),
+            index: stringArg(args, "index"),
+          });
+          return jsonText(result);
+        }
         const requestOptions = {
           limit: typeof args?.["limit"] === "number" ? args["limit"] : undefined,
           candidateLimit: typeof args?.["candidateLimit"] === "number" ? args["candidateLimit"] : undefined,
@@ -458,27 +588,53 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
             : undefined,
           mode: stringArg(args, "mode") as "query" | "search" | "vsearch" | undefined,
           lex: stringArg(args, "lex"),
-          vec: stringArg(args, "vec"),
-          hyde: stringArg(args, "hyde"),
+          vec,
+          hyde,
           index: stringArg(args, "index"),
         };
         const result = await searchBackend.search({
           ...requestOptions,
-          query: stringArg(args, "query"),
+          // `query` is the default lexical representation. An explicit vector
+          // or HyDE shorthand selects its own representation instead; only
+          // `query` plus typed `searches` is contradictory.
+          query: vec !== undefined || hyde !== undefined ? undefined : query,
           searches: Array.isArray(args?.["searches"])
             ? args["searches"] as McpSemanticTypedSearch[]
             : undefined,
         });
         return jsonText(result);
       }
+      const useEphemeralLexicalFallback =
+        name === "oms_semantic_query" &&
+        publicName === "oms_search" &&
+        !hasExplicitEmbeddingIntent(args) &&
+        (hasEmbeddingModel()
+          ? getReadOnlySemanticEngine() === null
+          : getReadOnlyCoreSemanticEngine() === null);
       const semanticAdapter =
+        useEphemeralLexicalFallback
+          ? await resolveReadOnlyLexicalAdapter()
+          :
         isEngineSemanticOp(name) &&
         name !== "oms_semantic_cleanup" &&
         !(name === "oms_sync_embeddings" && args?.["embed"] === false) &&
         !isModelOptionalSemanticQueryOp(name, args, vault)
-          ? getSemanticEngine().adapter
-          : resolveDocumentAdapter();
-      const semanticToolResult = await handleSemanticTool(name, args, vault, semanticAdapter);
+          ? publicName === "oms_search"
+            ? resolveReadOnlyIndexAdapter()
+            : getSemanticEngine().adapter
+          : isEngineDocumentOp(name)
+            ? resolveDocumentAdapter(publicName)
+            : publicName === "oms_search"
+              ? resolveReadOnlyIndexAdapter()
+              : resolveDocumentAdapter(publicName);
+      const semanticToolResult = await handleSemanticTool(
+        name,
+        useEphemeralLexicalFallback
+          ? { ...args, lex: stringArg(args, "query") }
+          : args,
+        vault,
+        semanticAdapter,
+      );
       if (semanticToolResult) {
         if (!semanticToolResult.ok) return errorText(semanticToolResult.message);
         return jsonText(semanticToolResult.value);
@@ -639,6 +795,12 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
 
     return errorText(`Unknown Oh My Second Brain tool: ${publicName}`);
     } catch (error) {
+      if (error instanceof SemanticIndexUnavailableError) {
+        return jsonText({
+          available: false,
+          reason: error.message,
+        });
+      }
       return errorText(`Oh My Second Brain MCP error: ${error instanceof Error ? error.message : String(error)}`);
     }
   });


### PR DESCRIPTION
## Summary

Closes the `oms_search` follow-up recorded in #62's Risks section. Stacked on `restructure/g001-gates`; merge #62 first.

`oms_search` was annotated `readOnlyHint: false` and deserved it. Two separate writes lived on the read path:

- searching a vault with no index called `openEngineStoreCore`, which created `.oms/`, created the SQLite file, set `journal_mode = WAL`, and ran `CREATE TABLE`
- the `embeddingSyncBeforeSearch` family of parameters reached `syncEmbeddings` through `src/mcp/engine-morning-backend.ts`, so any caller could turn a search into a write by passing a flag

That second one is why the annotation could not simply be flipped. `readOnlyHint` is a claim about what a tool *can* do, and MCP hosts may auto-approve tools that make it.

## Linked issue / scope

Follow-up to #62. Scope is the `oms_search` write paths, the store opener, and the engine assembly that feeds them. `oms_doctor`, `oms_write`, `oms_link` and `oms_status` are untouched.

## SSOT check

- **Docs/process SSOT changes:** `CHANGELOG-mcp.md` under `## [Unreleased]`, describing the annotation change, the removed parameters, and the in-memory fallback that keeps first-search working.
- **Runtime enforcement SSOT changes:** `oms_search` posture in `surface-registry.ts` moves `write` → `read`, which the live parity gate ties to the annotation. Two new test files pin the guarantee.

## Verification evidence

- [x] `npm run build`
- [x] `npm test` — 881 passed / 0 failed / 11 skipped across 85 files
- [x] User-facing change? Entry added under `## [Unreleased]` in `CHANGELOG-mcp.md`
- [x] Additional focused checks documented below

`npm run lint` clean. All five gates exit 0, including `release-artifact-smoke`, which is the one that mattered here.

Verified against the built binary over stdio, not by reading source. Five probes, all measured:

| probe | result |
|---|---|
| fresh vault, plain query | `available: true`, 1 hit, tree byte-identical afterwards |
| explicit `vec`, no embeddings | `isError: true`, names `OMS_EMBEDDING_PROVIDER`/`OMS_EMBEDDING_MODEL`, nothing written |
| repair after a search | succeeds, creates `engine-store.sqlite` |
| indexed vault, plain query | 1 hit, tree unchanged |
| built tool surface | `readOnlyHint: true`, no sync knob in schema, five tools |

## What the fix actually had to solve

Removing the writes naively is worse than leaving them. Measured on the previous build, a plain query against a fresh vault returned real hits **because** it silently built the index first. Cutting that turned a working first search into "the semantic index has not been built yet. Run `oms semantic sync`" — install, point a host at your vault, ask a question, get told to go run a command.

`release-artifact-smoke` caught that after 880 unit tests passed. The unit suite only ever asserted that nothing was written; it never asserted an answer still came back. Both are now pinned.

So the index moved rather than disappeared:

- **no store on disk** — the lexical index is built in memory for the session and the query is answered from it. Nothing touches the vault.
- **store on disk** — opened without creating, and the implicit sync is suppressed so a read never rewrites the stored index. Refreshing it is `oms semantic sync`'s job.
- **write-permitted paths** — doctor repairs, the CLI, direct assembly — unchanged, still sync to disk.

Vector retrieval is deliberately *not* served by the in-memory fallback. An explicit `vec`/`hyde` request still fails loudly rather than quietly degrading to lexical, and the ADR-007 guard keeps precedence over the index-missing message: if embeddings are unconfigured, naming the two environment variables is the actionable answer, and building an index would not have helped.

## Risks / follow-ups

**`readonly: true` was tried and rejected.** The store runs in WAL mode; a read-only SQLite connection needs the `-shm` sidecar, creates it, and then cannot check-point or remove it on close — so every search left `engine-store.sqlite-shm` and `-wal` behind, which is worse than the problem. A writable connection with `fileMustExist: true` refuses to create the store yet still tidies up after itself. Write protection therefore sits above SQLite: only SELECTs are prepared and every mutator throws. `store-read-only.test.ts` pins that, including a case proving a foreign SQLite file is declined rather than adopted.

**Removing the sync parameters is a breaking schema change.** `embeddingSyncBeforeSearch`, `embeddingSyncForce` and `embeddingSyncEmbed` are gone from `oms_search`. The capability is not lost — `oms_doctor { op: "sync-embeddings" }` does exactly that work and is annotated as writing — but a caller passing those fields must move. This is the status/doctor boundary #62 made binding: reads never write.

**Re-indexing cost on an unindexed vault.** The in-memory index is built once per server session, not per query, but a large unindexed vault pays that on first search. Running `oms semantic sync` once removes it permanently.

Two test assertions were updated rather than added: the `readOnlyHint` pin in `server.test.ts` (it encoded the defect) and the setup step in `semantic-server.test.ts` (the index build moved to the tool that now owns writes). Every behavioural assertion in both files is unchanged.

## Reference policy check

- [x] No external reference material was used for this change.
