### PR TITLE
Install a pinned local embedding model in one step

### DIFF
--- a/CHANGELOG-cli.md
+++ b/CHANGELOG-cli.md
@@ -4,6 +4,15 @@ Changes to the `oms` command surface belong here.
 
 ## [Unreleased]
 
+### Added
+
+- **`oms setup --embedding-default` installs a working local embedding model in one step.** It downloads the pinned EmbeddingGemma-300M model, verifies it against the shipped SHA-256, and publishes it to the user-level cache. After that, `oms embed` and vector search work without setting `OMS_EMBEDDING_PROVIDER` or `OMS_EMBEDDING_MODEL` at all — the gap that previously forced anyone wanting native semantic search to hand-author a descriptor JSON or export a matching environment pair. Nothing changes for a vault that does not run it: with no model installed, lexical search keeps working and vector requests still fail loudly naming both variables, and the guidance now names this command as the one-step remedy.
+- The three setup embedding options are mutually exclusive and now say so. Passing more than one of `--embedding-default`, `--embedding-descriptor`, or `--embedding-no-default` exits with an error naming the conflicting flags instead of silently letting one win.
+
+### Changed
+
+- `oms --help` documents the setup embedding options. All three existed only in source before this; `--embedding-descriptor` and `--embedding-no-default` shipped undocumented.
+
 ## [0.7.0] - 2026-08-27
 
 ### Breaking

--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -4,6 +4,19 @@ Domain logic changes belong here.
 
 ## [Unreleased]
 
+### Added
+
+- **A pinned default embedding model is now available for explicit one-step install.** `PINNED_DEFAULT_EMBEDDING_MODEL` describes EmbeddingGemma-300M (`embeddinggemma-300M-Q8_0.gguf`, 768d, 2048-token context) with its source URL and a verified SHA-256 of `b5ce9d77…90d63`. This is the same model qmd resolves from its own `DEFAULT_EMBED_MODEL_URI`, so a vault indexed by `oms embed` gets that toolchain's retrieval quality instead of a lesser stand-in. The constant is deliberately **not** a fallback: `resolveEmbeddingModel` never reaches for it, because an implicit default would defeat the E-1 no-default contract, which verifies at runtime that embedding capability stays honestly unavailable with no environment pair and an empty cache. Its only consumer is the explicit setup acquisition path, which verifies the downloaded bytes against the pinned digest before publishing them. ADR-007 P-B is unaffected — a real, explicitly installed model was never the fake fallback that principle forbids.
+- **Chunks now carry their document title into the embedding input.** `Chunk.title` is resolved from frontmatter `title`, then the first ATX H1, then the literal `none`, and `EmbeddingProvider.embed(text, title?)` accepts it. A passage prefix may declare a `{title}` slot, which the GGUF and Upstage providers substitute per chunk; the pinned descriptor uses `title: {title} | text: `, reproducing qmd's `formatDocForEmbedding` byte-for-byte. This matters for retrieval rather than cosmetics: a chunk from the middle of a note is frequently ambiguous on its own, and the document title is the cheapest available disambiguating context. A prefix without the slot is prepended exactly as before, so every existing descriptor keeps its current behavior.
+
+### Changed
+
+- **Chunk change-detection digests now cover the document title as well as the chunk text.** The title reaches every chunk's embedding input, so a digest over text alone reported "unchanged" for each chunk that did not itself contain the title line — leaving stored vectors that still encoded the *old* title after a retitle. The digest is now taken over title and text with a NUL separator, so no retitle can collide with a body edit. The cost is explicit: because the digest formula changed, the first `oms embed` after upgrading re-embeds every chunk once. We chose that over making the digest conditional on provider configuration, which would have coupled chunking to embedding settings and left the stale-vector bug reachable.
+
+### Fixed
+
+- **Vector queries no longer fail outright on an unbounded candidate limit.** The MCP facade requests `Number.MAX_SAFE_INTEGER` candidates so collection aggregation can page globally. FTS tolerates that, but sqlite-vec rejects any knn `k` above its own 4096 ceiling, so every vector query failed with `k value in knn query too large`. The collection-scoped branch had the same defect from the opposite direction: it passed the *total* chunk count, which fails on any vault with more than 4096 chunks. The store — the only layer that knows the extension's constraint — now clamps `k` into the supported range, and a non-positive request collapses to 1 rather than 0 so a caller asking for "some" results never silently gets an empty page. This was unreachable in practice until now, because a vault with no embedding model never got as far as a vector query; configuring a local model exposed it immediately. The clamp is a genuine ceiling, not a cure-all: in a vault with more than 4096 chunks, a collection-scoped vector query still ranks within the global top-4096 before filtering, so a collection whose chunks all fall outside that band can be starved. That is inherent to ANN-before-predicate search in sqlite-vec; the alternative was failing every vector query.
+
 ## [0.7.0] - 2026-08-27
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -103,14 +103,19 @@ oms hook       Vault guard hooks (Claude Code pre/post tool-use)
 
 ## Semantic search (optional)
 
-Semantic retrieval requires a real embedding model — there is no fake/hash fallback (ADR-007). Configure embeddings explicitly with `OMS_EMBEDDING_PROVIDER` + `OMS_EMBEDDING_MODEL` (`gguf` with a local GGUF model path, or `upstage` with a model id and `UPSTAGE_API_KEY`), then sync and query:
+Semantic retrieval requires a real embedding model — there is no fake/hash fallback (ADR-007). The quickest path is the pinned local default:
 
 ```bash
-oms semantic sync  --vault /path/to/vault --collection vault
-oms semantic query "what should I retrieve?" --vault /path/to/vault
+oms setup --vault /path/to/vault --yes --embedding-default
+oms embed  --vault /path/to/vault
+oms semantic vsearch "what should I retrieve?" --vault /path/to/vault
 ```
 
