### PR TITLE
Read titles from the body only, and stop guessing at a bad knn k

### DIFF
--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -4,6 +4,14 @@ Domain logic changes belong here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Frontmatter YAML comments and fenced-code headings are no longer mistaken for a document title.** `documentTitle` fell back to scanning the raw document for the first ATX H1, which reads the frontmatter block too — where a YAML comment (`# rewrite this later`) is byte-identical to an H1. The same unguarded regex matched an `# heading` inside a fenced code block, so a note demonstrating markdown was titled by its own example. Because the title is prepended to *every* chunk's embedding input, one wrong title skews the vectors for the whole note, not just the chunk containing that line. The H1 scan is now confined to `parsed.body` and tracks backtick and tilde fences, closing a fence only on a run at least as long as the opener per CommonMark. A document whose frontmatter fence never closes has an empty body and is therefore untitled, which is the honest answer for a malformed document rather than a guess drawn from non-body text.
+
+  This is a title-selection fix, not a redaction: `chunkDocument` receives the raw document, so frontmatter text was and remains part of the indexed chunk text. The bug was which text got treated as the title.
+- **The chunk digest can no longer be made to collide across the title boundary.** The digest joined title and text with a bare NUL separator and claimed that made the pair unambiguous. Nothing forbids a NUL in note text, so `("a", "\0b")` and `("a\0", "b")` hashed identically — meaning a crafted retitle could impersonate a body edit and suppress re-embedding. The title is now length-prefixed, making the encoding injective for every input. **This changes the digest formula again, so the first `oms embed` after upgrading re-embeds once**, on top of 0.8.0's own one-time reindex.
+- **A `NaN` vector-query width is rejected instead of silently becoming the widest possible scan.** `clampVecK` treated every non-finite value alike via `!Number.isFinite(k)`, so `NaN` and `-Infinity` both saturated to the 4096 ceiling. For `NaN` that ran the most expensive ANN scan available and then returned nothing, because the subsequent `.slice(0, NaN)` yields an empty array — hiding a caller bug behind an empty page. `NaN` now throws, matching how `vecBuf` rejects a non-finite vector component; `Infinity` still saturates, since it is the honest spelling of "every candidate"; and a negative or zero request still floors to 1.
+
 ## [0.8.0] - 2026-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ This aggregate changelog contains changes that span multiple layers.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A note could be given the wrong title, degrading semantic search across that whole note.** 0.8.0 started mixing each note's title into every one of its chunks when embedding, which is what makes a mid-note passage findable by what the note is *about*. But the title was picked from the first `#` line anywhere in the file, and `#` means "comment" in frontmatter and "heading" in Markdown. So a frontmatter comment like `# rewrite this later`, or an `# Example` heading shown inside a fenced code block, could be adopted as the note's title and then mixed into every chunk of it — pulling the entire note toward the wrong topic. Titles are now read only from frontmatter `title` or a real heading in the note body, with code fences skipped. A note affected by either case had no real title to begin with, so it is now correctly untitled.
+
+  To be clear about what this does and does not change: frontmatter text has always been part of what gets indexed, and still is. This fixes which text is treated as the *title*, not what is stored.
+
+  **If you ran `oms embed` on 0.8.0, re-run it.** Affected notes are corrected automatically, but only once you sync again.
+
+### Changed
+
+- **This release re-embeds your vault once, for the last time in this series.** Fixing the title bug above required changing how OMS fingerprints a chunk, which invalidates the fingerprints written by 0.8.0. Combined with 0.8.0's own one-time reindex, that is two full re-embeds across two consecutive releases — not a pattern, and worth taking now while the affected code is one release old rather than carrying a known-wrong fingerprint forward.
+
+### Documentation
+
+- **The limits of the 0.8.0 vector-search fix are now stated where users read.** That release described vector search as fixed without noting the ceiling it works under: results come from at most 4096 candidates, so on a vault larger than that a vector-derived result count and any deep page are bounded by it, and a collection-scoped vector search can miss matches whose documents rank outside that band globally. This is a property of how the vector index ranks before filtering, not something the fix introduced — but it belonged in the release note and was only in the kernel changelog.
+- The pinned default model's decision record now documents why an explicit, opt-in `--embedding-default` command is not the automatic default-model acquisition that `docs/measurements/model-default-deferral.md` withholds, and states plainly that the model's retrieval quality rests on matching the reference toolchain rather than on a measurement in this project's own harness.
+
 ## [0.8.0] - 2026-08-29
 
 ### Added

