### PR TITLE
Gate the installable default's unmeasured disclosure

### DIFF
--- a/docs/measurements/model-default-deferral.md
+++ b/docs/measurements/model-default-deferral.md
@@ -101,3 +101,25 @@ selecting it is adopting that unmeasured assertion.
 The deferral above still closes only on a validator-accepted, green
 `model-default` manifest produced from a real vault by that vault's owner.
 Until then, automatic or implicit default-model acquisition stays withheld.
+
+## What enforces this, and what does not
+
+Nothing automated asks for the `model-default` manifest. `npm run
+check:measurement` runs the `boost-c040` profile only, and no workflow requests
+any other profile. So this deferral can remain open indefinitely while an
+installable default ships, and no build will object.
+
+That is deliberate rather than an oversight to fix in code. Only the vault owner
+can produce the manifest, from a real vault with curated labels, and the
+preregistration forbids satisfying it with fabricated relevance. A gate
+demanding it would therefore fail every run for a reason no contributor could
+fix. Whether to accept the drift, commit to producing the measurement, or
+withdraw the installable default is an owner decision, not something a test can
+settle.
+
+One narrower invariant *is* enforced, by
+`test/architecture/model-default-disclosure.test.ts`: while an installable
+default ships, this document must keep stating that the model is unmeasured.
+That stops the tradeoff from going silent through a routine edit. Withdrawing
+the default lifts the requirement, so a genuine removal is not obstructed. The
+gate holds the disclosure, not the measurement.

--- a/test/architecture/model-default-disclosure.test.ts
+++ b/test/architecture/model-default-disclosure.test.ts
@@ -1,0 +1,127 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { absolute, pathExists } from "./repo-root.js";
+
+/**
+ * Installable-default disclosure gate.
+ *
+ * `docs/measurements/model-default-deferral.md` withholds *automatic*
+ * default-model acquisition until a green real-vault `model-default` manifest
+ * exists, and separately records the vault owner's authorisation of the
+ * explicit, opt-in `oms setup --embedding-default` install. Nothing in
+ * `package.json` or the workflows ever asks for that manifest — `check:measurement`
+ * runs the `boost-c040` profile only — so the deferral can stay open indefinitely
+ * while an installable default ships.
+ *
+ * This gate does NOT try to close that by demanding the manifest. Only the vault
+ * owner can produce one from a real vault with curated labels, so a gate
+ * requiring it would fail every CI run for a reason no contributor could fix,
+ * and the preregistration forbids satisfying it with fabricated relevance. That
+ * decision belongs to the owner, not to a test.
+ *
+ * What a test CAN hold is the honesty invariant underneath it: **if an
+ * installable default ships, the repository must still say the model is
+ * unmeasured.** Today that disclosure is prose, and prose can be deleted or
+ * reworded in a routine edit while the shipping default stays exactly as it is —
+ * which would turn an openly-declared tradeoff into a silent one. That is the
+ * half of the drift a gate can actually prevent, so this gate prevents it.
+ *
+ * Both directions are enforced. Withdrawing the default is legitimate and lifts
+ * the requirement; keeping the default while dropping the disclosure fails.
+ */
+
+const DEFERRAL_DOC = "docs/measurements/model-default-deferral.md";
+const MODEL_SOURCE = "src/kernel/engine/embed/model.ts";
+const CLI_SOURCE = "src/cli/oms.ts";
+const CLI_ARGS = "src/cli/args.ts";
+
+const PINNED_CONSTANT = "PINNED_DEFAULT_EMBEDDING_MODEL";
+const DEFAULT_FLAG = "--embedding-default";
+
+/**
+ * Sentences that carry the unmeasured status. Each is matched as a regex so
+ * incidental whitespace or line wrapping does not decide whether the repository
+ * is judged honest, but the substance still has to be present.
+ */
+const DISCLOSURE_ANCHORS: ReadonlyArray<{ readonly label: string; readonly pattern: RegExp }> = [
+  {
+    label: "states no real-vault model-default measurement exists for this model",
+    pattern: /No real-vault\s+`model-default`\s+measurement exists for this model/u,
+  },
+  {
+    label: "attributes quality to matching the reference toolchain rather than measurement",
+    pattern: /not on a measured\s+comparison/u,
+  },
+  {
+    label: "keeps the closing condition on a validator-accepted real-vault manifest",
+    pattern: /closes only on a validator-accepted, green\s+`model-default`\s+manifest/u,
+  },
+  {
+    label: "keeps automatic or implicit acquisition withheld",
+    pattern: /automatic or implicit default-model acquisition stays withheld/u,
+  },
+];
+
+async function read(relativePath: string): Promise<string> {
+  return readFile(absolute(relativePath), "utf8");
+}
+
+/**
+ * True when the tree ships a default a user can install in one step: the
+ * descriptor constant exists, the CLI consumes it, and a flag reaches that path.
+ * All three are required, so deleting any one of them is a real withdrawal
+ * rather than a way to slip past the disclosure requirement.
+ */
+async function shipsInstallableDefault(): Promise<boolean> {
+  const [model, cli, args] = await Promise.all([
+    read(MODEL_SOURCE),
+    read(CLI_SOURCE),
+    read(CLI_ARGS),
+  ]);
+  return (
+    model.includes(`export const ${PINNED_CONSTANT}`) &&
+    cli.includes(PINNED_CONSTANT) &&
+    args.includes(DEFAULT_FLAG)
+  );
+}
+
+describe("installable default embedding model discloses its unmeasured status", () => {
+  it("scans the real source and documentation paths", async () => {
+    // A gate that silently stopped finding its own inputs would pass forever.
+    for (const relativePath of [DEFERRAL_DOC, MODEL_SOURCE, CLI_SOURCE, CLI_ARGS]) {
+      expect(await pathExists(relativePath), `${relativePath} must exist for this gate to mean anything`).toBe(true);
+    }
+  });
+
+  it("keeps the unmeasured-status disclosure while an installable default ships", async () => {
+    if (!(await shipsInstallableDefault())) {
+      // No installable default ships, so there is nothing to disclose. This is
+      // the legitimate withdrawal path, not a bypass.
+      return;
+    }
+
+    const doc = await read(DEFERRAL_DOC);
+    const missing = DISCLOSURE_ANCHORS.filter((anchor) => !anchor.pattern.test(doc)).map(
+      (anchor) => anchor.label,
+    );
+
+    expect(
+      missing,
+      `${DEFERRAL_DOC} must keep disclosing that the shipped installable default is unmeasured. ` +
+        "Missing: " +
+        missing.join("; ") +
+        ". Either restore the disclosure, or withdraw the installable default " +
+        `(${PINNED_CONSTANT} plus its ${DEFAULT_FLAG} wiring).`,
+    ).toEqual([]);
+  });
+
+  it("records that no pipeline demands the model-default measurement", async () => {
+    // The gap itself is a governance decision for the vault owner, but it must
+    // not be possible to believe it was closed. If some pipeline later does
+    // demand the profile, this expectation fails and the comment above plus the
+    // deferral doc's standing caveat need rewriting to match reality.
+    const packageJson = await read("package.json");
+    expect(packageJson).toContain("OMS_MEASUREMENT_PROFILE=boost-c040");
+    expect(packageJson).not.toContain("OMS_MEASUREMENT_PROFILE=model-default");
+  });
+});


