### PR TITLE
Link the model-default deferral to its open decision thread

### DIFF
--- a/docs/measurements/model-default-deferral.md
+++ b/docs/measurements/model-default-deferral.md
@@ -161,3 +161,9 @@ EmbeddingGemma-300M scores under it.
 Until that exists, the closing condition is aspirational, and the honest reading
 of this document is that the installable default ships unmeasured with no dated
 commitment to measuring it.
+
+That gap is an open decision, not a settled position:
+[#78](https://github.com/GoBeromsu/oh-my-second-brain/issues/78) carries the
+three options (accept the drift on the record, commit to producing the
+measurement, or withdraw the installable default) along with the measured cost of
+each. Read it before treating anything above as final.


### PR DESCRIPTION
## Summary

`docs/measurements/model-default-deferral.md` explains that its own closing condition names an artifact nothing can currently produce, then stops. A reader had no way to know the resulting gap is an **open question with three costed options** rather than a settled position — that lives in #78.

This adds the pointer.

Same shape as the other staleness fixed this cycle: a document accurate about the past and silent about what is actually live.

## Effect

Documentation only. `docs/measurements/` is repo-only, not in the published `files` list. No version bump.

## Testing

`test/architecture/model-default-disclosure.test.ts` still passes 4/4 — it reads this file, so a doc edit is exactly what could break it. `npm run check:docs` clean, `changelog-history-guard` confirms released sections unchanged.