--- a/docs/measurements/model-default-deferral.md
+++ b/docs/measurements/model-default-deferral.md
@@ -48,3 +48,56 @@ measurement and model measurement are different measurements; a
 
 The deferral closes only when a validator-accepted, green `model-default`
 manifest exists and was produced from a real vault by that vault's owner.
+
+---
+
+# Explicit-acquisition decision record (v0.8.0)
+
+> **Decision: ship an explicit, opt-in acquisition command; do not ship an
+> implicit or automatic default.** Recorded 2026-08-30 by the vault owner when
+> authorising v0.8.0. This record does **not** close the deferral above, does
+> not select a default model for any unconfigured vault, and consumes no
+> waiver.
+
+## What was decided
+
+v0.8.0 adds `oms setup --embedding-default`, which acquires a pinned
+EmbeddingGemma-300M descriptor, verifies the downloaded bytes against a pinned
+SHA-256, and publishes it as the installed default for that machine.
+
+The owner was presented with the tension against the deferral above and chose
+the explicit-install path over both waiting for a real-vault `model-default`
+measurement and shipping an automatic first-run download.
+
+## Why this is not the capability the deferral withheld
+
+Rule 1's substance is that a release "introduces no new default embedding
+model" and leaves "explicit configuration behaviour unchanged". Both hold:
+
+- No unconfigured vault gains a default. With no environment pair and an empty
+  cache, `resolveEmbeddingModel` still returns `available: false`,
+  `source: "none"`. The pinned constant is unreachable from resolution; its only
+  production consumer is the explicit setup branch.
+- The machine-verified no-default contract still passes unchanged, including its
+  zero-download assertion over the MCP surface.
+- Explicit `OMS_EMBEDDING_PROVIDER` + `OMS_EMBEDDING_MODEL` behaviour is
+  untouched, and a half pair still fails loudly naming both variables.
+
+The user names the model by running a command; the runtime never chooses one.
+That is the distinction this record turns on.
+
+## What remains unproven
+
+No real-vault `model-default` measurement exists for this model. Its retrieval
+quality is therefore asserted on the basis that it is the same model and prompt
+format the reference toolchain (qmd) uses by default, not on a measured
+comparison against an alternative in this project's own harness. Anyone
+selecting it is adopting that unmeasured assertion.
+
+`boost-c040` is unaffected and remains required and never waivable.
+
+## Closing condition (unchanged)
+
+The deferral above still closes only on a validator-accepted, green
+`model-default` manifest produced from a real vault by that vault's owner.
+Until then, automatic or implicit default-model acquisition stays withheld.

--- a/src/kernel/engine/embed/chunker.test.ts
+++ b/src/kernel/engine/embed/chunker.test.ts
@@ -92,6 +92,55 @@ describe("chunkDocument", () => {
     expect(chunks[0]?.title).toBe("Real Heading");
   });
 