### PR DESCRIPTION
## Summary

Review of the 0.8.x releases surfaced a real gap: **nothing ever asks for the `model-default` manifest.** `npm run check:measurement` runs the `boost-c040` profile only, and no workflow requests another. So `docs/measurements/model-default-deferral.md` can stay open indefinitely while an installable default ships, and no build objects.

### What this deliberately does not do

It does not close the gap by demanding the manifest. Only the vault owner can produce one, from a real vault with curated labels, and the preregistration forbids satisfying it with fabricated relevance — so a gate requiring it would fail every CI run for a reason no contributor could fix. Whether to accept the drift, commit to producing the measurement, or withdraw the installable default is an owner decision, not something a test can settle.

### What it does hold

The honesty invariant underneath it: **if an installable default ships, the repository must still say the model is unmeasured.**

That disclosure is prose today, and prose can be deleted or reworded in a routine edit while the shipping default stays exactly as it is — turning an openly declared tradeoff into a silent one. That is the half of the drift a gate can actually prevent.

`test/architecture/model-default-disclosure.test.ts` checks four anchor sentences in the deferral document, but only while all three parts of the installable default are present (`PINNED_DEFAULT_EMBEDDING_MODEL`, its CLI consumption, and the `--embedding-default` flag). Withdrawing the default lifts the requirement, so a genuine removal is not obstructed.

A third case pins that no pipeline demands the profile, so nobody can read the repo and believe the gap was closed. If enforcement is added later, that expectation fails and the standing caveat has to be rewritten to match reality.

## Mutation-tested in both directions

A passing gate proves nothing on its own, so I verified it fails when it should:

- **Reworded the unmeasured-status sentence, default still shipping** → FAILS, naming the missing anchor and both remedies.
- **Withdrew `PINNED_DEFAULT_EMBEDDING_MODEL`, disclosure also dropped** → PASSES, confirming legitimate withdrawal is not blocked.

Both mutations were reverted and the tree confirmed byte-identical afterward.

## Documentation

The deferral document now states what enforces it and what does not. A reader hitting "closes only on a validator-accepted, green `model-default` manifest" reasonably infers something checks for one; leaving that implicit let the document's strongest sentence imply enforcement that was never wired.

## No release

Neither file is in the published `files` list — `test/` is not packaged and `docs/measurements/` is repo-only. Nothing user-facing changes, so this carries no changelog entry and needs no version bump.

## Testing

Full suite **1066 passed** / 11 skipped (93 files), up from 1063. `npm run lint` clean, `npm run check:docs` clean, `changelog-history-guard` confirms released sections unchanged. Architecture gates 6 files / 82 tests pass.
