### PR TITLE
test: cap Vitest workers for stable release checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "node scripts/clean-dist.mjs && tsc -p tsconfig.json",
     "postbuild": "chmod +x dist/cli/oms.js",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --maxWorkers=2 --minWorkers=2",
     "check:docs": "node scripts/check-doc-mapping.mjs",
     "check:measurement": "OMS_MEASUREMENT_REQUIRED=1 OMS_MEASUREMENT_ATTESTATION_REQUIRED=1 OMS_MEASUREMENT_RELEASE=1 OMS_MEASUREMENT_PROFILE=boost-c040 OMS_MEASUREMENT_MANIFEST=docs/measurements/boost-c040.json node scripts/check-measurement-manifest.mjs",
     "audit": "npm audit --omit=dev",


### PR DESCRIPTION
Caps the default Vitest worker count at two so the existing 5-second behavioral timeouts measure product behavior instead of machine-wide process contention. The full suite passes: 99 files passed, 1 skipped; 1112 tests passed, 11 skipped.