### PR TITLE
Drop a dead env var from the Korean README and disclose the default is unmeasured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ This aggregate changelog contains changes that span multiple layers.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Korean README told you to set an environment variable that does nothing.** It documented `OMS_MODEL_PATH` as the way to point OMS at a local GGUF model, but that name was retired and is read nowhere in the codebase — anyone following those instructions got no embeddings and no explanation why. It also never mentioned `oms setup --embedding-default`, so the one-step path that has shipped since 0.8.0 was invisible to Korean readers. Both READMEs now describe the same setup, and both name `OMS_EMBEDDING_PROVIDER` + `OMS_EMBEDDING_MODEL` as the way to choose your own model.
+
+### Documentation
+
+- **Both READMEs now say the default embedding model is unmeasured.** `--embedding-default` installs the same model and prompt format qmd resolves by default, and its ranking quality here rests on that equivalence — not on a measured comparison in this project's own retrieval harness. That caveat existed only in a repository decision record, which npm users never see. It is now stated where the feature is recommended, alongside a link explaining why the measurement is not simply pending.
+
 ## [0.8.1] - 2026-08-29
 
 ### Fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -102,14 +102,21 @@ oms hook       볼트 가드 훅 (Claude Code pre/post tool-use)
 
 ## 시맨틱 검색 (선택)
 
-시맨틱 검색에는 실제 임베딩 모델이 필요하다 — 프로덕션 경로에 가짜/해시 폴백은 없다(ADR-007). 로컬 GGUF 모델(`OMS_MODEL_PATH`) **또는** 임베딩 API 키(`UPSTAGE_API_KEY`) 중 하나를 설정한 뒤 동기화·질의한다:
+시맨틱 검색에는 실제 임베딩 모델이 필요하다 — 프로덕션 경로에 가짜/해시 폴백은 없다(ADR-007). 가장 간단한 경로는 핀 고정된 로컬 기본 모델이다:
 
 ```bash
-oms semantic sync  --vault /path/to/vault --collection vault
-oms semantic query "무엇을 찾아야 하나?" --vault /path/to/vault
+oms setup --vault /path/to/vault --yes --embedding-default
+oms embed  --vault /path/to/vault
+oms semantic vsearch "무엇을 찾아야 하나?" --vault /path/to/vault
 ```
 
-모델을 설정하지 않아도 그래프 기반 검색과 컨벤션 검증은 그대로 동작한다.
+`--embedding-default`는 EmbeddingGemma-300M(약 318 MB)을 내려받아 핀 고정된 SHA-256으로 검증한 뒤, 볼트가 아니라 사용자 캐시 디렉터리에 설치한다. `node-llama-cpp`로 로컬 실행되므로 API 키가 필요 없고, 모델 원본 768차원을 폴딩 없이 그대로 사용한다. 이후 `oms embed`와 벡터 검색은 환경변수 없이 동작한다.
+
+의존하기 전에 알아둘 점이 하나 있다. 이 모델과 프롬프트 형식은 [qmd](https://github.com/tobi/qmd)가 기본으로 쓰는 것과 동일하지만, 이 프로젝트의 자체 검색 하네스에서 측정된 적은 한 번도 없다. 여기서의 랭킹 품질은 대안과의 측정 비교가 아니라 그 동일성에 근거한다. 그 이유와, 해당 측정이 단순히 '보류 중'이 아닌 이유는 [결정 기록](https://github.com/GoBeromsu/oh-my-second-brain/blob/main/docs/measurements/model-default-deferral.md)에 적혀 있다.
+
+직접 고른 모델을 쓰려면 `OMS_EMBEDDING_PROVIDER`와 `OMS_EMBEDDING_MODEL`을 함께 지정한다(`gguf`에 로컬 GGUF 경로, 또는 `upstage`에 모델 id와 `UPSTAGE_API_KEY`). 둘 중 하나만 지정하면 두 변수 이름을 모두 알려주며 실패한다. 조용한 폴백은 없다.
+
+모델이 없어도 어휘 검색, 그래프 기반 검색, 컨벤션 검증은 그대로 동작한다. 벡터와 HyDE 요청만 거부되며, 그때 어떤 변수를 설정해야 하는지 알려준다.
 
 ## 개발
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ oms semantic vsearch "what should I retrieve?" --vault /path/to/vault
 
 `--embedding-default` downloads EmbeddingGemma-300M (~318 MB), verifies it against a pinned SHA-256, and installs it under your user cache — not in the vault. It runs locally through `node-llama-cpp`, needs no API key, and embeds at the model's full 768 dimensions with no folding. After that, `oms embed` and vector search need no environment variables.
 
+One thing to know before you rely on it: this is the same model and prompt format [qmd](https://github.com/tobi/qmd) resolves by default, but it has never been measured in this project's own retrieval harness. Its ranking quality here rests on that equivalence, not on a measured comparison against alternatives. [The decision record](https://github.com/GoBeromsu/oh-my-second-brain/blob/main/docs/measurements/model-default-deferral.md) explains why, and why the measurement is not merely pending.
+
 To choose your own model instead, set `OMS_EMBEDDING_PROVIDER` + `OMS_EMBEDDING_MODEL` (`gguf` with a local GGUF path, or `upstage` with a model id and `UPSTAGE_API_KEY`). Setting only one of the pair is an error naming both, never a silent fallback.
 
 Without any model, lexical search, graph-based retrieval, and convention validation all still work; only vector and HyDE requests are refused, and they say which variables to set.


### PR DESCRIPTION
## Summary

Two user-facing documentation problems. Both READMEs ship in the npm tarball, so these affect people installing the package, not just readers of this repo.

### The Korean README documented a variable that does nothing

It told readers to set `OMS_MODEL_PATH` to point OMS at a local GGUF model. That name was retired: it appears nowhere in `src/` or `scripts/`, and ADR-007 states explicitly that there is no `OMS_MODEL_PATH` alias. Anyone following those instructions got no embeddings and no explanation why.

It also never mentioned `oms setup --embedding-default`, so the one-step path that has shipped since 0.8.0 was invisible to Korean readers — that file was two releases stale. Both READMEs now describe the same setup and both name `OMS_EMBEDDING_PROVIDER` + `OMS_EMBEDDING_MODEL` for choosing your own model.

### Neither README said the default model is unmeasured

`--embedding-default` installs the same model and prompt format qmd resolves by default, and its ranking quality here rests on that equivalence — not on a measured comparison in this project's own retrieval harness. That caveat lived only in `docs/measurements/model-default-deferral.md`, which is repo-only and which npm users never see.

It now sits where the feature is recommended, with a link to the decision record explaining why the measurement is not simply pending. Recommending a default while keeping the "it's unmeasured" part in a file the audience cannot read is the wrong side of that asymmetry.

## On the Korean edit specifically

My first attempt at it corrupted Hangul mid-character — "시맨틱" became "시맨햍", and several other words broke the same way. I reverted it and rewrote it through a path that preserves UTF-8, then verified mechanically rather than by eye: valid UTF-8 decode, absence of the specific corruption markers that had appeared, dead variable gone, new content present. Reviewing my own Korean prose by sight is exactly how the first version got through.

## Testing

`npm run check:docs` clean, `npm run lint` clean, architecture gates 6 files / 82 tests pass. `changelog-history-guard` confirms the released 0.8.1 section is byte-identical — the changelog diff is additions only.