+  it("never mistakes a YAML frontmatter comment for the document title", () => {
+    // A YAML comment is syntactically identical to an ATX H1. Scanning the raw
+    // document for a heading would embed private metadata as the note's title,
+    // making an internal remark searchable content.
+    const chunks = chunkDocument(
+      "notes/comment.md",
+      "---\n# Internal note, do not ship\nstatus: draft\n---\nBody text here.",
+    );
+    expect(chunks[0]?.title).toBe(UNTITLED_DOCUMENT_TITLE);
+  });
+
+  it("ignores an H1 inside a fenced code block", () => {
+    const backticks = chunkDocument(
+      "notes/fence.md",
+      "Intro.\n\n```markdown\n# Sample Heading\n```\n\nMore body.",
+    );
+    const tildes = chunkDocument("notes/tilde.md", "Intro.\n\n~~~\n# Sample Heading\n~~~\n\nBody.");
+
+    expect(backticks[0]?.title).toBe(UNTITLED_DOCUMENT_TITLE);
+    expect(tildes[0]?.title).toBe(UNTITLED_DOCUMENT_TITLE);
+  });
+
+  it("finds a real H1 that follows a fenced code block", () => {
+    const chunks = chunkDocument(
+      "notes/after-fence.md",
+      "Intro.\n\n```\n# Sample\n```\n\n# Real Title\nBody.",
+    );
+    expect(chunks[0]?.title).toBe("Real Title");
+  });
+
+  it("keeps a fence open across a shorter inner run", () => {
+    // CommonMark closes a fence only on a run at least as long as the opener,
+    // so the inner ``` does not end a ```` block and the heading stays sample text.
+    const chunks = chunkDocument(
+      "notes/nested-fence.md",
+      "Intro.\n\n````\n```\n# Still Inside\n````\n\nBody.",
+    );
+    expect(chunks[0]?.title).toBe(UNTITLED_DOCUMENT_TITLE);
+  });
+
+  it("ignores a non-string frontmatter title instead of coercing it", () => {
+    expect(chunkDocument("n.md", "---\ntitle: 12345\n---\nBody.")[0]?.title)
+      .toBe(UNTITLED_DOCUMENT_TITLE);
+    expect(chunkDocument("l.md", "---\ntitle:\n  - A\n  - B\n---\nBody.")[0]?.title)
+      .toBe(UNTITLED_DOCUMENT_TITLE);
+    expect(chunkDocument("z.md", "---\ntitle: null\n---\n# Real H1\nBody.")[0]?.title)
+      .toBe("Real H1");
+  });
+
   it("changes the sha of body-only chunks when only the title changes", () => {
     // The title reaches every chunk's embedding input, so a retitle must
     // invalidate chunks that do not themselves contain the title line.
@@ -112,6 +161,19 @@ describe("chunkDocument", () => {
   it("keeps the sha stable when neither title nor text changes", () => {
     const raw = "---\ntitle: Stable\n---\nUnchanged body.";
     expect(chunkDocument("a.md", raw)[0]?.sha).toBe(chunkDocument("b.md", raw)[0]?.sha);
+  });
+
+  it("cannot be made to collide by moving a NUL across the title boundary", () => {
+    // A bare separator is only unambiguous while the inputs cannot contain it.
+    // Nothing forbids a NUL in note text, so ("a", "\0b") and ("a\0", "b") would
+    // hash identically under plain concatenation, letting a crafted retitle
+    // impersonate a body edit and suppress re-embedding.
+    const left = chunkDocument("x.md", "---\ntitle: \"a\"\n---\n\u0000b");
+    const right = chunkDocument("x.md", "---\ntitle: \"a\\u0000\"\n---\nb");
+
+    expect(left[0]?.title).toBe("a");
+    expect(right[0]?.title).toBe("a\u0000");
+    expect(left[0]?.sha).not.toBe(right[0]?.sha);
   });
 
   it("respects maxTokens option by splitting large docs", () => {

--- a/src/kernel/engine/embed/chunker.ts
+++ b/src/kernel/engine/embed/chunker.ts
@@ -62,29 +62,72 @@ function isCjk(cp: number): boolean {
  * The title must be inside the digest. It is prepended to every chunk's
  * embedding input, so a digest over `text` alone would report "unchanged" for
  * each chunk that does not itself contain the title line — leaving vectors that
- * still encode the OLD title after a retitle. The NUL separator keeps
- * (title, text) unambiguous so no retitle can collide with a body edit.
+ * still encode the OLD title after a retitle.
+ *
+ * The title is length-prefixed rather than merely separated. A bare separator is
+ * only unambiguous while the inputs cannot contain it, and nothing forbids a NUL
+ * in note text: with a plain separator, `("a", "\0b")` and `("a\0", "b")` hash
+ * identically, so a crafted retitle could impersonate a body edit and suppress
+ * re-embedding. The length prefix makes the encoding injective for every input.
  */
 function chunkDigest(title: string, text: string): string {
-  return createHash("sha256").update(`${title}\u0000${text}`).digest("hex");
+  return createHash("sha256")
+    .update(`${title.length}\u0000${title}\u0000${text}`)
+    .digest("hex");
+}
+
+/**
+ * Find the first ATX H1 in a markdown body, ignoring fenced code blocks.
+ *
+ * A `# ...` line inside a fence is sample content, not the document's heading.
+ * Scanning without fence tracking would let a README-style note that shows a
+ * markdown example be titled by that example. Both backtick and tilde fences
+ * count, and a fence closes only on a run of the same character at least as
+ * long as the one that opened it, so a fence containing a shorter run stays
+ * open as CommonMark specifies.
+ */
+function firstHeadingTitle(body: string): string | undefined {
+  let fence: { char: string; length: number } | null = null;
+  for (const line of body.split("\n")) {
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+    if (fenceMatch !== null) {
+      const run = fenceMatch[1]!;
+      const char = run[0]!;
+      if (fence === null) {
+        fence = { char, length: run.length };
+      } else if (char === fence.char && run.length >= fence.length) {
+        fence = null;
+      }
+      continue;
+    }
+    if (fence !== null) continue;
+    const heading = /^#\s+(.+)$/.exec(line);
+    const title = heading?.[1]?.trim();
+    if (title !== undefined && title !== "") return title;
+  }
+  return undefined;
 }
 
 /**
  * The document title carried into every chunk's embedding input.
  *
- * Frontmatter `title` wins, then the first ATX H1, else the untitled literal.
- * Reuses the shared convention parser rather than re-deriving frontmatter here.
- * A malformed-frontmatter document still yields a title: `parseNote` reports
- * diagnostics instead of throwing, and the H1 scan covers the body.
+ * Frontmatter `title` wins, then the first ATX H1 in the body, else the
+ * untitled literal. Reuses the shared convention parser rather than
+ * re-deriving frontmatter here.
+ *
+ * The H1 scan is deliberately confined to `parsed.body`. Scanning the raw
+ * document would read frontmatter too, where a YAML comment (`# note to self`)
+ * is syntactically indistinguishable from an H1 — which would embed private
+ * metadata as though it were the note's title. A document whose frontmatter
+ * fence never closes therefore has an empty body and is untitled: `none` is the
+ * honest answer for a malformed document, and preferable to guessing from a
+ * region that is not body text.
  */
 function documentTitle(rawText: string): string {
   const parsed = parseNote(rawText);
   const declared = parsed.frontmatter["title"];
   if (typeof declared === "string" && declared.trim() !== "") return declared.trim();
-  const heading = /^#\s+(.+)$/m.exec(parsed.body) ?? /^#\s+(.+)$/m.exec(rawText);
-  const headingTitle = heading?.[1]?.trim();
-  if (headingTitle !== undefined && headingTitle !== "") return headingTitle;
-  return UNTITLED_DOCUMENT_TITLE;
+  return firstHeadingTitle(parsed.body) ?? UNTITLED_DOCUMENT_TITLE;
 }
 
 /**

--- a/src/kernel/engine/embed/store.test.ts
+++ b/src/kernel/engine/embed/store.test.ts
@@ -113,6 +113,26 @@ describe("openEngineStore — queryVec", () => {
     expect(store.queryVec(vec, Number.MAX_SAFE_INTEGER).length).toBeLessThanOrEqual(SQLITE_VEC_MAX_K);
   });
 
+  it("rejects NaN rather than turning a caller bug into the widest possible scan", async () => {
+    // NaN is not a width. Saturating it to the ceiling would run the most
+    // expensive ANN scan available and then return nothing from slice(0, NaN),
+    // hiding the caller's bug behind an empty page.
+    const provider = createHashProjectionProvider(DIMS);
+    const vec = await provider.embed("retrieval augmented generation");
+    await provider.dispose();
+
+    expect(() => store.queryVec(vec, Number.NaN)).toThrow(/NaN/);
+  });
+
+  it("floors a negative-infinity request to a single candidate", async () => {
+    const provider = createHashProjectionProvider(DIMS);
+    const vec = await provider.embed("retrieval augmented generation");
+    await provider.dispose();
+
+    expect(() => store.queryVec(vec, Number.NEGATIVE_INFINITY)).not.toThrow();
+    expect(store.queryVec(vec, Number.NEGATIVE_INFINITY).length).toBeLessThanOrEqual(1);
+  });
+
   it("returns at least one candidate for a non-positive k rather than an empty page", async () => {
     const provider = createHashProjectionProvider(DIMS);
     const vec = await provider.embed("retrieval augmented generation");

--- a/src/kernel/engine/embed/store.ts
+++ b/src/kernel/engine/embed/store.ts
@@ -93,8 +93,13 @@ export const SQLITE_VEC_MAX_K = 4096;
 /**
  * Clamp a requested knn width into sqlite-vec's supported range.
  *
- * A non-positive or non-finite request collapses to 1 rather than 0 so a caller
- * that asks for "some" results never silently receives an empty page.
+ * `Infinity` is the honest spelling of "every candidate", so it saturates to the
+ * ceiling. `NaN` is not a width at all — it is a caller bug, and silently
+ * turning it into the most expensive possible ANN scan would hide that bug while
+ * `.slice(0, NaN)` returned nothing — so it is rejected, matching how `vecBuf`
+ * rejects a non-finite vector component. A negative or zero request floors to 1
+ * rather than 0 so a caller asking for "some" results never silently receives an
+ * empty page.
  *
  * Clamping is a real ceiling, not a formality. In a vault with more than
  * `SQLITE_VEC_MAX_K` indexed chunks the vector candidate stream is truncated, so
@@ -106,7 +111,10 @@ export const SQLITE_VEC_MAX_K = 4096;
  * vector query outright, which is what shipped before this clamp.
  */
 function clampVecK(k: number): number {
-  if (!Number.isFinite(k)) return SQLITE_VEC_MAX_K;
+  if (Number.isNaN(k)) {
+    throw new Error("EngineStore vector query k must be a number, got NaN.");
+  }
+  if (k === Number.POSITIVE_INFINITY) return SQLITE_VEC_MAX_K;
   return Math.max(1, Math.min(SQLITE_VEC_MAX_K, Math.floor(k)));
 }
 


### PR DESCRIPTION
## Summary

Post-release review of 0.8.0 found four defects in code that release shipped, plus two disclosure gaps. All are fixed forward here; 0.8.0's changelog sections are immutable and untouched.

### The title bug is the significant one

0.8.0 started mixing each note's title into **every** chunk when embedding — that is what makes a mid-note passage findable by what the note is *about*. But `documentTitle` picked the first `#` line anywhere in the file, and `#` means "comment" in frontmatter and "heading" in Markdown. So a frontmatter comment like `# rewrite this later`, or an `# Example` inside a fenced code block, could be adopted as the note's title and mixed into all of its chunks — pulling the whole note toward the wrong topic.

The H1 scan is now confined to `parsed.body` and tracks backtick and tilde fences, closing a fence only on a run at least as long as the opener (CommonMark). A document whose frontmatter fence never closes has an empty body and is therefore untitled, which is the honest answer for a malformed document rather than a guess drawn from non-body text.

**I initially wrote this up as a privacy leak. That was wrong and I corrected it before shipping.** `chunkDocument` receives the raw document, so frontmatter text was already part of the indexed chunk text and still is. The bug was *which text got treated as the title*, not what gets stored. Both changelogs now say so explicitly rather than letting readers infer a redaction that did not happen.

### Digest collision

The chunk digest joined title and text with a bare NUL and claimed that made the pair unambiguous. Nothing forbids a NUL in note text, so `("a", "\0b")` and `("a\0", "b")` hashed identically — a crafted retitle could impersonate a body edit and suppress re-embedding. The title is now length-prefixed, making the encoding injective.

### `NaN` was the worst possible input

`clampVecK` folded every non-finite `k` to the 4096 ceiling via `!Number.isFinite(k)`. For `NaN` that ran the widest possible ANN scan and then returned nothing, because the following `.slice(0, NaN)` is empty — hiding a caller bug behind an empty page. `NaN` now throws, matching how `vecBuf` rejects a non-finite vector component. `Infinity` still saturates (it is the honest spelling of "every candidate"); negative and zero still floor to 1.

### Two disclosure gaps

- The aggregate `CHANGELOG.md` described 0.8.0's vector fix as simply working, omitting the 4096 candidate ceiling, the bounded `totalCount`/deep pages, and collection starvation. Those were only in the kernel changelog.
- The vault owner authorised explicit `--embedding-default` acquisition, but that authorisation was never recorded next to `docs/measurements/model-default-deferral.md`, so the repository could not show why an opt-in command is not the automatic acquisition that deferral withholds. A dated decision record now sits below the original, which is unmodified. It states plainly what remains unproven: no real-vault `model-default` measurement exists for this model, and its quality rests on matching the reference toolchain rather than on a measurement in this project's harness.

## Cost, stated plainly

The digest change means **a second full re-embed**, on top of 0.8.0's own. Two consecutive reindexes is a real cost. I took it now, while the wrong fingerprint is one release old, rather than carrying a known-broken fingerprint forward.

## Testing

Full suite **1063 passed** / 11 skipped, up from 1055. `npm run lint` clean. `changelog-history-guard` confirms 0.8.0's released sections are byte-identical.

New regression tests: YAML-comment title, backtick and tilde fenced H1, a real H1 following a fence, a shorter inner fence run staying open, non-string frontmatter titles, the NUL boundary collision, `NaN` rejection, and `-Infinity` flooring.

Verified end to end on a disposable vault with `HOME`/`XDG_CACHE_HOME` redirected. The cache started empty, so this exercised the **real** HuggingFace download and SHA-256 verification path, not a pre-seeded copy: downloaded bytes hashed to `b5ce9d77…90d63`, 333590944 bytes. After the fix, cross-lingual retrieval with zero lexical overlap still ranks correctly in both directions, a note whose body never mentions Kubernetes still ranks first for a Kubernetes query on its title alone, and the frontmatter-comment note is now correctly untitled.

Re-ran the E-1 no-default red-team directly: empty env + empty cache gives `available: false, source: "none"`; a half pair throws naming both variables; a non-object `default-model.json` is ignored; a descriptor missing identity fields fails closed.
