### PR TITLE
fix: stop one note from aborting the whole vault scan

### DIFF
--- a/CHANGELOG-assets.md
+++ b/CHANGELOG-assets.md
@@ -4,6 +4,10 @@ Skills, agents, and ontology data changes belong here.
 
 ## [Unreleased]
 
+### Changed
+
+- The `search` skill now documents axes, so a request that names a kind reaches the right notes. `query` matches text only; a note whose body never restates its own subject was unreachable by the bare query the skill described, even though the vault declares the kind as a frontmatter axis. The skill now says to put a named kind, declared property, or relationship on `axes.field.<key>`, `axes.folder`, or `axes.link`, to discover the available keys from the `facets` in every response and from `op: "concepts"` rather than guessing them, and to treat a refused axis — which returns `available: false` with a `reason`, not an error — as a signal to read `facets`. It also records the two constraints that silently return nothing when missed: an axis query matches lexically, so pairing it with explicit `vec`/`hyde` retrieval is refused, and `concept` is folder-derived rather than a property, so it is scoped with `axes.folder` or `op: "context"`. An axis filter with `query` omitted enumerates a whole kind.
+
 ## [0.6.1] - 2026-08-27
 
 ## [0.6.0] - 2026-08-27

--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -4,6 +4,12 @@ Domain logic changes belong here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`taxonomy.yaml: exclude` now applies to retrieval, not just linting.** The exclude list was parsed into the ontology and resolved into globs for the lint and setup lanes, but the three walkers behind search, axis observation, and graph caching never consulted it and each threw on the first note whose frontmatter would not parse as YAML. Declaring a template source in `exclude` — the documented remedy, and necessary because pre-substitution template frontmatter is intentionally not valid YAML — therefore had no effect on those lanes. All three now filter their yielded paths against the resolved exclude list before parsing, so an excluded file is skipped instead of aborting the scan. Because excluded files no longer contribute to the node-index source signature, the first run after upgrading rebuilds that cache once.
+- **A frontmatter field set to an empty string no longer aborts the axis scan.** `field: ""` states that a field is declared but unset, which is what `field:` already meant; only the explicit empty string was fatal, because empty strings were rejected while `null` and `undefined` were skipped silently. Empty and whitespace-only strings are now skipped the same way. The non-empty invariant still holds for every value that is actually recorded.
+- **Axis value errors now name the note that caused them.** A rejected value threw with no path attached, so a whole-vault scan failure gave no indication of which of thousands of notes was responsible. These errors are now prefixed with the note path and preserve the original error as `cause`.
+
 ## [0.6.1] - 2026-08-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This aggregate changelog contains changes that span multiple layers.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A single unparseable note no longer disables the entire vault.** Two independent whole-vault aborts meant that one bad file anywhere made `oms_search` return no results and `oms_status` report `ontologySource: "vault-invalid"` with write tools disabled. Both are fixed: `taxonomy.yaml: exclude` is now honoured by the walkers that feed retrieval, and a frontmatter field set to an empty string is treated as unset rather than as an error. Vaults that hit this will start returning results again with no configuration change.
+
 ## [0.6.1] - 2026-08-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This aggregate changelog contains changes that span multiple layers.
 
 - **A single unparseable note no longer disables the entire vault.** Two independent whole-vault aborts meant that one bad file anywhere made `oms_search` return no results and `oms_status` report `ontologySource: "vault-invalid"` with write tools disabled. Both are fixed: `taxonomy.yaml: exclude` is now honoured by the walkers that feed retrieval, and a frontmatter field set to an empty string is treated as unset rather than as an error. Vaults that hit this will start returning results again with no configuration change.
 
+- **A search for a kind of note now reaches that kind.** Asking for a person, a meeting, or a project matched only notes whose text happened to repeat the word, because the `search` skill described a text query and never mentioned the axes the engine already supports. The skill now routes a named kind onto a frontmatter axis and discovers the available axis keys from the response itself, so the vault's own declared structure is used instead of guessed at.
+
 ## [0.6.1] - 2026-08-27
 
 ### Fixed