-Without a configured model, graph-based retrieval and convention validation still work.
+`--embedding-default` downloads EmbeddingGemma-300M (~318 MB), verifies it against a pinned SHA-256, and installs it under your user cache — not in the vault. It runs locally through `node-llama-cpp`, needs no API key, and embeds at the model's full 768 dimensions with no folding. After that, `oms embed` and vector search need no environment variables.
+
+To choose your own model instead, set `OMS_EMBEDDING_PROVIDER` + `OMS_EMBEDDING_MODEL` (`gguf` with a local GGUF path, or `upstage` with a model id and `UPSTAGE_API_KEY`). Setting only one of the pair is an error naming both, never a silent fallback.
+
+Without any model, lexical search, graph-based retrieval, and convention validation all still work; only vector and HyDE requests are refused, and they say which variables to set.
 
 ## Development
 

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -67,6 +67,34 @@ describe("CLI argument parser", () => {
     expect(linked.conventionNote).toBe(false);
   });
 
+  it("parses the three mutually exclusive setup embedding options independently", () => {
+    const pinned = parseCliArgs(["setup", "--embedding-default"], "/tmp/oms-cli");
+    const supplied = parseCliArgs(
+      ["setup", "--embedding-descriptor", "model.json"],
+      "/tmp/oms-cli",
+    );
+    const waived = parseCliArgs(["setup", "--embedding-no-default"], "/tmp/oms-cli");
+
+    expect(pinned.embeddingDefault).toBe(true);
+    expect(pinned.embeddingDescriptorPath).toBeUndefined();
+    expect(pinned.embeddingNoDefault).toBe(false);
+    expect(pinned.unknownFlags).toEqual([]);
+
+    expect(supplied.embeddingDescriptorPath).toBe("/tmp/oms-cli/model.json");
+    expect(supplied.embeddingDefault).toBe(false);
+
+    expect(waived.embeddingNoDefault).toBe(true);
+    expect(waived.embeddingDefault).toBe(false);
+  });
+
+  it("defaults every setup embedding option to unselected", () => {
+    const parsed = parseCliArgs(["setup"], "/tmp/oms-cli");
+
+    expect(parsed.embeddingDefault).toBe(false);
+    expect(parsed.embeddingNoDefault).toBe(false);
+    expect(parsed.embeddingDescriptorPath).toBeUndefined();
+  });
+
   it("parses audit flags", () => {
     const parsed = parseCliArgs(
       ["audit", "--vault", "Vault", "--folder", "references", "--json", "--suggest-fields"],

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -31,6 +31,8 @@ export interface ParsedCliArgs {
   readonly conventionNote: boolean;
   readonly embeddingDescriptorPath: string | undefined;
   readonly embeddingNoDefault: boolean;
+  /** setup: install the pinned default embedding model. */
+  readonly embeddingDefault: boolean;
   readonly unknownFlags: readonly string[];
   readonly error: CliArgumentError | undefined;
 }
@@ -61,6 +63,7 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
   let conventionNote = true;
   let embeddingDescriptorPath: string | undefined;
   let embeddingNoDefault = false;
+  let embeddingDefault = false;
   const unknownFlags: string[] = [];
 
   for (let i = 1; i < argv.length; i++) {
@@ -122,6 +125,8 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
       i++;
     } else if (arg === "--embedding-no-default") {
       embeddingNoDefault = true;
+    } else if (arg === "--embedding-default") {
+      embeddingDefault = true;
     } else if (arg !== undefined) {
       unknownFlags.push(arg);
     }
@@ -148,6 +153,7 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
     conventionNote,
     embeddingDescriptorPath,
     embeddingNoDefault,
+    embeddingDefault,
     unknownFlags,
     error: undefined,
   };
@@ -174,6 +180,7 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
       conventionNote,
       embeddingDescriptorPath,
       embeddingNoDefault,
+      embeddingDefault,
       unknownFlags,
       error: new CliArgumentError(message),
     };

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -8,6 +8,7 @@ import type { WriteTargetSource } from "../kernel/conventions/write-protocol.js"
 import { resolveEffectiveVault } from "../kernel/link/link.js";
 import { runMcpServer } from "../mcp/server.js";
 import { resolveBundledAssetPaths } from "../kernel/runtime/assets.js";
+import { PINNED_DEFAULT_EMBEDDING_MODEL } from "../kernel/engine/embed/model.js";
 import { parseCliArgs } from "./args.js";
 import { runAudit } from "./audit.js";
 import { runDoctor, runLint } from "./doctor-lint.js";
@@ -83,6 +84,7 @@ async function main(): Promise<void> {
     conventionNote,
     embeddingDescriptorPath,
     embeddingNoDefault,
+    embeddingDefault,
     unknownFlags,
   } = parsedArgs;
 
@@ -114,9 +116,21 @@ async function main(): Promise<void> {
   }
 
   if (command === "setup") {
+    const embeddingChoices = [
+      embeddingDescriptorPath !== undefined ? "--embedding-descriptor" : undefined,
+      embeddingDefault ? "--embedding-default" : undefined,
+      embeddingNoDefault ? "--embedding-no-default" : undefined,
+    ].filter((flag): flag is string => flag !== undefined);
+    if (embeddingChoices.length > 1) {
+      console.error(`[oms] Choose one embedding option, not ${embeddingChoices.join(" and ")}.`);
+      process.exitCode = 1;
+      return;
+    }
     let embeddingDescriptor: SetupEmbeddingDescriptor | null | undefined;
     if (embeddingDescriptorPath !== undefined) {
       embeddingDescriptor = JSON.parse(readFileSync(embeddingDescriptorPath, "utf8")) as SetupEmbeddingDescriptor;
+    } else if (embeddingDefault) {
+      embeddingDescriptor = PINNED_DEFAULT_EMBEDDING_MODEL;
     } else if (embeddingNoDefault) {
       embeddingDescriptor = null;
     }

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -8,7 +8,15 @@ interface MainUsageCommand {
 }
 
 const MAIN_USAGE_COMMANDS: readonly MainUsageCommand[] = [
-  { name: "setup", line: "  setup    Adopt an existing vault into the Oh My Second Brain convention." },
+  {
+    name: "setup",
+    line: "  setup    Adopt an existing vault into the Oh My Second Brain convention.",
+    detailLines: [
+      "             --embedding-default       Install the pinned local embedding model (EmbeddingGemma-300M, 768d).",
+      "             --embedding-descriptor <path>  Install an operator-supplied model descriptor instead.",
+      "             --embedding-no-default    Waive model installation; vector search stays unavailable.",
+    ],
+  },
   { name: "install", line: "  install  Install Oh My Second Brain host adapters and MCP registration." },
   { name: "uninstall", line: "  uninstall Remove Oh My Second Brain host adapters and MCP registration." },
   { name: "update", line: "  update   Check for or apply an explicit package update, then refresh host adapters." },
@@ -73,6 +81,7 @@ oh-my-second-brain — Oh My Second Brain convention layer for Obsidian vaults
 
 Usage:
   oh-my-second-brain setup [--vault <path>] [--yes] [--suggest-fields] [--install-claude]
+                           [--embedding-default | --embedding-descriptor <path> | --embedding-no-default]
   oh-my-second-brain install [--vault <path>] [--runtime <${runtime}>] [--dry-run] [--execute] [--yes] [--json]
   oh-my-second-brain uninstall [--runtime <all|${registry.hosts.map((host) => host.runtime).join("|")}>] [--dry-run] [--execute] [--yes] [--json]
   oh-my-second-brain update [--check] [--dry-run] [--yes] [--runtime <${runtime}>] [--vault <path>]
@@ -106,6 +115,14 @@ Options:
   --apply          linkify: rewrite notes in place; must be combined with --yes.
   --no-convention-note
                   link: skip writing the managed OMS usage block to AGENTS.md.
+  --embedding-default
+                  setup: download and verify the pinned EmbeddingGemma-300M model into the
+                  user-level cache, then select it for \`oms embed\` and vector search without
+                  requiring OMS_EMBEDDING_PROVIDER / OMS_EMBEDDING_MODEL.
+  --embedding-descriptor <path>
+                  setup: install an operator-supplied model descriptor (SHA-256 verified).
+  --embedding-no-default
+                  setup: explicitly install no model; lexical search still works.
 `;
 }
 

--- a/src/kernel/engine/embed/chunker.test.ts
+++ b/src/kernel/engine/embed/chunker.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { chunkDocument } from "./chunker.js";
+import { UNTITLED_DOCUMENT_TITLE } from "../types.js";
+
+/** A body long enough to span several chunks at a small token budget. */
+function longBody(): string {
+  return Array.from({ length: 400 }, (_, index) => `Body line number ${index}.`).join("\n");
+}
 
 describe("chunkDocument", () => {
   it("produces at least one chunk for non-empty text", () => {
@@ -46,6 +52,66 @@ describe("chunkDocument", () => {
     const chunks = chunkDocument("notes/nested.md", text);
     expect(chunks[0]?.headingPath).toContain("Chapter");
     expect(chunks[0]?.headingPath).toContain("Section");
+  });
+
+  it("carries the frontmatter title on every chunk", () => {
+    const chunks = chunkDocument(
+      "notes/titled.md",
+      `---\ntitle: Stellar Nucleosynthesis\n---\n${longBody()}`,
+      { maxTokens: 60 },
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) expect(chunk.title).toBe("Stellar Nucleosynthesis");
+  });
+
+  it("falls back to the first H1 when frontmatter declares no title", () => {
+    const chunks = chunkDocument("notes/h1.md", "# Braising Technique\nLow steady heat.");
+    expect(chunks[0]?.title).toBe("Braising Technique");
+  });
+
+  it("prefers a frontmatter title over an H1", () => {
+    const chunks = chunkDocument(
+      "notes/both.md",
+      "---\ntitle: Declared\n---\n# Heading Title\nBody.",
+    );
+    expect(chunks[0]?.title).toBe("Declared");
+  });
+
+  it("uses the untitled literal when no title is declared at all", () => {
+    const chunks = chunkDocument("notes/bare.md", "Just body text, no title anywhere.");
+    expect(chunks[0]?.title).toBe(UNTITLED_DOCUMENT_TITLE);
+  });
+
+  it("ignores a blank frontmatter title rather than embedding an empty one", () => {
+    const chunks = chunkDocument("notes/blank.md", "---\ntitle: '   '\n---\nBody text.");
+    expect(chunks[0]?.title).toBe(UNTITLED_DOCUMENT_TITLE);
+  });
+
+  it("still yields a title when frontmatter is malformed", () => {
+    const chunks = chunkDocument("notes/broken.md", "---\ntitle: [broken\n---\n# Real Heading\nBody.");
+    expect(chunks[0]?.title).toBe("Real Heading");
+  });
+
+  it("changes the sha of body-only chunks when only the title changes", () => {
+    // The title reaches every chunk's embedding input, so a retitle must
+    // invalidate chunks that do not themselves contain the title line.
+    // Without a title-aware digest those chunks would be reported unchanged
+    // and keep vectors encoding the OLD title.
+    const body = longBody();
+    const before = chunkDocument("notes/retitle.md", `---\ntitle: Before\n---\n${body}`, { maxTokens: 60 });
+    const after = chunkDocument("notes/retitle.md", `---\ntitle: After\n---\n${body}`, { maxTokens: 60 });
+
+    const tail = before.length - 1;
+    expect(before.length).toBe(after.length);
+    expect(before.length).toBeGreaterThan(1);
+    // The final chunk's raw text is identical; only the document title differs.
+    expect(after[tail]?.text).toBe(before[tail]?.text);
+    expect(after[tail]?.sha).not.toBe(before[tail]?.sha);
+  });
+
+  it("keeps the sha stable when neither title nor text changes", () => {
+    const raw = "---\ntitle: Stable\n---\nUnchanged body.";
+    expect(chunkDocument("a.md", raw)[0]?.sha).toBe(chunkDocument("b.md", raw)[0]?.sha);
   });
 
   it("respects maxTokens option by splitting large docs", () => {

--- a/src/kernel/engine/embed/chunker.ts
+++ b/src/kernel/engine/embed/chunker.ts
@@ -7,6 +7,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { parseNote } from "../../conventions/frontmatter.js";
+import { UNTITLED_DOCUMENT_TITLE } from "../types.js";
 import type { Chunk, ChunkerOptions } from "../types.js";
 
 const DEFAULT_MAX_TOKENS = 900;
@@ -53,9 +55,36 @@ function isCjk(cp: number): boolean {
   );
 }
 
-/** SHA-256 hex digest of text for change-detection. */
-function sha256(text: string): string {
-  return createHash("sha256").update(text).digest("hex");
+/**
+ * SHA-256 change-detection digest over everything that reaches the embedding
+ * input: the document title AND the chunk text.
+ *
+ * The title must be inside the digest. It is prepended to every chunk's
+ * embedding input, so a digest over `text` alone would report "unchanged" for
+ * each chunk that does not itself contain the title line — leaving vectors that
+ * still encode the OLD title after a retitle. The NUL separator keeps
+ * (title, text) unambiguous so no retitle can collide with a body edit.
+ */
+function chunkDigest(title: string, text: string): string {
+  return createHash("sha256").update(`${title}\u0000${text}`).digest("hex");
+}
+
+/**
+ * The document title carried into every chunk's embedding input.
+ *
+ * Frontmatter `title` wins, then the first ATX H1, else the untitled literal.
+ * Reuses the shared convention parser rather than re-deriving frontmatter here.
+ * A malformed-frontmatter document still yields a title: `parseNote` reports
+ * diagnostics instead of throwing, and the H1 scan covers the body.
+ */
+function documentTitle(rawText: string): string {
+  const parsed = parseNote(rawText);
+  const declared = parsed.frontmatter["title"];
+  if (typeof declared === "string" && declared.trim() !== "") return declared.trim();
+  const heading = /^#\s+(.+)$/m.exec(parsed.body) ?? /^#\s+(.+)$/m.exec(rawText);
+  const headingTitle = heading?.[1]?.trim();
+  if (headingTitle !== undefined && headingTitle !== "") return headingTitle;
+  return UNTITLED_DOCUMENT_TITLE;
 }
 
 /**
@@ -80,8 +109,9 @@ function applyHeading(current: string[], level: number, title: string): string[]
  *   - vault-relative `docPath`
  *   - zero-based `ordinal` within the document
  *   - raw `text`
+ *   - `title` — the document title, prepended to this chunk's embedding input
  *   - `headingPath` — breadcrumb from doc root to the chunk's section
- *   - `sha` — SHA-256 hex digest of `text` for change-detection
+ *   - `sha` — SHA-256 digest of `title` + `text` for change-detection
  *
  * When a section exceeds `maxTokens`, it is further split line by line until
  * each emitted chunk fits the budget. Overlap lines from the previous flush
@@ -99,6 +129,7 @@ export function chunkDocument(
 
   const lines = rawText.split("\n");
   const chunks: Chunk[] = [];
+  const title = documentTitle(rawText);
   let ordinal = 0;
   let buffer: string[] = [];
   let headingPath: string[] = [];
@@ -113,8 +144,9 @@ export function chunkDocument(
       docPath,
       ordinal: ordinal++,
       text,
+      title,
       headingPath: headingPath.slice(),
-      sha: sha256(text),
+      sha: chunkDigest(title, text),
     });
     // Carry the last N lines as overlap into the next chunk
     buffer = buffer.slice(-overlapLineCount);
@@ -143,8 +175,9 @@ export function chunkDocument(
       docPath,
       ordinal: ordinal++,
       text: remaining,
+      title,
       headingPath: headingPath.slice(),
-      sha: sha256(remaining),
+      sha: chunkDigest(title, remaining),
     });
   }
 

--- a/src/kernel/engine/embed/model.test.ts
+++ b/src/kernel/engine/embed/model.test.ts
@@ -10,6 +10,7 @@ import {
   EMBEDDING_PROVIDER_ENV,
   embeddingModelCacheDir,
   INSTALLED_DEFAULT_DESCRIPTOR,
+  PINNED_DEFAULT_EMBEDDING_MODEL,
   readInstalledEmbeddingDefault,
   resolveEmbeddingModel,
 } from "./model.js";
@@ -114,6 +115,67 @@ describe("resolveEmbeddingModel", () => {
     } finally {
       await rm(cacheDir, { recursive: true, force: true });
     }
+  });
+
+  it("never resolves the pinned default implicitly", async () => {
+    // The E-1 no-default contract verifies at runtime that embedding capability
+    // stays honestly unavailable with no env pair and an empty cache. Shipping a
+    // pinned descriptor must not become an implicit fallback, or that contract
+    // and ADR-007 P-B both break. The constant is for explicit acquisition only.
+    const cacheDir = await mkdtemp(path.join(tmpdir(), "oms-pinned-implicit-"));
+    try {
+      const resolved = resolveEmbeddingModel({ env: {}, cacheDir });
+      expect(resolved).toMatchObject({ available: false, source: "none" });
+      expect(resolved.provider).toBeUndefined();
+      expect(resolved.model).toBeUndefined();
+      expect(resolved.descriptor).toBeUndefined();
+      // Resolution is read-only: it must not publish the pinned descriptor.
+      await expect(readFile(path.join(cacheDir, INSTALLED_DEFAULT_DESCRIPTOR))).rejects.toThrow();
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it("points an unconfigured vault at the one-step default install", async () => {
+    const cacheDir = await mkdtemp(path.join(tmpdir(), "oms-pinned-guidance-"));
+    try {
+      const guidance = resolveEmbeddingModel({ env: {}, cacheDir }).receipt.guidance;
+      expect(guidance).toContain("oms setup --embedding-default");
+      expect(guidance).toContain(EMBEDDING_PROVIDER_ENV);
+      expect(guidance).toContain(EMBEDDING_MODEL_ENV);
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ships a pinned descriptor complete enough to resolve and sync", () => {
+    // An incomplete descriptor throws in assertCompleteDescriptor / vector sync,
+    // so the shipped constant must carry every identity field up front.
+    const resolved = resolveEmbeddingModel({
+      env: {
+        [EMBEDDING_PROVIDER_ENV]: PINNED_DEFAULT_EMBEDDING_MODEL.provider,
+        [EMBEDDING_MODEL_ENV]: PINNED_DEFAULT_EMBEDDING_MODEL.model,
+      },
+      installedDefault: PINNED_DEFAULT_EMBEDDING_MODEL,
+    });
+
+    expect(resolved.available).toBe(true);
+    expect(resolved.descriptor?.dimensions).toBe(768);
+    expect(PINNED_DEFAULT_EMBEDDING_MODEL.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(PINNED_DEFAULT_EMBEDDING_MODEL.url).toContain("embeddinggemma-300M-Q8_0.gguf");
+  });
+
+  it("declares qmd's EmbeddingGemma prompts with a per-chunk title slot", () => {
+    // Byte-compatible with qmd's formatQueryForEmbedding /
+    // formatDocForEmbedding so the same note embeds identically under either
+    // toolchain. `{title}` is what carries the document title per chunk.
+    const scheme = JSON.parse(PINNED_DEFAULT_EMBEDDING_MODEL.prefixScheme!) as {
+      query: string;
+      passage: string;
+    };
+
+    expect(scheme.query).toBe("task: search result | query: ");
+    expect(scheme.passage).toBe("title: {title} | text: ");
   });
 
   it("rejects a half-configured pair and names both canonical variables", () => {

--- a/src/kernel/engine/embed/model.ts
+++ b/src/kernel/engine/embed/model.ts
@@ -10,6 +10,47 @@ export const EMBEDDING_MODEL_ENV = "OMS_EMBEDDING_MODEL" as const;
 export const INSTALLED_DEFAULT_DESCRIPTOR = "default-model.json";
 export const CAPABILITY_RECEIPT = "capability-receipt.json";
 
+/**
+ * The one pinned default embedding model, offered by `oms setup --embedding-default`.
+ *
+ * This is the same model qmd resolves from its own `DEFAULT_EMBED_MODEL_URI`
+ * (`hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf`), so a
+ * vault indexed by `oms embed` gets that toolchain's retrieval quality rather
+ * than a lesser stand-in. `dimensions` is the model's native width and is
+ * stored unfolded (ADR-007 P-A); `mrlDim: 0` records that no Matryoshka
+ * truncation is applied.
+ *
+ * This constant is NOT a fallback. `resolveEmbeddingModel` never reaches for
+ * it, because an implicit default would defeat the E-1 no-default contract in
+ * `src/kernel/measurement/no-default-contract.ts`: with no environment pair and
+ * an empty cache, embedding capability must stay honestly unavailable. The only
+ * consumer is the explicit setup acquisition path, which verifies `sha256`
+ * against the downloaded bytes before publishing them.
+ *
+ * `prefixScheme` reproduces EmbeddingGemma's asymmetric prompts byte-for-byte
+ * as qmd formats them in `formatQueryForEmbedding` / `formatDocForEmbedding`,
+ * including the document title: `{title}` is substituted per chunk, matching
+ * qmd's `title: <title> | text: <text>` document prompt.
+ */
+export const PINNED_DEFAULT_EMBEDDING_MODEL: EmbeddingModelDescriptor & {
+  readonly url: string;
+  readonly sha256: string;
+} = {
+  provider: "gguf",
+  model: "embeddinggemma-300M-Q8_0.gguf",
+  filename: "embeddinggemma-300M-Q8_0.gguf",
+  url: "https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf",
+  sha256: "b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63",
+  dimensions: 768,
+  context: 2048,
+  mrlDim: 0,
+  normalization: "l2",
+  prefixScheme: JSON.stringify({
+    query: "task: search result | query: ",
+    passage: "title: {title} | text: ",
+  }),
+};
+
 /** Metadata needed to use an installed embedding model. */
 export interface EmbeddingModelDescriptor {
   readonly provider: string;
@@ -84,8 +125,9 @@ export interface ResolveEmbeddingModelOptions {
 const INCOMPLETE_CONFIG_ERROR =
   `Embedding configuration is incomplete. Set both ${EMBEDDING_PROVIDER_ENV} and ${EMBEDDING_MODEL_ENV}.`;
 const NO_MODEL_GUIDANCE =
-  `No embedding model is configured. Set ${EMBEDDING_PROVIDER_ENV} and ${EMBEDDING_MODEL_ENV}, ` +
-  "or install a local model with `oms setup --embedding-descriptor <descriptor>`.";
+  "No embedding model is configured. Run `oms setup --embedding-default` to install the pinned " +
+  `local model, or set ${EMBEDDING_PROVIDER_ENV} and ${EMBEDDING_MODEL_ENV} to choose your own ` +
+  "(`oms setup --embedding-descriptor <path>` installs an operator-supplied descriptor).";
 
 function trim(value: string | undefined): string {
   return (value ?? "").trim();

--- a/src/kernel/engine/embed/provider.test.ts
+++ b/src/kernel/engine/embed/provider.test.ts
@@ -93,6 +93,73 @@ describe("embedding provider runtime guards", () => {
     );
   });
 
+  it("substitutes the document title into a passage prefix that declares the slot", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [3, 4] }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createUpstageProvider("test-key", "test-model", 2, {
+      prefixScheme: JSON.stringify({
+        query: "task: search result | query: ",
+        passage: "title: {title} | text: ",
+      }),
+    });
+
+    await provider.embed("body text", "Stellar Nucleosynthesis");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.upstage.ai/v1/embeddings",
+      expect.objectContaining({
+        body: JSON.stringify({
+          input: "title: Stellar Nucleosynthesis | text: body text",
+          model: "test-model",
+        }),
+      }),
+    );
+  });
+
+  it("falls back to the untitled literal for a missing or blank title", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [3, 4] }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createUpstageProvider("test-key", "test-model", 2, {
+      prefixScheme: JSON.stringify({ passage: "title: {title} | text: " }),
+    });
+
+    await provider.embed("body");
+    await provider.embed("body", "   ");
+    for (const call of [1, 2]) {
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        call,
+        "https://api.upstage.ai/v1/embeddings",
+        expect.objectContaining({
+          body: JSON.stringify({ input: "title: none | text: body", model: "test-model" }),
+        }),
+      );
+    }
+  });
+
+  it("leaves a prefix without a title slot byte-identical when a title is supplied", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [3, 4] }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createUpstageProvider("test-key", "test-model", 2, {
+      prefixScheme: "query=Q:,passage=P:",
+    });
+
+    await provider.embed("document", "Ignored Title");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.upstage.ai/v1/embeddings",
+      expect.objectContaining({ body: JSON.stringify({ input: "P:document", model: "test-model" }) }),
+    );
+  });
+
   it("rejects a non-finite model vector instead of coercing it to zero", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
       ok: true,

--- a/src/kernel/engine/embed/provider.ts
+++ b/src/kernel/engine/embed/provider.ts
@@ -18,6 +18,7 @@
  */
 
 import { cpus } from "node:os";
+import { UNTITLED_DOCUMENT_TITLE } from "../types.js";
 import type { EmbeddingProvider } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -91,6 +92,29 @@ function normalizeVector(values: readonly number[]): Float32Array {
 interface EmbeddingPrefixes {
   readonly query: string;
   readonly passage: string;
+}
+
+/**
+ * Placeholder a passage prefix uses to request the document title.
+ *
+ * EmbeddingGemma's document prompt is `title: <title> | text: <text>`, so the
+ * title sits INSIDE the prefix rather than before it. A prefix declaring this
+ * slot gets the real title substituted; a prefix without it is prepended
+ * unchanged, which keeps every existing descriptor byte-identical.
+ */
+const TITLE_PLACEHOLDER = "{title}";
+
+/**
+ * Build the full passage embedding input.
+ *
+ * Substitutes the title slot when the scheme declares one. An absent or blank
+ * title falls back to the shared untitled literal so the emitted prompt never
+ * contains an empty title field.
+ */
+function passageInput(prefix: string, text: string, title: string | undefined): string {
+  const resolved = title?.trim() ? title.trim() : UNTITLED_DOCUMENT_TITLE;
+  if (!prefix.includes(TITLE_PLACEHOLDER)) return `${prefix}${text}`;
+  return `${prefix.split(TITLE_PLACEHOLDER).join(resolved)}${text}`;
 }
 
 /** Embedding provider seam for callers that need the query-side prefix. */
@@ -295,8 +319,8 @@ export function createGGUFEmbeddingProvider(
       ? { prefixScheme: dimensionsOrOptions.prefixScheme }
       : {}),
 
-    async embed(text: string): Promise<Float32Array> {
-      return embedPassage(text);
+    async embed(text: string, title?: string): Promise<Float32Array> {
+      return embedPassage(text, title);
     },
 
     async embedQuery(text: string): Promise<Float32Array> {
@@ -335,8 +359,8 @@ export function createGGUFEmbeddingProvider(
     return vector;
   }
 
-  async function embedPassage(text: string): Promise<Float32Array> {
-    return embedText(`${prefixes.passage}${text}`);
+  async function embedPassage(text: string, title?: string): Promise<Float32Array> {
+    return embedText(passageInput(prefixes.passage, text, title));
   }
 
   async function disposeProvider(): Promise<void> {
@@ -395,8 +419,8 @@ export function createUpstageProvider(
     ...(metadata.normalization === undefined ? {} : { normalization: metadata.normalization }),
     ...(metadata.prefixScheme === undefined ? {} : { prefixScheme: metadata.prefixScheme }),
 
-    async embed(text: string): Promise<Float32Array> {
-      return embedPassage(text);
+    async embed(text: string, title?: string): Promise<Float32Array> {
+      return embedPassage(text, title);
     },
 
     async embedQuery(text: string): Promise<Float32Array> {
@@ -412,8 +436,8 @@ export function createUpstageProvider(
     readonly embedQuery: (text: string) => Promise<Float32Array>;
   }>;
 
-  async function embedPassage(text: string): Promise<Float32Array> {
-    return embedText(`${prefixes.passage}${text}`);
+  async function embedPassage(text: string, title?: string): Promise<Float32Array> {
+    return embedText(passageInput(prefixes.passage, text, title));
   }
 
   async function embedText(text: string): Promise<Float32Array> {

--- a/src/kernel/engine/embed/store.test.ts
+++ b/src/kernel/engine/embed/store.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, it, expect } from "vitest";
-import { openEngineStore, openEngineStoreCore } from "./store.js";
+import { openEngineStore, openEngineStoreCore, SQLITE_VEC_MAX_K } from "./store.js";
 import type { EngineStore } from "./store.js";
 import { createHashProjectionProvider } from "./hash-stub.test-helper.js";
 
@@ -28,6 +28,7 @@ async function makeRow(docPath: string, ordinal: number, text: string) {
     docPath,
     ordinal,
     text,
+    title: "Test Document",
     headingPath: [] as string[],
     sha: "aabbcc",
     vector,
@@ -39,6 +40,7 @@ function makeLexRow(docPath: string, text: string) {
     docPath,
     ordinal: 0,
     text,
+    title: "Test Document",
     headingPath: [] as string[],
     sha: docPath,
   };
@@ -95,6 +97,29 @@ describe("openEngineStore — queryVec", () => {
     await provider.dispose();
     const hits = store.queryVec(vec, 5);
     expect(Array.isArray(hits)).toBe(true);
+  });
+
+  it("clamps an unbounded k instead of failing the sqlite-vec knn query", async () => {
+    // The MCP facade passes Number.MAX_SAFE_INTEGER as its unbounded candidate
+    // limit. FTS tolerates that, but sqlite-vec rejects any k above its own
+    // ceiling, which made every vector query fail once a real embedding model
+    // made the path reachable.
+    const provider = createHashProjectionProvider(DIMS);
+    const vec = await provider.embed("retrieval augmented generation");
+    await provider.dispose();
+
+    expect(() => store.queryVec(vec, Number.MAX_SAFE_INTEGER)).not.toThrow();
+    expect(() => store.queryVec(vec, Number.POSITIVE_INFINITY)).not.toThrow();
+    expect(store.queryVec(vec, Number.MAX_SAFE_INTEGER).length).toBeLessThanOrEqual(SQLITE_VEC_MAX_K);
+  });
+
+  it("returns at least one candidate for a non-positive k rather than an empty page", async () => {
+    const provider = createHashProjectionProvider(DIMS);
+    const vec = await provider.embed("retrieval augmented generation");
+    await provider.dispose();
+
+    expect(() => store.queryVec(vec, 0)).not.toThrow();
+    expect(() => store.queryVec(vec, -5)).not.toThrow();
   });
 
   it("queryVec scores are in (0, 1] range", async () => {

--- a/src/kernel/engine/embed/store.ts
+++ b/src/kernel/engine/embed/store.ts
@@ -73,9 +73,38 @@ export interface EngineStore extends VectorStore {
 
 export const ENGINE_EMBED_META_VERSION = "oms-embed-meta-v2";
 
+/**
+ * Largest `k` sqlite-vec accepts in a knn query.
+ *
+ * Above this the extension rejects the statement outright ("k value in knn
+ * query too large"). Callers legitimately ask for an unbounded candidate set -
+ * the MCP facade passes `Number.MAX_SAFE_INTEGER` so collection aggregation can
+ * page globally, and FTS tolerates that - so the vector store clamps instead of
+ * propagating a limit the extension cannot honour.
+ */
+export const SQLITE_VEC_MAX_K = 4096;
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Clamp a requested knn width into sqlite-vec's supported range.
+ *
+ * A non-positive or non-finite request collapses to 1 rather than 0 so a caller
+ * that asks for "some" results never silently receives an empty page.
+ *
+ * Clamping is a real ceiling, not a formality: in a vault with more than
+ * `SQLITE_VEC_MAX_K` indexed chunks, a collection-scoped vector query ranks
+ * within the global top-`SQLITE_VEC_MAX_K` before filtering, so a collection
+ * whose chunks all fall outside that band can still be starved. That is a
+ * property of ANN-before-predicate search in sqlite-vec; the alternative here
+ * was a hard failure on every vector query.
+ */
+function clampVecK(k: number): number {
+  if (!Number.isFinite(k)) return SQLITE_VEC_MAX_K;
+  return Math.max(1, Math.min(SQLITE_VEC_MAX_K, Math.floor(k)));
+}
 
 /** Pack a finite Float32Array as raw bytes for sqlite-vec operations. */
 function vecBuf(vector: Float32Array): Buffer {
@@ -686,11 +715,13 @@ export function openEngineStore(
       if (!stmtQueryVec) {
         throw new Error("EngineStore: vector queries are unavailable (sqlite-vec not loaded).");
       }
-      // sqlite-vec cannot apply a metadata predicate to ANN search. Fetch every
-      // indexed chunk before filtering so collection scoping cannot be starved
-      // by globally higher-ranked candidates, then restore the requested limit.
-      const candidateLimit = collection === undefined ? k : (stmtCountChunks.get()?.count ?? 0);
-      const rows = stmtQueryVec.all(buf, candidateLimit);
+      // sqlite-vec cannot apply a metadata predicate to ANN search. Widen the
+      // candidate set to every indexed chunk before filtering so collection
+      // scoping is not starved by globally higher-ranked candidates, then
+      // restore the requested limit. Both branches clamp: the extension caps
+      // knn `k`, and callers may legitimately request an unbounded page.
+      const requested = collection === undefined ? k : (stmtCountChunks.get()?.count ?? 0);
+      const rows = stmtQueryVec.all(buf, clampVecK(requested));
       return rows
         .filter((r) => collection === undefined || r.doc_path === collection || r.doc_path.startsWith(`${collection}/`))
         .slice(0, k)
@@ -904,8 +935,8 @@ function openReadOnlyStore(
       if (!stmtQueryVec || !stmtCountChunks) {
         throw new Error("EngineStore: vector queries are unavailable (sqlite-vec not loaded).");
       }
-      const candidateLimit = collection === undefined ? k : (stmtCountChunks.get()?.count ?? 0);
-      return stmtQueryVec.all(buf, candidateLimit)
+      const requested = collection === undefined ? k : (stmtCountChunks.get()?.count ?? 0);
+      return stmtQueryVec.all(buf, clampVecK(requested))
         .filter((row) => collection === undefined || row.doc_path === collection || row.doc_path.startsWith(`${collection}/`))
         .slice(0, k)
         .map((row): ScoredHit => ({

--- a/src/kernel/engine/embed/sync.test.ts
+++ b/src/kernel/engine/embed/sync.test.ts
@@ -36,7 +36,7 @@ function writeDoc(rel: string, content: string): void {
 }
 
 function lexChunk(docPath: string, text: string): Chunk {
-  return { docPath, ordinal: 0, text, headingPath: [], sha: `${docPath}:0` };
+  return { docPath, ordinal: 0, text, title: "Test Document", headingPath: [], sha: `${docPath}:0` };
 }
 
 beforeEach(() => {

--- a/src/kernel/engine/embed/sync.ts
+++ b/src/kernel/engine/embed/sync.ts
@@ -471,7 +471,7 @@ async function syncDocument(opts: {
     opts.store.clearDocument(opts.relPath);
     const toUpsert: Array<Chunk & { vector: Float32Array }> = [];
     for (const chunk of chunks) {
-      const vector = await opts.provider.embed(chunk.text);
+      const vector = await opts.provider.embed(chunk.text, chunk.title);
       toUpsert.push({ ...chunk, vector });
       opts.counters.added++;
     }
@@ -486,7 +486,7 @@ async function syncDocument(opts: {
       opts.counters.skipped++;
       continue;
     }
-    const vector = await opts.provider.embed(chunk.text);
+    const vector = await opts.provider.embed(chunk.text, chunk.title);
     toUpsert.push({ ...chunk, vector });
     if (storedSha === undefined) opts.counters.added++;
     else opts.counters.updated++;

--- a/src/kernel/engine/types.ts
+++ b/src/kernel/engine/types.ts
@@ -34,6 +34,14 @@ export interface EngineConfig {
 // Chunking
 // ---------------------------------------------------------------------------
 
+/**
+ * Title used for a document that declares none.
+ *
+ * The literal matches what qmd substitutes for an untitled document, so the
+ * same file yields the same embedding input under either toolchain.
+ */
+export const UNTITLED_DOCUMENT_TITLE = "none";
+
 /** Options controlling how documents are split into chunks. */
 export interface ChunkerOptions {
   /** Maximum token budget per chunk. Default 900. */
@@ -53,9 +61,14 @@ export interface Chunk {
   ordinal: number;
   /** Raw text content of the chunk. */
   text: string;
+  /**
+   * The source document's title, prepended to this chunk's embedding input so a
+   * chunk that is ambiguous on its own still carries document context.
+   */
+  title: string;
   /** Breadcrumb of heading text from the document root to this chunk's section. */
   headingPath: string[];
-  /** SHA-256 hex digest of `text`, used for change-detection. */
+  /** SHA-256 digest of `title` + `text`, used for change-detection. */
   sha: string;
 }
 
@@ -75,8 +88,14 @@ export interface EmbeddingProvider {
   readonly model: string;
   /** Dimensionality of the Float32Array returned by `embed`. */
   readonly dimensions: number;
-  /** Produce a normalised embedding vector for `text`. */
-  embed(text: string): Promise<Float32Array>;
+  /**
+   * Produce a normalised embedding vector for `text`.
+   *
+   * `title` is the source document's title. Providers whose prefix scheme
+   * declares a `{title}` slot substitute it; the others ignore it, so passing
+   * it is always safe.
+   */
+  embed(text: string, title?: string): Promise<Float32Array>;
   /** Release any native resources held by the provider. */
   dispose(): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Native semantic search already worked, but only for someone willing to hand-author a descriptor JSON or export a matching `OMS_EMBEDDING_PROVIDER` / `OMS_EMBEDDING_MODEL` pair. That is the whole gap between `oms embed` and qmd, which resolves a sensible default on its own.

`oms setup --embedding-default` now downloads EmbeddingGemma-300M, verifies it against a pinned SHA-256, and publishes it to the user-level cache. After that `oms embed` and vector search need no environment variables. It is the **same model** qmd resolves from its own `DEFAULT_EMBED_MODEL_URI`, embedded at its full 768 dimensions with no folding.

### The pinned descriptor is not a fallback

`resolveEmbeddingModel` never reaches for it. An implicit default would defeat the E-1 no-default contract, which verifies at runtime that embedding capability stays honestly unavailable with no env pair and an empty cache. Only the explicit setup path consumes the constant, and it verifies bytes before publishing them. ADR-007 P-B is unaffected — a real, explicitly installed model was never the fake fallback that principle forbids, and `docs/measurements/model-default-deferral.md` stays open and unmodified.

### Document titles now reach the embedding input

Chunks carry their document title, and the passage prefix supports a `{title}` slot, reproducing qmd's `title: <title> | text: <text>` prompt. A mid-note chunk is frequently ambiguous on its own and the title is the cheapest disambiguating context available. A prefix without the slot is prepended exactly as before, so every existing descriptor is byte-identical.

Because the title reaches every chunk's embedding input, the change-detection digest now covers it too. Without that, a retitle left stale vectors encoding the *old* title on every chunk that did not itself contain the title line. **Cost, stated plainly:** the digest formula changed, so the first `oms embed` after upgrading re-embeds once. The alternative — making the digest conditional on provider configuration — would have coupled chunking to embedding settings and left the stale-vector bug reachable.

### Fixes a defect this feature exposed

The MCP facade requests `Number.MAX_SAFE_INTEGER` candidates so collection aggregation can page globally. FTS tolerates that; sqlite-vec rejects any knn `k` above its 4096 ceiling, so **every** vector query failed with `k value in knn query too large`. The collection-scoped branch had the mirror defect, passing the total chunk count, which fails on any vault over 4096 chunks. The store now clamps `k`.

This was unreachable in practice until now: a vault with no embedding model never got as far as a vector query. Configuring a local model exposed it immediately. The clamp is a real ceiling, not a cure-all — in a vault over 4096 chunks a collection-scoped vector query still ranks within the global top-4096 before filtering, so a collection whose chunks all fall outside that band can be starved. That is inherent to ANN-before-predicate search in sqlite-vec; the alternative was failing every vector query.

## Testing

Full suite **1055 passed** / 11 skipped (was 1036), `npm run release:check` green end to end including pack, artifact-smoke, and `claude plugin validate`.

Verified end to end on a disposable vault with `XDG_CACHE_HOME` redirected:

- `setup --embedding-default` downloaded and SHA-256-verified the model, wrote `default-model.json`
- `oms embed` then ran with both env vars confirmed **unset** and produced real vectors
- 768d storage proven by DDL: `CREATE VIRTUAL TABLE engine_chunk_vec USING vec0(embedding float[768])`
- **Cross-lingual, zero lexical overlap:** Korean `초신성에서 무거운 원소가 만들어지는 과정` ranked the astronomy note first; Korean `질긴 고기를 부드럽게 익히는 조리법` ranked the cooking note first. Both `lexical: false, vector: true`.
- **Title injection proven to affect retrieval:** a note whose body never mentions Kubernetes but whose frontmatter title does ranked first for `Kubernetes container orchestration`.
- Incremental sync correct: `upserted=1 skipped=2`
- Conflicting setup flags exit 1 naming both and write no `.oms`

New tests cover the title fallback chain, the retitle digest invalidation, `{title}` substitution and its no-slot passthrough, the knn clamp, the flag parsing, and — most importantly — that the pinned constant is never resolved implicitly.

## Not in scope

The `model-default` measurement deferral is untouched. This ships an explicit one-step install, not an automatic first-run download, so no waiver is consumed and no measurement gate is weakened.
