### PR TITLE
Bind the unconfigured-vault guidance to whether the flag actually exists

### DIFF
--- a/test/architecture/model-default-disclosure.test.ts
+++ b/test/architecture/model-default-disclosure.test.ts
@@ -115,6 +115,29 @@ describe("installable default embedding model discloses its unmeasured status", 
     ).toEqual([]);
   });
 
+  it("keeps the unconfigured-vault guidance consistent with whether the flag exists", async () => {
+    // The guidance a model-less vault prints is the one place that tells a user
+    // how to get embeddings. If the pinned default is ever withdrawn, guidance
+    // still naming `--embedding-default` would send users to a command that no
+    // longer exists -- the same defect as the Korean README's long-dead
+    // `OMS_MODEL_PATH`, which shipped for two releases telling people to set a
+    // variable nothing reads. Enforced symmetrically: wired but unmentioned
+    // hides the one-step path, mentioned but unwired is an outright lie.
+    const [model, ships] = await Promise.all([read(MODEL_SOURCE), shipsInstallableDefault()]);
+    const guidanceMentionsFlag = /No embedding model is configured[\s\S]{0,400}?--embedding-default/u.test(
+      model,
+    );
+
+    expect(
+      guidanceMentionsFlag,
+      ships
+        ? `${MODEL_SOURCE} ships ${DEFAULT_FLAG} but its unconfigured-vault guidance does not name it, ` +
+          "so users are not told the one-step path exists."
+        : `${MODEL_SOURCE} no longer wires ${DEFAULT_FLAG}, but its unconfigured-vault guidance still ` +
+          "names it. Update the guidance so it does not point at a command that no longer exists.",
+    ).toBe(ships);
+  });
+
   it("records that no pipeline demands the model-default measurement", async () => {
     // The gap itself is a governance decision for the vault owner, but it must
     // not be possible to believe it was closed. If some pipeline later does


### PR DESCRIPTION
## Summary

Measuring what withdrawing the pinned default would actually cost — one of the three options in #78 — turned up a hole in the gate I added in #75.

Withdrawal does **not** break existing users. Resolution reads the on-disk descriptor, so `source: "installed-default"` keeps working with the constant gone; I verified that by removing `PINNED_DEFAULT_EMBEDDING_MODEL` and its CLI wiring and confirming an already-installed cache still resolves.

But the guidance a model-less vault prints would still name `oms setup --embedding-default`, sending new users to a command that no longer exists.

That is the same defect class as the Korean README's `OMS_MODEL_PATH`, which shipped for two releases telling people to set a variable nothing reads. The #75 gate held the *disclosure* and missed the *instruction*.

## What this adds

One case binding the two together, enforced symmetrically:

- **wired but unmentioned** → fails, because it hides the one-step path from users who need it
- **mentioned but unwired** → fails, because it is an outright lie

Mutation-tested in both directions; each failure names which side to fix:

```
ships --embedding-default but its unconfigured-vault guidance does not name it,
so users are not told the one-step path exists.

no longer wires --embedding-default, but its unconfigured-vault guidance still
names it. Update the guidance so it does not point at a command that no longer exists.
```

## Effect

Test-only. `test/` is not in the published `files` list, so nothing ships and no version bump is needed.

## Testing

Full suite **1067 passed** / 11 skipped, up from 1066. `npm run lint` clean, `npm run check:docs` clean. Both mutations reverted and the tree confirmed clean afterward.