--- a/assets/skills/search/SKILL.md
+++ b/assets/skills/search/SKILL.md
@@ -23,3 +23,19 @@ Use this skill to find and assemble relevant vault knowledge without changing th
 ```
 
 Choose the declared lens that matches the request, return only that lens's fields, and group results by concept or folder. Search may combine the live note, frontmatter, and wikilink graph with available semantic candidates; graph results remain available when the semantic index is unavailable.
+
+## Axes
+
+`query` scores text, so it reaches a note only where the words are actually written. A request that names a kind — a person, a meeting, a project — belongs on an axis instead: an entity note is titled with its subject and then seldom repeats it, which is precisely what text scoring cannot find.
+
+Put the request on an axis whenever it names a kind, a declared property, or a relationship:
+
+- `axes.field.<key>` filters on a frontmatter property declared by the vault contract. The value may be a scalar, a list of scalars (matching any of them), or a predicate object — `in`, `contains`, `containsAll`, `between`, `gte`/`gt`/`lte`/`lt`, `from`/`to`.
+- `axes.folder` scopes to a top-level folder. It takes the folder's own name, not the concept name derived from it.
+- `axes.link` follows the wikilink graph to reach the notes that reference an entity rather than the one describing it. It matches on filename alone: a bare title is enough, and a surrounding folder path or `.md` extension is ignored rather than narrowing the match.
+
+Axes intersect, so a kind and a folder can be combined to narrow a single query. An axis filter is also a complete query by itself: omit `query` to enumerate a whole kind instead of searching inside it. Axis queries match lexically, so pair them with `query` or a `lex` sub-query; asking for `vec` or `hyde` retrieval alongside an axis returns nothing and says so.
+
+Discover axes rather than guessing them. A successful query returns `facets` — the axis keys this vault actually uses, each with its observed values and their counts — and `op: "concepts"` reports the fields every concept declares. Which properties exist is a per-vault contract, so read it before filtering on it.
+
+A rejected axis is not a failed call. The response returns `available: false` with a `reason` naming the key it refused, and comes back with `hits` and `facets` both empty — so recover by querying again without that axis and reading the facets that call returns, never by retrying the same guess. `concept` is derived from a note's folder rather than stored as a property, so scope it with `axes.folder` or with `op: "context"` — `axes.field.concept` is always refused.

--- a/src/kernel/conventions/note-exclude.test.ts
+++ b/src/kernel/conventions/note-exclude.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { DEFAULT_EXCLUDE_GLOBS, matchesAnyGlob, excludedNoteMatcher } from "./note-exclude.js";
+
+let roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function makeVault(files: Record<string, string> = {}): Promise<string> {
+  const vaultPath = await mkdtemp(path.join(os.tmpdir(), "oms-note-exclude-"));
+  roots.push(vaultPath);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(vaultPath, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, content);
+  }
+  return vaultPath;
+}
+
+describe("matchesAnyGlob", () => {
+  it("`**` crosses a `/` boundary", () => {
+    expect(matchesAnyGlob("a/b/c.template.md", ["**/*.template.md"])).toBe(true);
+    expect(matchesAnyGlob("references/skip.template.md", ["**/*.template.md"])).toBe(true);
+  });
+
+  it("plain `*` does not cross a `/` boundary", () => {
+    // A single-star glob anchored at the root must not reach into subfolders.
+    expect(matchesAnyGlob("notes/skip.md", ["*.md"])).toBe(false);
+    expect(matchesAnyGlob("skip.md", ["*.md"])).toBe(true);
+  });
+
+  it("regression: the globstar placeholder must survive the escaping step", () => {
+    // If GLOBSTAR were a printable stand-in instead of an actual NUL
+    // character, the `[.+^${}()|[\]\\]` escaping pass would itself escape
+    // the placeholder's backslash and the later split would never match,
+    // silently disabling all "**" handling. This exercises exactly that path:
+    // a nested markdown file under a "**"-prefixed glob.
+    expect(matchesAnyGlob("25. Digital Garden/.deploy-staging/draft.md", DEFAULT_EXCLUDE_GLOBS)).toBe(
+      true,
+    );
+    expect(matchesAnyGlob("templates/daily/entry.template.md", ["**/*.template.md"])).toBe(true);
+    expect(matchesAnyGlob("a/b/c/d/SKILL.md", ["**/SKILL.md"])).toBe(true);
+  });
+
+  it("returns false when no glob matches", () => {
+    expect(matchesAnyGlob("references/clean-architecture.md", DEFAULT_EXCLUDE_GLOBS)).toBe(false);
+  });
+});
+
+describe("excludedNoteMatcher", () => {
+  it("applies only the built-in defaults when taxonomy.yaml has no exclude key", async () => {
+    const vault = await makeVault({
+      ".oms/taxonomy.yaml": "folders: {}\n",
+    });
+    const isExcluded = await excludedNoteMatcher(vault);
+    expect(isExcluded(".obsidian/workspace.md")).toBe(true);
+    expect(isExcluded("notes/idea.md")).toBe(false);
+  });
+
+  it("merges vault-declared exclude globs with the built-in defaults", async () => {
+    const vault = await makeVault({
+      ".oms/taxonomy.yaml": "folders: {}\nexclude:\n  - \"drafts/**\"\n",
+    });
+    const isExcluded = await excludedNoteMatcher(vault);
+    expect(isExcluded("drafts/unfinished.md")).toBe(true);
+    expect(isExcluded(".obsidian/workspace.md")).toBe(true);
+    expect(isExcluded("notes/idea.md")).toBe(false);
+  });
+
+  it("degrades to the built-in defaults when taxonomy.yaml is missing", async () => {
+    const vault = await makeVault();
+    const isExcluded = await excludedNoteMatcher(vault);
+    expect(isExcluded(".obsidian/workspace.md")).toBe(true);
+    expect(isExcluded("notes/idea.md")).toBe(false);
+  });
+
+  it("degrades to the built-in defaults when taxonomy.yaml is malformed", async () => {
+    const vault = await makeVault({
+      ".oms/taxonomy.yaml": "broken: [legacy\n",
+    });
+    const isExcluded = await excludedNoteMatcher(vault);
+    expect(isExcluded(".obsidian/workspace.md")).toBe(true);
+    expect(isExcluded("notes/idea.md")).toBe(false);
+  });
+});

--- a/src/kernel/conventions/note-exclude.ts
+++ b/src/kernel/conventions/note-exclude.ts
@@ -1,0 +1,102 @@
+/**
+ * Vault-declared note exclusions for the scanning walkers.
+ *
+ * `taxonomy.yaml: exclude` names markdown files that are not notes - template
+ * sources whose pre-substitution frontmatter is intentionally not valid YAML
+ * (Templater tags, agent {{var}} placeholders), build staging, skill files.
+ * The vault-lint lane already honours it via `resolveExcludeGlobs` in
+ * ../engine/conventions/vault-lint.ts, but the walkers that feed retrieval
+ * (the engine graph builder, the EAV axis scan, the graph cache) never saw
+ * it and threw on the first excluded note, aborting the whole vault scan.
+ *
+ * This module gives those walkers the same exclusion policy without
+ * requiring a full Ontology load (two of the three call sites intentionally
+ * do not load one): it reads <vaultRoot>/.oms/taxonomy.yaml directly and
+ * degrades to the built-in defaults when the file is missing or malformed.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Default audit exemptions - build artifacts, self-documenting templates, and
+ * skill files that intentionally carry no frontmatter. This is the single
+ * declaration; ../engine/conventions/vault-lint.ts re-exports it so its
+ * existing importers are unaffected.
+ */
+export const DEFAULT_EXCLUDE_GLOBS: readonly string[] = [
+  "25. Digital Garden/.deploy-staging/**",
+  "**/*.template.md",
+  "**/SKILL.md",
+  ".obsidian/**",
+  ".trash/**",
+  ".oms/**",
+  "_attachments/**",
+];
+
+/**
+ * Convert a `*`/`**` glob into an anchored RegExp. `**` matches across `/`,
+ * `*` does not.
+ *
+ * GLOBSTAR must be a placeholder character that (a) cannot appear in a glob
+ * and (b) survives the escaping step below untouched. The NUL character
+ * (written here as the escape sequence "\u0000") satisfies both. A printable
+ * stand-in typed as the literal four-character escape sequence would not
+ * survive: the escaping regex would itself escape its backslash, and the
+ * later split on the placeholder would never match again - silently
+ * disabling all "**" handling.
+ */
+function globToRegExp(glob: string): RegExp {
+  const GLOBSTAR = "\u0000";
+  const withPlaceholder = glob.replace(/\*\*/g, GLOBSTAR);
+  const escaped = withPlaceholder.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const withStar = escaped.replace(/\*/g, "[^/]*");
+  const pattern = withStar.split(GLOBSTAR).join(".*");
+  return new RegExp(`^${pattern}$`);
+}
+
+/** True when `notePath` matches at least one of `globs`. */
+export function matchesAnyGlob(notePath: string, globs: readonly string[]): boolean {
+  return globs.some((glob) => globToRegExp(glob).test(notePath));
+}
+
+/** One resolve per vault root per process; every walker level shares it. */
+const matcherCache = new Map<string, Promise<RegExp[]>>();
+
+async function loadExcludeMatchers(vaultRoot: string): Promise<RegExp[]> {
+  const key = path.resolve(vaultRoot);
+  let pending = matcherCache.get(key);
+  if (pending === undefined) {
+    pending = (async () => {
+      let declared: string[] = [];
+      try {
+        const raw = await readFile(path.join(key, ".oms", "taxonomy.yaml"), "utf-8");
+        const parsed = parseYaml(raw) as unknown;
+        const rawExclude =
+          parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)["exclude"]
+            : undefined;
+        if (Array.isArray(rawExclude) && rawExclude.every((item) => typeof item === "string")) {
+          declared = rawExclude;
+        }
+      } catch {
+        // A vault with no (or an unparsable) taxonomy.yaml still gets the
+        // built-in defaults - a missing exclude declaration is not fatal.
+      }
+      return [...DEFAULT_EXCLUDE_GLOBS, ...declared].map(globToRegExp);
+    })();
+    matcherCache.set(key, pending);
+  }
+  return pending;
+}
+
+/**
+ * Predicate over vault-relative, forward-slashed note paths.
+ * Resolved once per vault root and reused by every walker level.
+ */
+export async function excludedNoteMatcher(
+  vaultRoot: string,
+): Promise<(notePath: string) => boolean> {
+  const matchers = await loadExcludeMatchers(vaultRoot);
+  return (notePath: string) => matchers.some((pattern) => pattern.test(notePath));
+}

--- a/src/kernel/engine/axes/r4-contract-axis.test.ts
+++ b/src/kernel/engine/axes/r4-contract-axis.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { CONTRACT_SCHEMA, loadContract, loadObsidianTypes, parseContract, serializeContract, writeContract } from "../../contracts/index.js";
 import { buildNodeIndex } from "../graph/builder.js";
 import { filterNodesByQueryAxes, type EngineGraphNode } from "../graph/node.js";
-import { collectVaultAxisObservations, openAxisStore } from "./store.js";
+import { collectVaultAxisObservations, normalizeAxisValue, openAxisStore } from "./store.js";
 
 let roots: string[] = [];
 
@@ -134,5 +134,66 @@ describe("R4 contract and axis primitives", () => {
 
     await expect(collectVaultAxisObservations(root)).rejects.toThrow(/malformed frontmatter/i);
     await expect(readdir(path.join(root, ".oms"))).rejects.toThrow();
+  });
+
+  it("honors taxonomy.yaml: exclude instead of aborting the EAV scan on invalid frontmatter", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-r4-axis-exclude-"));
+    roots.push(root);
+    await mkdir(path.join(root, ".oms"), { recursive: true });
+    await writeFile(
+      path.join(root, ".oms", "taxonomy.yaml"),
+      "folders: {}\nexclude:\n  - \"templates/**\"\n",
+      "utf8",
+    );
+    // Template source frontmatter is intentionally not valid YAML.
+    await mkdir(path.join(root, "templates"), { recursive: true });
+    await writeFile(path.join(root, "templates", "daily.md"), "---\ndate: {{date}}\n---\n", "utf8");
+    await writeFile(path.join(root, "live.md"), "---\nstatus: live\n---\n", "utf8");
+
+    const store = await collectVaultAxisObservations(root);
+    expect(store.list().map((row) => row.notePath)).toEqual(["live.md"]);
+    store.close();
+  });
+
+  it("skips empty/whitespace-only string values while recording non-empty ones", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-r4-axis-empty-string-"));
+    roots.push(root);
+    const store = openAxisStore(path.join(root, "axes.sqlite"));
+
+    // `moc:` (null) is already dropped by flattenValue; `moc: ""` must be
+    // dropped the same way instead of throwing "Axis string value must be
+    // non-empty.".
+    expect(() =>
+      store.replaceNote("note.md", { moc: "", spacer: "   ", title: "Real Title" }),
+    ).not.toThrow();
+    const rows = store.list({ notePath: "note.md" });
+    expect(rows.map((row) => row.axisKey)).toEqual(["title"]);
+    // canonicalScalar trims + lowercases every recorded string value.
+    expect(rows[0]?.value).toBe("real title");
+
+    store.close();
+  });
+
+  it("canonicalScalar's invariant still rejects an empty string when called directly", () => {
+    // insertValues only skips blank strings before they reach
+    // normalizeAxisValue/canonicalScalar; the underlying invariant itself is
+    // untouched and must still reject an empty string for any direct caller.
+    expect(() => normalizeAxisValue("")).toThrow(/Axis string value must be non-empty\./);
+    expect(() => normalizeAxisValue("   ")).toThrow(/Axis string value must be non-empty\./);
+    expect(normalizeAxisValue("kept").value).toBe("kept");
+  });
+
+  it("wraps a canonicalScalar-style throw with the offending note path", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-r4-axis-note-path-"));
+    roots.push(root);
+    const store = openAxisStore(path.join(root, "axes.sqlite"));
+
+    // An invalid Date value reaches canonicalScalar's "Axis date value must
+    // be valid." throw; insertValues must prefix it with the note path.
+    expect(() =>
+      store.replaceNote("references/broken-date.md", { published: new Date(NaN) }),
+    ).toThrow(/references\/broken-date\.md: Axis date value must be valid\./);
+
+    store.close();
   });
 });

--- a/src/kernel/engine/axes/store.ts
+++ b/src/kernel/engine/axes/store.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, readdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import Database from "better-sqlite3";
 import { parseNote } from "../../conventions/frontmatter.js";
+import { excludedNoteMatcher } from "../../conventions/note-exclude.js";
 
 export type AxisKind = "folder" | "field" | "link";
 export type AxisValueType = "string" | "number" | "boolean" | "date";
@@ -194,7 +195,21 @@ export class AxisObservationStore {
     statement: Database.Statement<unknown[]>,
   ): void {
     for (const original of flattenValue(value)) {
-      const normalized = normalizeAxisValue(original);
+      // An empty or whitespace-only string carries no axis information, so
+      // it is dropped exactly like the null/undefined that flattenValue
+      // already discards. `field: ""` is a normal "declared but unset"
+      // frontmatter state, not vault corruption; it must not abort the
+      // whole vault scan.
+      if (typeof original === "string" && original.trim().length === 0) continue;
+      let normalized: ReturnType<typeof normalizeAxisValue>;
+      try {
+        normalized = normalizeAxisValue(original);
+      } catch (error) {
+        // canonicalScalar's own errors carry no note path, which makes them
+        // undiagnosable from the message alone during a whole-vault scan.
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`${notePath}: ${message}`, { cause: error });
+      }
       statement.run(notePath, axisKind, axisKey, normalized.type, JSON.stringify(normalized.value), normalized.normalizedValue);
     }
   }
@@ -374,6 +389,7 @@ function ensureInsideVault(root: string, candidate: string, label: string): void
 async function* walkVaultMarkdownStrict(
   dir: string,
   base: string,
+  isExcluded: (notePath: string) => boolean,
   rootRealPath?: string,
   visitedDirectories: Set<string> = new Set(),
 ): AsyncGenerator<string> {
@@ -391,9 +407,12 @@ async function* walkVaultMarkdownStrict(
     if (AXIS_SKIP_DIRS.has(entry.name) || entry.name.startsWith(".")) continue;
     const entryStat = await stat(fullPath);
     if (entryStat.isDirectory()) {
-      yield* walkVaultMarkdownStrict(fullPath, base, root, visitedDirectories);
+      yield* walkVaultMarkdownStrict(fullPath, base, isExcluded, root, visitedDirectories);
     } else if (entryStat.isFile() && entry.name.toLowerCase().endsWith(".md")) {
-      yield path.relative(base, fullPath).replace(/\\/g, "/");
+      const notePath = path.relative(base, fullPath).replace(/\\/g, "/");
+      // Taxonomy-declared non-notes (template sources above all) never enter
+      // the EAV scan: their frontmatter is intentionally not valid YAML.
+      if (!isExcluded(notePath)) yield notePath;
     }
   }
 }
@@ -412,9 +431,10 @@ export async function collectVaultAxisObservations(
     parsed: ReturnType<typeof parseNote>;
   }> = [];
   try {
+    const isExcluded = await excludedNoteMatcher(vault);
     // Read and parse the complete source set before touching the existing
     // snapshot. This keeps read/parse failures from exposing a partial scan.
-    for await (const notePath of walkVaultMarkdownStrict(vault, vault)) {
+    for await (const notePath of walkVaultMarkdownStrict(vault, vault, isExcluded)) {
       const raw = await readFile(path.join(vault, notePath), "utf-8");
       sourceFiles.set(notePath, Buffer.from(raw, "utf8"));
       const parsed = parseNote(raw);

--- a/src/kernel/engine/conventions/vault-lint.ts
+++ b/src/kernel/engine/conventions/vault-lint.ts
@@ -28,6 +28,7 @@ import {
   routingLawViolations,
 } from "../../conventions/write-contract.js";
 import { walkVaultMarkdown } from "../../conventions/vault-walk.js";
+import { DEFAULT_EXCLUDE_GLOBS, matchesAnyGlob } from "../../conventions/note-exclude.js";
 import { resolveConcept } from "../../ontology/resolver.js";
 import type { Concept, Ontology } from "../../ontology/types.js";
 
@@ -89,30 +90,13 @@ export interface VaultLintOptions {
 /**
  * Default audit exemptions — deliberately not contract violations: build artifacts,
  * self-documenting templates, and skill files that intentionally carry no frontmatter.
+ *
+ * Defined in `../../conventions/note-exclude.js` (below the engine layer) and
+ * re-exported here so existing importers of this module are unaffected; the
+ * scanning walkers that also need this policy (graph builder, EAV axis scan,
+ * graph cache) import it from there directly instead of duplicating it.
  */
-export const DEFAULT_EXCLUDE_GLOBS: readonly string[] = [
-  "25. Digital Garden/.deploy-staging/**",
-  "**/*.template.md",
-  "**/SKILL.md",
-  ".obsidian/**",
-  ".trash/**",
-  ".oms/**",
-  "_attachments/**",
-];
-
-/** Convert a `*`/`**` glob into an anchored RegExp. `**` matches across `/`, `*` does not. */
-function globToRegExp(glob: string): RegExp {
-  const GLOBSTAR = "\u0000";
-  const withPlaceholder = glob.replace(/\*\*/g, GLOBSTAR);
-  const escaped = withPlaceholder.replace(/[.+^${}()|[\]\\]/g, "\\$&");
-  const withStar = escaped.replace(/\*/g, "[^/]*");
-  const pattern = withStar.split(GLOBSTAR).join(".*");
-  return new RegExp(`^${pattern}$`);
-}
-
-export function matchesAnyGlob(notePath: string, globs: readonly string[]): boolean {
-  return globs.some((glob) => globToRegExp(glob).test(notePath));
-}
+export { DEFAULT_EXCLUDE_GLOBS, matchesAnyGlob };
 
 /** Merge built-in defaults with vault-declared and caller-supplied exclude globs. */
 export function resolveExcludeGlobs(ontology: Ontology, extra: readonly string[] = []): string[] {

--- a/src/kernel/engine/graph/builder.test.ts
+++ b/src/kernel/engine/graph/builder.test.ts
@@ -202,6 +202,37 @@ describe("Tier 4 – type-affinity edges", () => {
 // Cache round-trip
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// taxonomy.yaml: exclude — malformed frontmatter must not abort the scan
+// ---------------------------------------------------------------------------
+
+describe("taxonomy-declared exclusions", () => {
+  it("honors taxonomy.yaml: exclude instead of aborting on invalid frontmatter", async () => {
+    await writeVaultFile(
+      ".oms/taxonomy.yaml",
+      "folders: {}\nexclude:\n  - \"templates/**\"\n",
+    );
+    // A template source's pre-substitution frontmatter is intentionally not
+    // valid YAML — this must be skipped, not thrown on.
+    await writeVaultFile("templates/daily.md", "---\ndate: {{date}}\n---\n# {{title}}\n");
+    await writeVaultFile("notes/idea.md", "# Idea\n");
+
+    const nodes = await buildNodeIndex({ vaultPath: tmpVault });
+    expect(nodes.map((n) => n.path)).toEqual(["notes/idea.md"]);
+
+    const edges = await buildGraph({ vaultPath: tmpVault });
+    expect(edges.every((e) => e.from !== "templates/daily.md" && e.to !== "templates/daily.md")).toBe(
+      true,
+    );
+  });
+
+  it("still throws for malformed frontmatter on a note that is not excluded", async () => {
+    await writeVaultFile(".oms/taxonomy.yaml", "folders: {}\n");
+    await writeVaultFile("broken.md", "---\nstatus: [broken\n---\nBody\n");
+    await expect(buildNodeIndex({ vaultPath: tmpVault })).rejects.toThrow(/Malformed frontmatter/);
+  });
+});
+
 describe("cache helpers", () => {
   it("preserves numeric and boolean frontmatter values in the node snapshot", async () => {
     await writeVaultFile(

--- a/src/kernel/engine/graph/builder.ts
+++ b/src/kernel/engine/graph/builder.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 import { parseNote } from "../../conventions/frontmatter.js";
+import { excludedNoteMatcher } from "../../conventions/note-exclude.js";
 import type { GraphEdge } from "../types.js";
 import type { AxisScalar, EngineGraphNode } from "./node.js";
 import { toAxisScalars, tokenize } from "./node.js";
@@ -31,6 +32,7 @@ function ensureInsideRoot(root: string, candidate: string, label: string): void 
 async function* walkMarkdown(
   dir: string,
   base: string,
+  isExcluded: (notePath: string) => boolean,
   rootRealPath?: string,
   visitedDirectories: Set<string> = new Set(),
 ): AsyncGenerator<string> {
@@ -51,9 +53,13 @@ async function* walkMarkdown(
     if (name === ".oms" || name === "node_modules" || name.startsWith(".")) continue;
     const entryStat = await stat(full);
     if (entryStat.isDirectory()) {
-      yield* walkMarkdown(full, base, root, visitedDirectories);
+      yield* walkMarkdown(full, base, isExcluded, root, visitedDirectories);
     } else if (entryStat.isFile() && name.toLowerCase().endsWith(".md")) {
-      yield path.relative(base, full).replace(/\\/g, "/");
+      const notePath = path.relative(base, full).replace(/\\/g, "/");
+      // Template sources and other taxonomy-declared non-notes are skipped
+      // here: their pre-substitution frontmatter is intentionally invalid
+      // YAML, and a single one of them must not abort the whole vault scan.
+      if (!isExcluded(notePath)) yield notePath;
     }
   }
 }
@@ -195,8 +201,9 @@ export async function buildGraph(opts: {
     files = opts.files;
     await validateExplicitFiles(vaultPath, files);
   } else {
+    const isExcluded = await excludedNoteMatcher(vaultPath);
     const collected: string[] = [];
-    for await (const f of walkMarkdown(vaultPath, vaultPath)) collected.push(f);
+    for await (const f of walkMarkdown(vaultPath, vaultPath, isExcluded)) collected.push(f);
     files = collected;
   }
 
@@ -463,8 +470,9 @@ interface NodeCacheFile {
 /** Hash sorted markdown paths and bytes so add/edit/delete invalidates a cache. */
 export async function nodeSourceSignature(vaultPath: string): Promise<string> {
   const vault = path.resolve(vaultPath);
+  const isExcluded = await excludedNoteMatcher(vault);
   const files: string[] = [];
-  for await (const file of walkMarkdown(vault, vault)) files.push(file);
+  for await (const file of walkMarkdown(vault, vault, isExcluded)) files.push(file);
   files.sort();
 
   const digest = createHash("sha256");
@@ -509,8 +517,9 @@ export async function buildNodeIndex(opts: {
     files = opts.files;
     await validateExplicitFiles(vaultPath, files);
   } else {
+    const isExcluded = await excludedNoteMatcher(vaultPath);
     const collected: string[] = [];
-    for await (const f of walkMarkdown(vaultPath, vaultPath)) collected.push(f);
+    for await (const f of walkMarkdown(vaultPath, vaultPath, isExcluded)) collected.push(f);
     files = collected;
   }
 

--- a/src/kernel/graph/cache.test.ts
+++ b/src/kernel/graph/cache.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { loadOntology } from "../ontology/loader.js";
+import type { Ontology } from "../ontology/types.js";
 import {
   buildGraphCache,
   graphCacheStatus,
@@ -125,6 +126,32 @@ describe("derived graph cache", () => {
 
     await writeFile(path.join(cacheDirectory, "graph.json"), JSON.stringify({ version: 999 }), "utf8");
     await expect(readGraphCache(tmpVault)).rejects.toThrow(/invalid format/i);
+  });
+
+  it("honors ontology.taxonomy.exclude instead of aborting the cache build on invalid frontmatter", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-graph-exclude-"));
+    await cp(fixtureVault, tmpVault, { recursive: true });
+    const bundled = await loadOntology(ontologyDir);
+    const ontology: Ontology = {
+      ...bundled,
+      taxonomy: { ...bundled.taxonomy, exclude: ["templates/**"] },
+    };
+    // Template source frontmatter is intentionally not valid YAML.
+    await mkdir(path.join(tmpVault, "templates"), { recursive: true });
+    await writeFile(path.join(tmpVault, "templates", "daily.md"), "---\ndate: {{date}}\n---\n", "utf-8");
+
+    const cache = await buildGraphCache({ vault: tmpVault, ontology });
+    expect(cache.notes.map((note) => note.path)).not.toContain("templates/daily.md");
+    expect(cache.notes.map((note) => note.path)).toContain("references/clean-architecture.md");
+  });
+
+  it("still throws for malformed frontmatter on a note that is not excluded", async () => {
+    tmpVault = await mkdtemp(path.join(tmpdir(), "oms-graph-exclude-throw-"));
+    const ontology = await loadOntology(ontologyDir);
+    await writeFile(path.join(tmpVault, "broken.md"), "---\nstatus: [broken\n---\n", "utf8");
+    await expect(buildGraphCache({ vault: tmpVault, ontology })).rejects.toThrow(
+      /malformed frontmatter/i,
+    );
   });
 
   it("keeps engine graph and node cache IO failures loud", async () => {

--- a/src/kernel/graph/cache.ts
+++ b/src/kernel/graph/cache.ts
@@ -16,6 +16,7 @@ import { validateFrontmatter } from "../conventions/validate.js";
 import { safeVaultNotePath } from "../capture/safe.js";
 import { resolveConcept } from "../ontology/resolver.js";
 import type { Concept, Ontology } from "../ontology/types.js";
+import { matchesAnyGlob, resolveExcludeGlobs } from "../engine/conventions/vault-lint.js";
 
 export type GraphEdgeType = "folder-concept" | "property-axis" | "property-value" | "wikilink";
 
@@ -190,6 +191,7 @@ function isGraphCacheShape(value: unknown): value is OMSGraphCache {
 async function* walkMarkdown(
   dir: string,
   base: string,
+  excludeGlobs: readonly string[],
   rootRealPath?: string,
   visitedDirectories: Set<string> = new Set(),
 ): AsyncGenerator<string> {
@@ -220,9 +222,12 @@ async function* walkMarkdown(
     }
     const entryStat = await stat(full);
     if (entryStat.isDirectory()) {
-      yield* walkMarkdown(full, base, root, visitedDirectories);
+      yield* walkMarkdown(full, base, excludeGlobs, root, visitedDirectories);
     } else if (entryStat.isFile() && entry.name.toLowerCase().endsWith(".md")) {
-      yield path.relative(base, full).replace(/\\/g, "/");
+      const notePath = path.relative(base, full).replace(/\\/g, "/");
+      // Taxonomy-declared non-notes never reach parseGraphFrontmatter, whose
+      // malformed-YAML throw would otherwise abort the entire cache rebuild.
+      if (!matchesAnyGlob(notePath, excludeGlobs)) yield notePath;
     }
   }
 }
@@ -299,7 +304,8 @@ function parseGraphFrontmatter(raw: string, notePath: string): ReturnType<typeof
 
 async function buildSourceSignatures(vault: string, ontology: Ontology): Promise<SourceSignatures> {
   const notes: Record<string, NoteSignature> = {};
-  for await (const notePath of walkMarkdown(vault, vault)) {
+  const excludeGlobs = resolveExcludeGlobs(ontology);
+  for await (const notePath of walkMarkdown(vault, vault, excludeGlobs)) {
     const fullPath = path.join(vault, notePath);
     const [raw, fileStat] = await Promise.all([readFile(fullPath, "utf-8"), stat(fullPath)]);
     const parsed = parseGraphFrontmatter(raw, notePath);
@@ -402,8 +408,9 @@ export async function buildGraphCache(opts: {
   const notes: GraphNote[] = [];
   const edges: GraphEdge[] = [];
   const search: SearchDocument[] = [];
+  const excludeGlobs = resolveExcludeGlobs(opts.ontology);
 
-  for await (const notePath of walkMarkdown(vault, vault)) {
+  for await (const notePath of walkMarkdown(vault, vault, excludeGlobs)) {
     const raw = await readFile(path.join(vault, notePath), "utf-8");
     const built = buildNoteGraph(notePath, raw, opts.ontology);
     notes.push(built.note);


### PR DESCRIPTION
Two independent whole-vault scan aborts, plus the retrieval gap they were hiding. Either one made `oms_search` return nothing and `oms_status` report `ontologySource: "vault-invalid"` with write tools disabled — from a single file, anywhere in the vault. Found on a 20,515-note vault; fixing the first revealed the second.

Closes #68. Addresses the root cause behind #67 (see [this comment](https://github.com/GoBeromsu/oh-my-second-brain/issues/67#issuecomment-5435436670)); #67 stays open for its `.obsidian` template-folder discovery proposal, which is the ergonomics layer on top of this.

## 1. `taxonomy.yaml: exclude` never reached the retrieval walkers

`loader.ts` parsed `exclude` into the ontology; `resolveExcludeGlobs()` turned it into globs for exactly two callers — the lint lane (`vault-lint.ts:309`) and the setup lane (`setup/axis.ts:93`). The three walkers behind search, axis observation, and graph caching consulted it in zero places, and each threw on the first note whose frontmatter would not parse as YAML.

Template sources are the case that matters: pre-substitution frontmatter is *intentionally* not valid YAML (Templater `<%* %>`, agent `{{var}}`), which is exactly why templates get declared in `exclude`. A multi-line `{{participants_yaml}}` injection point cannot be made valid YAML, so honouring `exclude` is the only available remedy — and it silently did nothing.

**Fix.** New `src/kernel/conventions/note-exclude.ts` owns the single declaration of `DEFAULT_EXCLUDE_GLOBS` and the glob→RegExp conversion, and exposes `excludedNoteMatcher(vaultRoot)` (memoized per vault root, degrading to defaults when `taxonomy.yaml` is missing or unparsable). `vault-lint.ts` re-exports the two symbols so its existing importers are untouched.

- `engine/graph/builder.ts` and `engine/axes/store.ts` take an `isExcluded` predicate through their walkers. Neither loads a full `Ontology`, and `loadOntology()` throws on missing/malformed input, so forcing one just to read an exclude list would be the wrong dependency.
- `graph/cache.ts` deliberately does **not** use that module. It already has a loaded `Ontology` — which may be `bundled`- or `vault`-sourced — so it derives its globs with `resolveExcludeGlobs(ontology)`. Re-reading `taxonomy.yaml` independently there could silently diverge from the ontology actually driving the build.

Note the placement rationale: "engine must not import upward out of `engine/`" turned out not to be a real constraint. `vault-lint.ts` (engine) already imports `conventions/vault-walk.js`, and `setup/axis.ts` already imports `engine/conventions/vault-lint.js`. R18 guards a different boundary — zero runtime imports from `engine/**` into the legacy `src/search` layer. So the globs are declared once rather than duplicated.

## 2. `field: ""` aborted the EAV axis scan

`canonicalScalar()` rejected empty and whitespace-only strings, while `flattenValue()` already dropped `null`/`undefined` silently — so `moc:` was fine and `moc: ""` was fatal. Both spellings mean the same thing: declared but unset. On the reporting vault 2,951 of 20,515 notes (14%) carried one, 2,653 of them just `date_published: ""` from an ingest pipeline that always emits the key.

**Fix.** `insertValues()` skips empty/whitespace-only strings before they reach `canonicalScalar`, mirroring how `flattenValue` already skips nullish values. `canonicalScalar`'s invariant is untouched and still holds for every value that *is* recorded.

**Also:** the throw carried no note path, which made it undiagnosable during a whole-vault scan — locating the offending note required a standalone script re-implementing `flattenValue`'s traversal. `insertValues` now wraps any `normalizeAxisValue` throw as `` `${notePath}: ${message}` `` with the original preserved as `cause`. That is the one call site holding both the error and the path.

## 3. A search for a kind of note never reached that kind

With the vault scanning again, the original symptom survived: asking for a person returned nothing, while the *same* query carrying `axes.field.type` returned the note immediately. Measured on the reporting vault — `query: "<name>"` alone gives `available: true, totalCount: 0`; adding `axes: {field: {type: "people"}}` gives the person's note as the only hit.

The engine had supported axes the whole time. `assets/skills/search/SKILL.md` only ever described a text query, so a text query is what agents sent. `query` matches text, and an entity note is precisely the shape text search cannot reach: it is titled with the subject's name and then talks about everything except the name.

**Fix.** The skill's body — not its frontmatter, which nothing in the repo dispatches — now routes a named kind onto `axes.field.<key>`, a place onto `axes.folder`, and a relationship onto `axes.link`, and says to discover which keys exist from the `facets` a successful query returns and from `op: "concepts"`. Declared properties are a per-vault contract, so a hardcoded list would be wrong on someone else's vault; the skill teaches discovery instead of shipping this vault's vocabulary.

It also records the three ways an axis query silently returns nothing:

- An axis query matches lexically. Pairing one with explicit `vec`/`hyde` retrieval is refused (`facade.ts:764-768`), verified live.
- `concept` is derived from a note's folder rather than stored as a property, so it is scoped with `axes.folder` or `op: "context"`; `axes.field.concept` is unconditionally rejected (`facade.ts:572-574`).
- A refused axis is **not** an error result. `semanticQuery` catches it at `facade.ts:770-775` and returns a normal `available: false` with a `reason` — and with `facets` empty, so recovery means re-querying without that axis rather than reading facets off the refusal.

And that an axis filter with `query` omitted is a whole-kind enumeration, which nothing previously advertised.

Every claim in the new section was checked against the schema (`server.ts:136-170`) and exercised against a live `oms mcp` server: the ten predicate names, scalar/list/predicate values, axis intersection, folder-name-not-concept-name, omitted `query`, and both refusal paths. Two claims were corrected by that pass: `axes.link` matches on filename alone — a bare title, a `.md` suffix, and even a *wrong* folder with the right filename all return the same hits, so documenting it as "by note path" would have pushed agents into constructing paths that carry no meaning — and `query` scores frontmatter tokens alongside body text, so it is described as scoring text rather than as ignoring frontmatter.

## Tests

16 new, colocated per repo convention (the skill change is documentation and is covered by the existing contract tests in `test/architecture/` and `src/mcp/server.test.ts`, 58 passing):

- `conventions/note-exclude.test.ts` — glob semantics (`**` crosses `/`, `*` does not), default globs with no `exclude` key, graceful degradation on missing/malformed `taxonomy.yaml`, and a regression pinning the GLOBSTAR placeholder. That last one guards a real trap: written as a literal escape sequence instead of the NUL character, the escaping step escapes its own backslash, the later split stops matching, and all `**` handling silently dies.
- `engine/graph/builder.test.ts`, `graph/cache.test.ts` — an excluded note with invalid frontmatter no longer aborts the scan; a **non**-excluded malformed note still throws.
- `engine/axes/r4-contract-axis.test.ts` — `""`/`"   "` skipped while real values are recorded, `normalizeAxisValue("")` still throws when called directly, and the note path appears in the wrapped error.

## Verification

`npm run release:check` passes locally: lint clean, build clean, `1056 passed | 11 skipped`, 0 failures.

Compiled output was spot-checked at runtime, not just in source — the GLOBSTAR placeholder survives compilation and `**/*.template.md` still matches nested paths.

## Upgrade note

Excluded files no longer contribute to the node-index source signature, so the first run after upgrading rebuilds that cache once.
