### PR TITLE
The model-default closing condition names an artifact nothing can produce

### DIFF
--- a/docs/measurements/model-default-deferral.md
+++ b/docs/measurements/model-default-deferral.md
@@ -123,3 +123,41 @@ default ships, this document must keep stating that the model is unmeasured.
 That stops the tradeoff from going silent through a routine edit. Withdrawing
 the default lifts the requirement, so a genuine removal is not obstructed. The
 gate holds the disclosure, not the measurement.
+
+## The closing condition currently names an artifact nothing can produce
+
+The condition above asks for a validator-accepted `model-default` manifest. The
+validator can check one: `scripts/check-measurement-manifest.mjs` lists
+`model-default` in `MEASUREMENT_PROFILES`, and in strict mode it demands a
+complete descriptor, `armId: "model-default"`, paired raw evidence with an
+A-embed `kind` and `outputDigest`, a green verdict, and a timestamp.
+
+Nothing can produce one. Three pieces are missing, and they are missing
+structurally rather than by oversight:
+
+- **No A-embed arm exists.** The validator reads `aEmbedMetrics`, but
+  `test/golden-set/harness.ts` knows only the three boost arms
+  (`boost-k-scale`, `boost-per-list`, `boost-zero`). There is no arm that
+  measures an embedding model.
+- **No preregistered protocol defines the measurement.**
+  `docs/preregistration/` contains `boost-arms.md` and nothing for
+  `model-default`: no query classes, no comparison, no pass rule.
+- **No manifest producer exists for any profile.** Nothing in `scripts/`,
+  `test/`, or `src/` emits a manifest. `boost-c040` never needed one, because
+  the shipped ranking default is the released baseline and that gate passes with
+  a receipt.
+
+So "produce the measurement" is not a data-entry task on the owner's vault. It
+is: preregister a protocol, add the arm, add a producer, then run it against a
+real vault with curated labels.
+
+The first of those must not be written by an agent, and deliberately was not.
+Preregistration is the commitment device that stops the metric from being chosen
+after the fact. An agent that authors the protocol, implements the arm, and then
+reports a pass has proved nothing except that it picked a rule its own candidate
+satisfies. Whoever defines this measurement must do so before knowing how
+EmbeddingGemma-300M scores under it.
+
+Until that exists, the closing condition is aspirational, and the honest reading
+of this document is that the installable default ships unmeasured with no dated
+commitment to measuring it.


### PR DESCRIPTION
## Summary

I previously recorded that the `model-default` measurement tooling was in place and only the owner's vault data was missing. **That was wrong**, and it understated the work substantially. Reading the validator alone is what produced the error.

The validator can *check* a `model-default` manifest — `MEASUREMENT_PROFILES` includes it, and strict mode demands a complete descriptor, `armId: "model-default"`, paired A-embed raw evidence with an `outputDigest`, a green verdict, and a timestamp.

Nothing can *produce* one. Three pieces are missing, structurally rather than by oversight:

- **No A-embed arm exists.** The validator reads `aEmbedMetrics`, but `test/golden-set/harness.ts` knows only `boost-k-scale`, `boost-per-list`, and `boost-zero`. Nothing there measures an embedding model.
- **No preregistered protocol defines the measurement.** `docs/preregistration/` holds `boost-arms.md` and nothing for `model-default` — no query classes, no comparison, no pass rule.
- **No manifest producer exists for any profile.** `boost-c040` never needed one, because the shipped ranking default is the released baseline and that gate passes by receipt. No manifest file has ever existed in this repo.

So "produce the measurement" is not data entry against a vault. It is: preregister a protocol, add the arm, add a producer, then run it against a real vault with curated labels.

## Why I did not just write the protocol

Preregistration is the commitment device that stops the metric being chosen after the fact. An agent that authors the protocol, implements the arm, and then reports a pass has proved nothing except that it picked a rule its own candidate satisfies. Whoever defines this measurement must do it *before* knowing how EmbeddingGemma-300M scores under it.

I also abandoned a related approach mid-way and want it on the record: I started extracting the manifest's required fields by probing the validator, intending to document a filling recipe. I stopped because `rawEvidence.paired: true`, `kind: "a-embed-production-v1"`, and `verdict: "pass"` are not schema holes — they are **assertions that a measurement was performed**. Documenting how to populate them without one would be a forgery guide, routing around the exact provision in `docs/preregistration/boost-arms.md` that forbids fabricated relevance.

## Effect

Documentation only; no code, no behavior, no version bump. `docs/measurements/` is repo-only and not in the published `files` list.

The practical consequence is that the closing condition is aspirational, and this document now says so. The honest reading: the installable default ships unmeasured, with no dated commitment to measuring it. That is a governance position the vault owner may well accept — but it should be accepted knowingly, not inferred from a sentence that implies a short errand.

## Testing

`test/architecture/model-default-disclosure.test.ts` still passes (3/3) — it reads this document, so a doc edit is exactly what could have broken it. `npm run lint` clean, `npm run check:docs` clean, `changelog-history-guard` confirms released sections unchanged.
