### PR TITLE
Correct the Korean README's MCP surface and the doctor/lint split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This aggregate changelog contains changes that span multiple layers.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Korean README documented an MCP surface that no longer exists.** It listed eleven tools — `oms_graph_status`, `oms_retrieve_by_axis`, `oms_lazy_load_note`, and eight more — as what `oms mcp` exposes. Those are the retired detail operations, which now route through the five public tools by an `op` parameter. It also named the write tool `write` rather than `oms_write`. Anyone wiring an MCP client from that list would have called tools the server does not advertise — `ListTools` returns exactly the five. It now states the same five tools the English README does: `oms_write`, `oms_search`, `oms_link`, `oms_status`, `oms_doctor`.
+- **The Korean README credited `oms doctor` with `oms lint`'s job and omitted `lint` entirely.** `doctor` was described as broken-link and orphan detection, which is what `lint` does; `doctor` validates note frontmatter against the ontology. Both commands are now listed with their actual responsibilities.
+
 ## [0.8.2] - 2026-08-29
 
 ### Fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -74,7 +74,8 @@ oms setup      기존 볼트를 컨벤션으로 채택 (.oms/taxonomy.yaml 작�
 oms install    호스트 어댑터 + MCP 등록 설치
 oms uninstall  호스트 어댑터 + MCP 등록 제거
 oms update     패키지 업데이트 확인/적용 후 어댑터 재조정
-oms doctor     온톨로지 기준 노트 검증 (broken-link + orphan 탐지)
+oms doctor     온톨로지 기준으로 노트 frontmatter 검증 (필드/컨셉별 집계)
+oms lint       볼트 링크 건강도 점검: 깨진 [[wikilink]] + 고아 노트
 oms semantic   네이티브 마크다운 시맨틱 인덱스 / 검색 / 조회
 oms mcp        stdio MCP 서버 시작
 oms hook       볼트 가드 훅 (Claude Code pre/post tool-use)
@@ -84,11 +85,11 @@ oms hook       볼트 가드 훅 (Claude Code pre/post tool-use)
 
 ## MCP 도구
 
-`oms mcp`는 상태, 읽기, 검색, 검증, 게이트된 write 도구를 노출한다:
+`oms mcp`는 정확히 다섯 개의 공개 도구를 노출한다:
 
-`oms_graph_status` · `oms_graph_build` · `oms_list_concepts` · `oms_retrieve_context` · `oms_retrieve_by_axis` · `oms_sync_embeddings` · `oms_semantic_query` · `oms_get_document` · `oms_multi_get_documents` · `oms_lazy_load_note` · `oms_validate_contract` · `write`
+`oms_write` · `oms_search` · `oms_link` · `oms_status` · `oms_doctor`
 
-`write`는 경로 안전성, 볼트 격리, 커널이 소유한 컨셉 계약으로 게이트된다.
+`oms_write`는 경로 안전성, 볼트 격리, 커널이 소유한 컨셉 계약으로 게이트된다.
 
 ## 볼트 구조 (`.oms/`)
 


### PR DESCRIPTION
## Summary

`README.ko.md` ships in the npm tarball and documented an MCP surface that does not exist.

### It listed eleven tools that are not advertised

It named `oms_graph_status`, `oms_graph_build`, `oms_list_concepts`, `oms_retrieve_context`, `oms_retrieve_by_axis`, `oms_sync_embeddings`, `oms_semantic_query`, `oms_get_document`, `oms_multi_get_documents`, `oms_lazy_load_note`, `oms_validate_contract` as what `oms mcp` exposes. Those are the retired detail operations, which now route through the five public tools by an `op` parameter.

Ground truth, checked rather than assumed: `src/mcp/server.ts:208` defines `omsMcpTools` as exactly five entries, and the `ListToolsRequestSchema` handler returns that array verbatim. Three independent sources agree on the count — `test/architecture/surface-parity.test.ts` asserts `TARGET = { skills: 6, tools: 5 }`, `AGENTS.md` states "Five MCP tools, a strict subset", and exactly five skills declare `mcp_tool`.

So a reader wiring an MCP client from the Korean list would have called tools the server never advertises. It also wrote the write tool as `write` rather than `oms_write`.

### It gave `doctor` the job that belongs to `lint`

`oms doctor` was described as broken-link and orphan detection. That is `oms lint`; `doctor` validates note frontmatter against the ontology. And `oms lint` was missing from the command list entirely — the only command the Korean list omitted that the English one includes. Both now match `src/cli/usage.ts`.

## Verified mechanically, not by eye

An earlier Korean edit in this cycle corrupted Hangul mid-character ("시맨틱" → "시맨햍") and I only caught it by re-reading. This edit asserts UTF-8 decode, absence of the specific corruption markers that appeared then, retired tool names gone, five public tools present, and `oms lint` documented.

## Checked and deliberately left alone

Both READMEs mention `oms_validate_contract` when describing what enforces the `.oms` contract, alongside `vault-lint`. Both are internal names in a sentence about internals rather than a tool list, and the two languages are symmetric. That is coherent prose, not the same defect — I am not going to manufacture a finding to look thorough.

I also swept the other shipped docs (`core/AGENTS.md`, `docs/adapters.md`, `docs/install.md`, all of `assets/`) for retired tool names presented as public. Clean.

## Testing

Full suite **1067 passed** / 11 skipped. `npm run lint` clean, `npm run check:docs` clean, architecture gates 83 tests pass, `changelog-history-guard` confirms released sections byte-identical (changelog diff is additions only).
