### PR TITLE
R1 safety patch: fail-closed host config edits, side-effect-free --help, template-source isolation (#54 #55 #67 #89)

### DIFF
--- a/CHANGELOG-cli.md
+++ b/CHANGELOG-cli.md
@@ -4,6 +4,11 @@ Changes to the `oms` command surface belong here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--help` is now a first-class, side-effect-free path.** (#55) Every recognized command plus the bare `oms --help`/`-h` prints usage and exits 0 before any vault resolution, host-config access, MCP server start, or update notice; `--help` never lands in unknown-flag handling, and an unknown command with `--help` still fails so typos are not hidden.
+- **Setup dry-run reports blocked proposals instead of aborting.** (#67) `oms setup --dry-run` on a vault with unresolved notes prints a deterministic blocked diagnosis without composing a manifest and issues no approval digest; apply requests are clearly rejected before composition.
+
 ## [0.10.0] - 2026-09-01
 
 ### Breaking

--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -4,6 +4,11 @@ Domain logic changes belong here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Host YAML configuration is now edited surgically, never reserialized.** (#89) `editYamlEntryPreservingComments` splices only the character range of the managed `mcp_servers.oms` entry, preserving every other byte — comments, key order, quoting style, wrapping, and non-ASCII content — and refuses unsafe documents (anchors/aliases, merge keys, tab indentation, multi-document, non-mapping roots) instead of silently rewriting them.
+- **One malformed note or external template source no longer aborts setup and doctor.** (#67) Obsidian core Templates and Templater folder locations declared under `.obsidian/` are discovered read-only and excluded from note scans without ever being promoted to OMS template candidates, malformed ordinary notes downgrade to `MIGRATION_NOTE_INVALID` diagnostics instead of throwing, and `applyTemplateMigration` still rejects unresolved proposals so write safety is unchanged.
+
 ## [0.10.0] - 2026-09-01
 
 ### Changed

--- a/CHANGELOG-vendors.md
+++ b/CHANGELOG-vendors.md
@@ -4,6 +4,11 @@ Per-host adapter and installer changes belong here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex managed-marker rewrites fail closed on ambiguity.** (#54) The greedy regex span removal is replaced by a line scanner: exactly one ordered `BEGIN`/`END` pair enclosing `[mcp_servers.oms]` is rewritten in place; orphan, duplicate, reversed, or nested markers refuse to write a single byte and report the config path with 1-based marker line numbers plus manual removal steps. Marker-free legacy tables continue to be cleaned up normally.
+- **Hermes install/uninstall is now a guarded transaction.** (#89) `Prepare → Admission → Apply → Verify`: all sources, symlink targets, and the YAML edit are validated before any write; OMS-owned adapter/skill files commit first and `config.yaml` commits last via a pre-imaged atomic temp→rename write; verification reparses the config, any failure restores the config byte-for-byte, and a rollback failure preserves both errors. Registration failures are no longer downgraded to warnings.
+
 ## [0.10.0] - 2026-09-01
 
 ## [0.9.0] - 2026-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This aggregate changelog contains changes that span multiple layers.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Safety patch across CLI, kernel, and host adapters.** User-owned host configuration can no longer be damaged or silently skipped: Codex managed markers fail closed on ambiguity (#54), Hermes YAML is edited surgically inside a pre-imaged atomic transaction (#89), `--help` is side-effect-free everywhere (#55), and one malformed note or external Obsidian/Templater template source no longer disables vault-wide setup/doctor (#67).
+
 ## [0.10.0] - 2026-09-01
 
 ### Breaking

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -78,6 +78,18 @@ describe("CLI argument parser", () => {
     expect(parsed.unknownFlags).toEqual(["--runtime"]);
   });
 
+  it("parses help as a first-class flag rather than an unknown option", () => {
+    for (const args of [["--help"], ["-h"], ["setup", "--help"], ["mcp", "-h"]]) {
+      const parsed = parseCliArgs(args);
+
+      expect(parsed.help).toBe(true);
+      expect(parsed.unknownFlags).not.toContain("--help");
+      expect(parsed.unknownFlags).not.toContain("-h");
+    }
+    expect(parseCliArgs(["--help"]).command).toBeUndefined();
+    expect(parseCliArgs(["setup", "--help"]).command).toBe("setup");
+  });
+
   it("parses repeated link folders and distinguishes implicit vault defaults", () => {
     const implicit = parseCliArgs(["doctor"], "/tmp/oms-cli");
     const linked = parseCliArgs(

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -11,6 +11,7 @@ export class CliArgumentError extends Error {
 
 export interface ParsedCliArgs {
   readonly command: string | undefined;
+  readonly help: boolean;
   readonly vault: string;
   readonly vaultExplicit: boolean;
   readonly yes: boolean;
@@ -43,7 +44,9 @@ export function isRuntimeSelection(value: string): value is RuntimeSelection {
 }
 
 export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): ParsedCliArgs {
-  const command = argv[0];
+  const firstArg = argv[0];
+  const command = firstArg === "--help" || firstArg === "-h" ? undefined : firstArg;
+  let help = firstArg === "--help" || firstArg === "-h";
   let vault = cwd;
   let vaultExplicit = false;
   let yes = false;
@@ -70,7 +73,9 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
   for (let i = 1; i < argv.length; i++) {
     const arg = argv[i];
     const next = argv[i + 1];
-    if (arg === "--vault" && next) {
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--vault" && next) {
       vault = path.resolve(cwd, next);
       vaultExplicit = true;
       i++;
@@ -168,6 +173,7 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
 
   return {
     command,
+    help,
     vault,
     vaultExplicit,
     yes,
@@ -196,6 +202,7 @@ export function parseCliArgs(argv: readonly string[], cwd = process.cwd()): Pars
   function parsedArgsWithError(message: string): ParsedCliArgs {
     return {
       command,
+      help,
       vault,
       vaultExplicit,
       yes,

--- a/src/cli/host-operations.test.ts
+++ b/src/cli/host-operations.test.ts
@@ -86,6 +86,128 @@ describe("host installer/uninstaller", () => {
     expect(existsSync(path.join(codexDir, "skills", "oms-write"))).toBe(false);
   });
 
+  it("fails closed for ambiguous Codex managed markers while preserving config bytes", async () => {
+    const managedBlock = [
+      "# BEGIN OMS MANAGED MCP",
+      "# OMS MCP hookup for Codex CLI. Managed by `oms install/uninstall`.",
+      "[mcp_servers.oms]",
+      'command = "oms"',
+      "# END OMS MANAGED MCP",
+      "",
+    ].join("\n");
+    const fixtures = [
+      {
+        name: "orphan start",
+        content: `${managedBlock.replace("# END OMS MANAGED MCP\n", "")}[other]\nvalue = 1\n`,
+        markerLines: [1],
+      },
+      {
+        name: "orphan end",
+        content: 'model = "gpt-5"\n# END OMS MANAGED MCP\n',
+        markerLines: [2],
+      },
+      {
+        name: "duplicate pairs",
+        content: `${managedBlock}${managedBlock}`,
+        markerLines: [1, 5, 6, 10],
+      },
+      {
+        name: "nested markers",
+        content: [
+          "# BEGIN OMS MANAGED MCP",
+          "[mcp_servers.oms]",
+          "# BEGIN OMS MANAGED MCP",
+          "# END OMS MANAGED MCP",
+          "# END OMS MANAGED MCP",
+          "",
+        ].join("\n"),
+        markerLines: [1, 3, 4, 5],
+      },
+      {
+        name: "reversed markers",
+        content: "# END OMS MANAGED MCP\n[mcp_servers.oms]\n# BEGIN OMS MANAGED MCP\n",
+        markerLines: [1, 3],
+      },
+    ];
+
+    for (const fixture of fixtures) {
+      const home = await mkdtemp(path.join(tmpdir(), "oms-codex-ambiguous-"));
+      const configPath = path.join(home, ".codex", "config.toml");
+      await mkdir(path.dirname(configPath), { recursive: true });
+      await writeFile(configPath, fixture.content, "utf-8");
+
+      for (const action of ["install", "uninstall"] as const) {
+        const result = await runHostOperation({
+          action,
+          runtime: "codex",
+          vault: "/tmp/Vault",
+          homeDir: home,
+          adapterRoot,
+        });
+        expect(result[0]?.messages.join("\n"), fixture.name).toContain("FAILED:");
+        expect(result[0]?.messages.join("\n"), fixture.name).toContain(configPath);
+        for (const line of fixture.markerLines) {
+          expect(result[0]?.messages.join("\n"), fixture.name).toContain(`line ${line}`);
+        }
+        expect(result[0]?.messages.join("\n"), fixture.name).toContain("Manually remove every OMS managed MCP block");
+        expect(await readFile(configPath, "utf-8"), fixture.name).toBe(fixture.content);
+      }
+    }
+  });
+
+  it("replaces one valid Codex managed block in place and removes legacy-only config", async () => {
+    const prefix = 'model = "gpt-5"\n\n';
+    const suffix = '[other]\nvalue = "preserve me"\n';
+    const managedBlock = [
+      "# BEGIN OMS MANAGED MCP",
+      "# OMS MCP hookup for Codex CLI. Managed by `oms install/uninstall`.",
+      "[mcp_servers.oms]",
+      'command = "old-oms"',
+      "# END OMS MANAGED MCP",
+      "",
+    ].join("\n");
+    const home = await mkdtemp(path.join(tmpdir(), "oms-codex-valid-marker-"));
+    const configPath = path.join(home, ".codex", "config.toml");
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(configPath, `${prefix}${managedBlock}${suffix}`, "utf-8");
+
+    const installOptions = { action: "install" as const, runtime: "codex" as const, vault: "/tmp/Vault", homeDir: home, adapterRoot };
+    await runHostOperation(installOptions);
+    const installed = await readFile(configPath, "utf-8");
+    expect(installed.startsWith(prefix)).toBe(true);
+    expect(installed.endsWith(suffix)).toBe(true);
+    await runHostOperation(installOptions);
+    expect(await readFile(configPath, "utf-8")).toBe(installed);
+
+    await runHostOperation({ ...installOptions, action: "uninstall" });
+    expect(await readFile(configPath, "utf-8")).toBe(`${prefix}${suffix}`);
+
+    const legacyHome = await mkdtemp(path.join(tmpdir(), "oms-codex-legacy-"));
+    const legacyConfigPath = path.join(legacyHome, ".codex", "config.toml");
+    const legacy = 'model = "gpt-5"\n\n# OMS MCP hookup for Codex CLI. Managed by `oms install/uninstall`.\n[mcp_servers.oms]\ncommand = "oms"\n\n[other]\nvalue = 1\n';
+    await mkdir(path.dirname(legacyConfigPath), { recursive: true });
+    await writeFile(legacyConfigPath, legacy, "utf-8");
+    const legacyInstall = await runHostOperation({
+      action: "install",
+      runtime: "codex",
+      vault: "/tmp/Vault",
+      homeDir: legacyHome,
+      adapterRoot,
+    });
+    expect(legacyInstall[0]?.messages.join("\n")).not.toContain("FAILED:");
+    expect(await readFile(legacyConfigPath, "utf-8")).toContain("# BEGIN OMS MANAGED MCP");
+    await writeFile(legacyConfigPath, legacy, "utf-8");
+    const legacyResult = await runHostOperation({
+      action: "uninstall",
+      runtime: "codex",
+      vault: "/tmp/Vault",
+      homeDir: legacyHome,
+      adapterRoot,
+    });
+    expect(legacyResult[0]?.messages.join("\n")).not.toContain("FAILED:");
+    expect(await readFile(legacyConfigPath, "utf-8")).toBe('model = "gpt-5"\n\n[other]\nvalue = 1\n');
+  });
+
   it("removes only stale Codex OMS skill directories during install", async () => {
     const home = await mkdtemp(path.join(tmpdir(), "oms-install-codex-stale-"));
     const codexSkillsDir = path.join(home, ".codex", "skills");
@@ -591,8 +713,9 @@ describe("host installer/uninstaller", () => {
 
     const [result] = await runHostOperation({ action: "install", runtime: "hermes", vault: "/tmp/Vault", homeDir: home, adapterRoot });
 
-    expect(result?.messages.join(" ")).toContain("not a supported YAML mapping");
+    expect(result?.messages.join(" ")).toContain("Refusing unsafe YAML edit: root must be a mapping");
     expect(await readFile(configPath, "utf-8")).toBe("- not\n- a mapping\n");
+    expect(existsSync(path.join(home, ".hermes", "skills", "knowledge-management", "oms"))).toBe(false);
   });
 
   it("dry-run reports all host plans without mutating home", async () => {

--- a/src/cli/oms-dispatch.test.ts
+++ b/src/cli/oms-dispatch.test.ts
@@ -141,6 +141,46 @@ describe("oms CLI dispatch", () => {
     expect(result.stdout).not.toMatch(/semantic/u);
   });
 
+  it.each([
+    { command: [] },
+    { command: ["setup"] },
+    { command: ["doctor"] },
+    { command: ["index"] },
+    { command: ["search"] },
+    { command: ["mcp"] },
+    { command: ["install"] },
+  ])("prints usage without side effects for $command --help", async ({ command }) => {
+    const vault = await makeVault();
+    const beforeVault = snapshotDir(vault);
+    const beforeHome = snapshotDir(smokeHome);
+    const result = runCli([...command, "--help", "--vault", vault]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toMatch(/Usage:|OMS search and index:/u);
+    expect(result.stdout).not.toContain("Update available");
+    expect(snapshotDir(vault)).toBe(beforeVault);
+    expect(snapshotDir(smokeHome)).toBe(beforeHome);
+  });
+
+  it("prints usage for -h without side effects", async () => {
+    const vault = await makeVault();
+    const beforeVault = snapshotDir(vault);
+    const result = runCli(["-h", "--vault", vault]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Usage:");
+    expect(snapshotDir(vault)).toBe(beforeVault);
+  });
+
+  it("rejects an unknown command even when help is requested", () => {
+    const result = runCli(["setpu", "--help"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("[oms] Unknown command: setpu");
+  });
+
   it("reports unknown hook subcommand with exit code 1", () => {
     const result = runCli(["hook"]);
 

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -25,6 +25,7 @@ import { runLink } from "./link-command.js";
 import { runLinkify } from "./linkify.js";
 import { isSearchCliCommand, runSearchCli } from "./search.js";
 import { runSetup } from "./setup-command.js";
+import { searchUsage } from "./search-usage.js";
 import { maybePrintUpdateNotice } from "./update-notice.js";
 import { printUsage } from "./usage.js";
 
@@ -57,9 +58,43 @@ function shouldResolveBridgeVault(command: string | undefined, vaultExplicit: bo
   );
 }
 
+function isKnownCommand(command: string | undefined): boolean {
+  return (
+    command === undefined ||
+    command === "setup" ||
+    command === "link" ||
+    command === "install" ||
+    command === "uninstall" ||
+    command === "update" ||
+    command === "reconcile" ||
+    command === "doctor" ||
+    command === "audit" ||
+    command === "linkify" ||
+    command === "lint" ||
+    command === "mcp" ||
+    command === "hook" ||
+    isSearchCliCommand(command)
+  );
+}
+
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
   const parsedArgs = parseCliArgs(argv);
+  if (parsedArgs.help) {
+    if (!isKnownCommand(parsedArgs.command)) {
+      console.error(`[oms] Unknown command: ${parsedArgs.command}`);
+      printUsage();
+      process.exitCode = 1;
+      return;
+    }
+    if (isSearchCliCommand(parsedArgs.command)) {
+      console.log(searchUsage());
+    } else {
+      printUsage();
+    }
+    process.exitCode = 0;
+    return;
+  }
   if (parsedArgs.error !== undefined) {
     console.error(parsedArgs.error.message);
     process.exitCode = 1;

--- a/src/cli/setup-command.ts
+++ b/src/cli/setup-command.ts
@@ -61,6 +61,17 @@ export async function runSetup(opts: {
     ? undefined
     : modelsConfigFromAcquisitionManifest(modelManifest);
   const state = await inspectSetup({ vault, templateFolder });
+  if (state.proposal.unresolved.length > 0) {
+    console.log(JSON.stringify({
+      status: "blocked",
+      diagnostics: state.proposal.unresolved.map(({ code, path }) => ({
+        code,
+        ...(path === undefined ? {} : { path }),
+      })),
+    }, null, 2));
+    process.exitCode = 1;
+    return;
+  }
   const decision = await decideNonInteractiveSetup(state);
   const manifest = await composeSetup(decision, { base: { fields: {} } });
   if (dryRun) {

--- a/src/cli/setup.e2e.test.ts
+++ b/src/cli/setup.e2e.test.ts
@@ -106,6 +106,51 @@ describe("template-first setup", () => {
     expect(existsSync(path.join(root, ".oms"))).toBe(false);
   });
 
+  it("blocks unresolved notes before composing a setup manifest and emits no digest", async () => {
+    const root = await fresh();
+    await authority(root);
+    await mkdir(path.join(root, "Notes"), { recursive: true });
+    await writeFile(path.join(root, "Notes", "broken.md"), "---\ntitle: [unterminated\n---\n");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      await runSetup({ vault: root, yes: true, dryRun: true });
+      const output = log.mock.calls.map(call => call.join(" ")).join("\n");
+      expect(output).toContain('"status": "blocked"');
+      expect(output).toContain("MIGRATION_NOTE_INVALID");
+      expect(output).not.toContain("inputDigest");
+      expect(output).not.toContain("approvalDigest");
+      expect(output).not.toContain("outputDigest");
+      expect(existsSync(path.join(root, ".oms"))).toBe(false);
+    } finally {
+      log.mockRestore();
+      process.exitCode = undefined;
+    }
+  });
+
+  it("dry-runs configured external template sources without adopting them", async () => {
+    const root = await fresh();
+    await authority(root);
+    await noteTemplate(root);
+    await mkdir(path.join(root, "External", "Templater"), { recursive: true });
+    await writeFile(path.join(root, "External", "Templater", "source.template.md"), "{{ unsupported }}\n");
+    await mkdir(path.join(root, ".obsidian", "plugins", "templater-obsidian"), { recursive: true });
+    await writeFile(path.join(root, ".obsidian", "templates.json"), JSON.stringify({ folder: "External/Obsidian" }));
+    await writeFile(path.join(root, ".obsidian", "plugins", "templater-obsidian", "data.json"), JSON.stringify({
+      templates_folder: "External/Templater",
+    }));
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      await runSetup({ vault: root, yes: true, dryRun: true });
+      const output = log.mock.calls.map(call => call.join(" ")).join("\n");
+      expect(output).toContain("inputDigest");
+      expect(output).toContain("approvalDigest");
+      expect(output).toContain("outputDigest");
+      expect(output).not.toContain("External/Templater/source.template.md");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
   it("fails loudly without Obsidian type authority", async () => {
     const root = await fresh(); await noteTemplate(root);
     await expect(runSetup({ vault: root, yes: true, dryRun: true })).rejects.toThrow("MIGRATION_CONTROL_MISSING");

--- a/src/kernel/conventions/note-exclude.ts
+++ b/src/kernel/conventions/note-exclude.ts
@@ -95,15 +95,78 @@ async function loadExcludeMatchers(vaultRoot: string): Promise<RegExp[]> {
         }
       } catch (error) {
         if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-          return DEFAULT_EXCLUDE_GLOBS.map(globToRegExp);
+          declared = [];
+        } else {
+          failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `.oms/taxonomy.yaml: ${error instanceof Error ? error.message : String(error)}`);
         }
-        failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `.oms/taxonomy.yaml: ${error instanceof Error ? error.message : String(error)}`);
       }
-      return [...DEFAULT_EXCLUDE_GLOBS, ...declared].map(globToRegExp);
+      const externalTemplatePaths = await loadExternalTemplatePaths(key);
+      return [
+        ...DEFAULT_EXCLUDE_GLOBS,
+        ...declared,
+        ...externalTemplatePaths.flatMap((templatePath) => [templatePath, `${templatePath}/**`]),
+      ].map(globToRegExp);
     })();
     matcherCache.set(key, pending);
   }
   return pending;
+}
+
+function configuredPath(value: unknown, source: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    return failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `${source} must be a non-empty string`);
+  }
+  return normalizedPath(value.trim().replace(/\/+$/g, ""));
+}
+
+async function configuredJson(pathname: string): Promise<unknown | undefined> {
+  try {
+    return JSON.parse(await readFile(pathname, "utf-8")) as unknown;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return undefined;
+    return failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `${pathname}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function loadExternalTemplatePaths(vaultRoot: string): Promise<readonly string[]> {
+  const paths: string[] = [];
+  const obsidianTemplatesPath = path.join(vaultRoot, ".obsidian", "templates.json");
+  const obsidianTemplates = await configuredJson(obsidianTemplatesPath);
+  if (obsidianTemplates !== undefined) {
+    if (obsidianTemplates === null || typeof obsidianTemplates !== "object" || Array.isArray(obsidianTemplates)) {
+      failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `${obsidianTemplatesPath} must be an object`);
+    }
+    const folder = (obsidianTemplates as Record<string, unknown>)["folder"];
+    if (folder !== undefined) paths.push(configuredPath(folder, `${obsidianTemplatesPath}: folder`));
+  }
+
+  const templaterPath = path.join(vaultRoot, ".obsidian", "plugins", "templater-obsidian", "data.json");
+  const templater = await configuredJson(templaterPath);
+  if (templater !== undefined) {
+    if (templater === null || typeof templater !== "object" || Array.isArray(templater)) {
+      failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `${templaterPath} must be an object`);
+    }
+    const settings = templater as Record<string, unknown>;
+    if (settings["templates_folder"] !== undefined) {
+      paths.push(configuredPath(settings["templates_folder"], `${templaterPath}: templates_folder`));
+    }
+    const folderTemplates = settings["folder_templates"];
+    if (folderTemplates !== undefined) {
+      if (!Array.isArray(folderTemplates)) {
+        failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `${templaterPath}: folder_templates must be a list`);
+      }
+      for (const [index, entry] of folderTemplates.entries()) {
+        if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+          failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `${templaterPath}: folder_templates[${index}] must be an object`);
+        }
+        const template = (entry as Record<string, unknown>)["template"];
+        if (template !== undefined) {
+          paths.push(configuredPath(template, `${templaterPath}: folder_templates[${index}].template`));
+        }
+      }
+    }
+  }
+  return [...new Set(paths)].sort();
 }
 
 async function managedSourcePaths(vaultRoot: string): Promise<readonly string[]> {
@@ -153,9 +216,10 @@ export async function managedSourcePathSet(vaultRoot: string): Promise<ReadonlyS
  */
 export async function excludedNoteMatcher(
   vaultRoot: string,
+  includeManagedSources = true,
 ): Promise<(notePath: string) => boolean> {
   const matchers = await loadExcludeMatchers(vaultRoot);
-  const sources = new Set(await managedSourcePaths(vaultRoot));
+  const sources = includeManagedSources ? new Set(await managedSourcePaths(vaultRoot)) : new Set<string>();
   return (notePath: string) => {
     const normalized = normalizedPath(notePath);
     return sources.has(normalized) || matchers.some((pattern) => pattern.test(normalized));

--- a/src/kernel/install/common.ts
+++ b/src/kernel/install/common.ts
@@ -3,7 +3,7 @@ import { existsSync, lstatSync } from "node:fs";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { isMap, parseDocument } from "yaml";
+import { isAlias, isMap, isScalar, parseAllDocuments, stringify } from "yaml";
 import type { HostOperationOptions } from "./types.js";
 
 export class InstallTargetSymlinkError extends Error {
@@ -69,6 +69,205 @@ export type YamlEntryEdit =
   | { readonly kind: "set"; readonly value: Record<string, unknown> }
   | { readonly kind: "delete" };
 
+export class UnsafeYamlEditError extends Error {
+  constructor(message: string) {
+    super(`Refusing unsafe YAML edit: ${message}`);
+    this.name = "UnsafeYamlEditError";
+  }
+}
+
+export interface YamlEntryRender {
+  readonly changed: boolean;
+  readonly text: string;
+}
+
+type YamlPair = {
+  readonly key: unknown;
+  readonly value: unknown;
+};
+
+function lineStart(text: string, offset: number): number {
+  const index = text.lastIndexOf("\n", Math.max(0, offset - 1));
+  return index === -1 ? 0 : index + 1;
+}
+
+function lineEndIncludingNewline(text: string, offset: number): number {
+  const newline = text.indexOf("\n", offset);
+  return newline === -1 ? text.length : newline + 1;
+}
+
+function entryEnd(text: string, start: number, indent: string): number {
+  let cursor = lineEndIncludingNewline(text, start);
+  while (cursor < text.length) {
+    const end = lineEndIncludingNewline(text, cursor);
+    const line = text.slice(cursor, end).replace(/\r?\n$/, "");
+    if (line.trim() === "" || line.startsWith("#")) return cursor;
+    const leading = line.match(/^ */)?.[0].length ?? 0;
+    if (leading <= indent.length) return cursor;
+    cursor = end;
+  }
+  return cursor;
+}
+
+function pairFor(map: { items: unknown[] }, key: string): YamlPair | undefined {
+  let found: YamlPair | undefined;
+  for (const item of map.items) {
+    const pair = item as YamlPair;
+    if (!isScalar(pair.key) || typeof pair.key.value !== "string") {
+      throw new UnsafeYamlEditError("mapping keys must be unique scalars");
+    }
+    if (pair.key.value === key) {
+      if (found) throw new UnsafeYamlEditError(`duplicate key ${key}`);
+      found = pair;
+    }
+  }
+  return found;
+}
+
+function rejectUnsafeNodes(node: unknown): void {
+  if (node === null || typeof node !== "object") return;
+  const yamlNode = node as { anchor?: unknown; items?: unknown[]; value?: unknown };
+  if (yamlNode.anchor || isAlias(node)) throw new UnsafeYamlEditError("anchors and aliases are not supported");
+  if (Array.isArray(yamlNode.items)) {
+    for (const item of yamlNode.items) {
+      const pair = item as YamlPair;
+      if ("key" in pair) {
+        if (!isScalar(pair.key) || typeof pair.key.value !== "string") {
+          throw new UnsafeYamlEditError("mapping keys must be unique scalars");
+        }
+        if (pair.key.value === "<<") throw new UnsafeYamlEditError("merge keys are not supported");
+        rejectUnsafeNodes(pair.key);
+        rejectUnsafeNodes(pair.value);
+      } else {
+        rejectUnsafeNodes(item);
+      }
+    }
+  }
+  if ("value" in yamlNode) rejectUnsafeNodes(yamlNode.value);
+}
+
+function pairSpan(text: string, pair: YamlPair): readonly [number, number] {
+  if (!isScalar(pair.key) || !pair.key.range || !pair.value || typeof pair.value !== "object") {
+    throw new UnsafeYamlEditError("entry does not have a ranged scalar key and value");
+  }
+  const value = pair.value as { range?: readonly number[] };
+  if (!value.range || value.range.length < 3) throw new UnsafeYamlEditError("entry value has no source range");
+  const start = lineStart(text, pair.key.range[0]);
+  const valueEnd = value.range[1] ?? value.range[2];
+  if (valueEnd === undefined) throw new UnsafeYamlEditError("entry value has no source range");
+  const indent = text.slice(start, pair.key.range[0]);
+  const end = entryEnd(text, start, indent);
+  const beforeKey = text.slice(start, pair.key.range[0]);
+  if (!/^[ ]*$/.test(beforeKey)) {
+    throw new UnsafeYamlEditError("entry boundaries are ambiguous");
+  }
+  return [start, end];
+}
+
+function indentation(text: string, pair: YamlPair): string {
+  if (!isScalar(pair.key) || !pair.key.range) throw new UnsafeYamlEditError("mapping key has no source range");
+  return text.slice(lineStart(text, pair.key.range[0]), pair.key.range[0]);
+}
+
+function sectionWithEntry(
+  entryPath: readonly [string, string],
+  value: Record<string, unknown>,
+  indent: string,
+  eol: string,
+): string {
+  return `${indent}${entryPath[0]}:${eol}${indent}  ${entryPath[1]}:${eol}${renderValue(value, `${indent}  `, eol)}`;
+}
+
+function renderValue(value: Record<string, unknown>, indent: string, eol: string): string {
+  const rendered = stringify(value).replace(/\n$/, "");
+  return rendered
+    .split("\n")
+    .map((line) => `${indent}  ${line}`)
+    .join(eol);
+}
+
+/**
+ * Creates a surgical YAML edit. Callers that need transactional writes can
+ * commit `text` with their own atomic-write primitive.
+ */
+export function renderYamlEntryPreservingComments(
+  raw: string,
+  entryPath: readonly [string, string],
+  edit: YamlEntryEdit,
+): YamlEntryRender {
+  if (!Buffer.from(raw, "utf8").equals(Buffer.from(Buffer.from(raw, "utf8").toString("utf8"), "utf8"))) {
+    throw new UnsafeYamlEditError("file is not losslessly representable as UTF-8");
+  }
+  if (/(^|\n)[ ]*\t/m.test(raw)) throw new UnsafeYamlEditError("tab indentation is not supported");
+  if (raw.trim() === "") {
+    if (edit.kind === "delete") return { changed: false, text: raw };
+    const emptyEol = raw.includes("\r\n") ? "\r\n" : "\n";
+    return { changed: true, text: `${sectionWithEntry(entryPath, edit.value, "", emptyEol)}${emptyEol}` };
+  }
+  const documents = parseAllDocuments(raw, { keepSourceTokens: true });
+  const doc = documents[0];
+  if (documents.length !== 1 || !doc || doc.errors.length > 0) {
+    throw new UnsafeYamlEditError("document must be one valid YAML document");
+  }
+  if (doc.contents !== null && !isMap(doc.contents)) throw new UnsafeYamlEditError("root must be a mapping");
+  rejectUnsafeNodes(doc.contents);
+  const eol = raw.includes("\r\n") ? "\r\n" : "\n";
+  if (raw.includes("\r\n") && /(^|[^\r])\n/.test(raw)) throw new UnsafeYamlEditError("mixed line endings");
+  const root = doc.contents;
+  const section = root === null ? undefined : pairFor(root, entryPath[0]);
+
+  if (section && section.value !== null && !isMap(section.value)) {
+    throw new UnsafeYamlEditError(`${entryPath[0]} must be a mapping`);
+  }
+  const sectionMap = section && isMap(section.value) ? section.value : undefined;
+  const entry = sectionMap ? pairFor(sectionMap, entryPath[1]) : undefined;
+  if (edit.kind === "delete") {
+    if (!entry) return { changed: false, text: raw };
+    if (section && sectionMap && sectionMap.items.length === 1) {
+      const [start, end] = pairSpan(raw, section);
+      const indent = indentation(raw, section);
+      const replacement = `${indent}${entryPath[0]}: {}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
+      return { changed: true, text: `${raw.slice(0, start)}${replacement}${raw.slice(end)}` };
+    }
+    const [start, end] = pairSpan(raw, entry);
+    const text = `${raw.slice(0, start)}${raw.slice(end)}`;
+    if (`${raw.slice(0, start)}${raw.slice(end)}` !== text) throw new UnsafeYamlEditError("splice integrity check failed");
+    return { changed: true, text };
+  }
+  if (entry) {
+    const [start, end] = pairSpan(raw, entry);
+    const indent = indentation(raw, entry);
+    const replacement = `${indent}${entryPath[1]}:${eol}${renderValue(edit.value, indent, eol)}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
+    const text = `${raw.slice(0, start)}${replacement}${raw.slice(end)}`;
+    return { changed: text !== raw, text };
+  }
+  if (root && root.items.length === 0) {
+    if (raw.trim() !== "{}") throw new UnsafeYamlEditError("empty mappings with source ambiguity are not supported");
+    const prefix = raw.slice(0, raw.indexOf("{"));
+    const suffix = raw.slice(raw.lastIndexOf("}") + 1);
+    const text = `${prefix}${sectionWithEntry(entryPath, edit.value, "", eol)}${suffix}`;
+    return { changed: true, text };
+  }
+  if (!root) throw new UnsafeYamlEditError("empty document was not handled");
+  if (section && sectionMap && sectionMap.items.length === 0) {
+    const [start, end] = pairSpan(raw, section);
+    const indent = indentation(raw, section);
+    const replacement = `${indent}${entryPath[0]}:${eol}${indent}  ${entryPath[1]}:${eol}${renderValue(edit.value, `${indent}  `, eol)}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
+    return { changed: true, text: `${raw.slice(0, start)}${replacement}${raw.slice(end)}` };
+  }
+  const last = sectionMap?.items.at(-1) as YamlPair | undefined;
+  if (last) {
+    const [, end] = pairSpan(raw, last);
+    const indent = indentation(raw, last);
+    const fragment = `${indent}${entryPath[1]}:${eol}${renderValue(edit.value, indent, eol)}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
+    return { changed: true, text: `${raw.slice(0, end)}${fragment}${raw.slice(end)}` };
+  }
+  const rootLast = root.items.at(-1) as YamlPair;
+  const [, end] = pairSpan(raw, rootLast);
+  const fragment = `${sectionWithEntry(entryPath, edit.value, "", eol)}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
+  return { changed: true, text: `${raw.slice(0, end)}${fragment}${raw.slice(end)}` };
+}
+
 /**
  * Applies one `section.key` edit to a YAML file while leaving every other byte,
  * comment, and key ordering the document already had in place.
@@ -78,18 +277,13 @@ export async function editYamlEntryPreservingComments(
   entryPath: readonly [string, string],
   edit: YamlEntryEdit,
 ): Promise<boolean> {
-  const raw = existsSync(file) ? await readFile(file, "utf-8") : "";
-  const doc = parseDocument(raw);
-  if (doc.errors.length > 0) return false;
-  if (doc.contents !== null && !isMap(doc.contents)) return false;
-  if (edit.kind === "delete") {
-    if (!doc.hasIn(entryPath)) return false;
-    doc.deleteIn(entryPath);
-  } else {
-    doc.setIn(entryPath, edit.value);
-  }
+  const rawBytes = existsSync(file) ? await readFile(file) : Buffer.alloc(0);
+  const raw = rawBytes.toString("utf8");
+  if (!rawBytes.equals(Buffer.from(raw, "utf8"))) throw new UnsafeYamlEditError("file is not valid UTF-8");
+  const rendered = renderYamlEntryPreservingComments(raw, entryPath, edit);
+  if (!rendered.changed) return false;
   await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, doc.toString(), "utf-8");
+  await writeFile(file, rendered.text, "utf-8");
   return true;
 }
 

--- a/src/kernel/install/yaml-edit.test.ts
+++ b/src/kernel/install/yaml-edit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  UnsafeYamlEditError,
+  renderYamlEntryPreservingComments,
+} from "./common.js";
+
+const entry = { command: "oms", args: ["mcp", "--vault", "/vault"], enabled: true };
+const path = ["mcp_servers", "oms"] as const;
+
+describe("renderYamlEntryPreservingComments", () => {
+  it("splices only the oms entry while retaining Korean text, BOM, CRLF, and comments", () => {
+    const raw = "\uFEFF# 앞\r\nmcp_servers:\r\n  other: keep # 유지\r\n  oms:\r\n    command: old\r\n# 뒤\r\n";
+    const result = renderYamlEntryPreservingComments(raw, path, { kind: "set", value: entry });
+    expect(result.changed).toBe(true);
+    expect(result.text.startsWith("\uFEFF# 앞\r\nmcp_servers:\r\n  other: keep # 유지\r\n")).toBe(true);
+    expect(result.text).toContain("# 뒤\r\n");
+    expect(result.text).toContain("    command: oms\r\n");
+  });
+
+  it("is idempotent and preserves a missing-entry document through deletion", () => {
+    const raw = "name: 한글\n# keep\nmcp_servers:\n  other: keep\n";
+    const inserted = renderYamlEntryPreservingComments(raw, path, { kind: "set", value: entry });
+    const again = renderYamlEntryPreservingComments(inserted.text, path, { kind: "set", value: entry });
+    expect(again.text).toBe(inserted.text);
+    const removed = renderYamlEntryPreservingComments(inserted.text, path, { kind: "delete" });
+    expect(removed.text).toBe(raw);
+  });
+
+  it("rejects ambiguous YAML constructs before any write", () => {
+    for (const raw of [
+      "mcp_servers: &servers {}\n",
+      "mcp_servers: *servers\n",
+      "mcp_servers:\n\toms: {}\n",
+      "mcp_servers:\n  oms: {}\n  oms: {}\n",
+    ]) {
+      expect(() => renderYamlEntryPreservingComments(raw, path, { kind: "set", value: entry })).toThrow(UnsafeYamlEditError);
+    }
+  });
+});

--- a/src/kernel/templates/migration.test.ts
+++ b/src/kernel/templates/migration.test.ts
@@ -33,6 +33,44 @@ describe("template migration planner", () => {
     expect(proposal.candidates[0]?.templateId).toBe("reading");
   });
 
+  it("excludes Obsidian and Templater sources from notes without adopting them as candidates", async () => {
+    const root = await fresh();
+    await template(root, "Templates/note.md");
+    await template(root, "External/Obsidian/template.md", "{{ unsupported }}\n");
+    await template(root, "External/Templater/mail-thread.template.md", "{{ unsupported }}\n");
+    await mkdir(path.join(root, ".obsidian", "plugins", "templater-obsidian"), { recursive: true });
+    await writeFile(path.join(root, ".obsidian", "templates.json"), JSON.stringify({ folder: "External/Obsidian" }));
+    await writeFile(path.join(root, ".obsidian", "plugins", "templater-obsidian", "data.json"), JSON.stringify({
+      templates_folder: "External/Templater",
+      folder_templates: [{ folder: "mail", template: "External/Templater/mail-thread.template.md" }],
+    }));
+    await writeFile(path.join(root, ".obsidian", "types.json"), JSON.stringify({ types: { template: "string" } }));
+
+    const proposal = await planTemplateMigration(root);
+    expect(proposal.candidates.map(candidate => candidate.sourcePath)).toEqual(["Templates/note.md"]);
+    expect(proposal.existingNotes.map(note => note.path)).not.toContain("External/Obsidian/template.md");
+    expect(proposal.existingNotes.map(note => note.path)).not.toContain("External/Templater/mail-thread.template.md");
+    expect(proposal.diagnostics.map(diagnostic => diagnostic.path)).not.toContain("External/Obsidian/template.md");
+    expect(proposal.diagnostics.map(diagnostic => diagnostic.path)).not.toContain("External/Templater/mail-thread.template.md");
+    expect(proposal.unresolved).toEqual([]);
+
+    const defaultManifest = await buildMigrationManifest(root, proposal, { base: { fields: {} } });
+    const explicitProposal = await planTemplateMigration(root, { templateFolder: "Templates" });
+    const explicitManifest = await buildMigrationManifest(root, explicitProposal, { base: { fields: {} } });
+    expect(defaultManifest.approvalDigest).toBe(explicitManifest.approvalDigest);
+  });
+
+  it("reports malformed ordinary notes instead of throwing and still rejects activation", async () => {
+    const root = await fresh();
+    await template(root, "Notes/broken.md", "---\ntitle: [unterminated\n---\n");
+    const proposal = await planTemplateMigration(root);
+    expect(proposal.unresolved).toContainEqual(expect.objectContaining({
+      code: "MIGRATION_NOTE_INVALID",
+      path: "Notes/broken.md",
+    }));
+    await expect(applyTemplateMigration(root, proposal, noManifest, { approvedDigest: approval })).rejects.toThrow("MIGRATION_UNRESOLVED_MAPPING");
+  });
+
   it("imports an explicitly registered external source without rewriting bytes", async () => {
     const root = await fresh();
     const bytes = "---\ntemplate: imported\n---\ncustom body\n";

--- a/src/kernel/templates/migration.ts
+++ b/src/kernel/templates/migration.ts
@@ -4,6 +4,7 @@ import { lstat, readdir, readFile } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import { parseDocument, stringify } from "yaml";
 import { parseNote } from "../conventions/frontmatter.js";
+import { excludedNoteMatcher } from "../conventions/note-exclude.js";
 
 import { approvalDigest, inputDigest, outputDigest } from "./canonical.js";
 import { parseTemplate } from "./extract.js";
@@ -18,7 +19,7 @@ import type { AuthorityEntry, BaseContract, ContractDefinition, DerivedProjectio
 const encoder = new TextEncoder();
 
 type LegacySource = ".oms/types.json" | ".oms/concepts" | ".oms/taxonomy.yaml";
-export type MigrationDiagnosticCode = "MIGRATION_UNRESOLVED_MAPPING" | "TEMPLATE_ID_DUPLICATE" | "TEMPLATE_SOURCE_DUPLICATE" | "MIGRATION_TEMPLATE_UNSAFE" | "MIGRATION_TEMPLATE_INVALID" | "MIGRATION_NOTE_IDENTITY_UNRESOLVED" | "MIGRATION_TAXONOMY_INVALID";
+export type MigrationDiagnosticCode = "MIGRATION_UNRESOLVED_MAPPING" | "TEMPLATE_ID_DUPLICATE" | "TEMPLATE_SOURCE_DUPLICATE" | "MIGRATION_TEMPLATE_UNSAFE" | "MIGRATION_TEMPLATE_INVALID" | "MIGRATION_NOTE_INVALID" | "MIGRATION_NOTE_IDENTITY_UNRESOLVED" | "MIGRATION_TAXONOMY_INVALID";
 export interface MigrationDiagnostic { readonly code: MigrationDiagnosticCode; readonly message: string; readonly path?: string; readonly templateId?: TemplateId; }
 export interface RegisteredTemplate { readonly templateId: string; readonly sourcePath: string; }
 export interface TemplateCandidate { readonly templateId: TemplateId; readonly sourcePath: TemplateSourcePath; readonly bytes: Uint8Array; readonly destinationClass: DestinationClass; }
@@ -142,8 +143,9 @@ function conceptsFromTaxonomy(entries: readonly LegacyLedgerEntry[], diagnostics
   return values.sort((left, right) => left.concept.localeCompare(right.concept) || left.folder.localeCompare(right.folder));
 }
 
-async function notes(root: string, sources: ReadonlySet<string>): Promise<ExistingNoteIdentity[]> {
+async function notes(root: string, sources: ReadonlySet<string>, diagnostics: MigrationDiagnostic[]): Promise<ExistingNoteIdentity[]> {
   const values: ExistingNoteIdentity[] = [];
+  const isExcluded = await excludedNoteMatcher(root, false);
   const visit = async (directory: string): Promise<void> => {
     for (const entry of await readdir(directory, { withFileTypes: true })) {
       if (entry.name.startsWith(".")) continue;
@@ -151,10 +153,13 @@ async function notes(root: string, sources: ReadonlySet<string>): Promise<Existi
       if (entry.isDirectory()) { await visit(absolute); continue; }
       if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
       const path = relative(root, absolute).replaceAll("\\", "/");
-      if (sources.has(path)) continue;
+      if (sources.has(path) || isExcluded(path)) continue;
       const content = await readFile(absolute, "utf8");
       const parsed = parseNote(content);
-      if (parsed.diagnostics.length > 0) throw new Error(`MIGRATION_NOTE_INVALID: ${path}`);
+      if (parsed.diagnostics.length > 0) {
+        diagnostics.push(issue("MIGRATION_NOTE_INVALID", "Existing note frontmatter is invalid", path));
+        continue;
+      }
       const fields = parsed.frontmatter;
       values.push({ path, templateId: typeof fields.template === "string" ? fields.template : null, legacyConcept: typeof fields.concept === "string" ? fields.concept : null });
     }
@@ -238,7 +243,7 @@ export async function planTemplateMigration(vault: string, options: MigrationOpt
     ...candidates.map(candidate => candidate.sourcePath),
   ])].sort();
   const effectiveIds = new Set(candidates.map(candidate => candidate.templateId));
-  const existingNotes = await notes(root, new Set(managedSourcePaths));
+  const existingNotes = await notes(root, new Set(managedSourcePaths), diagnostics);
   const managedFolders = new Set(taxonomyBindings.map(binding => binding.folder.replace(/\/+$/g, "")));
   for (const note of existingNotes) {
     const stableNoteId = note.templateId === null ? null : stableId(note.templateId);

--- a/src/vendors/codex/codex.ts
+++ b/src/vendors/codex/codex.ts
@@ -33,12 +33,89 @@ function isCodexOMSTable(line: string): boolean {
   return line === "[mcp_servers.oms]" || line.startsWith("[mcp_servers.oms.");
 }
 
-function removeManagedCodexBlock(content: string): { content: string; removed: boolean } {
-  const start = MANAGED_CODEX_START.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const end = MANAGED_CODEX_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const markerPattern = new RegExp(`\\n?${start}[\\s\\S]*?${end}\\n?`, "g");
-  const withoutMarkers = content.replace(markerPattern, "\n");
-  const markerRemoved = withoutMarkers !== content;
+type CodexManagedMarker = {
+  readonly token: typeof MANAGED_CODEX_START | typeof MANAGED_CODEX_END;
+  readonly line: number;
+  readonly offset: number;
+};
+
+type ManagedCodexBlock = {
+  readonly start: number;
+  readonly end: number;
+};
+
+export class CodexManagedBlockAmbiguousError extends Error {
+  constructor(configPath: string, markers: readonly CodexManagedMarker[]) {
+    const locations = markers.length === 0
+      ? "none"
+      : markers.map((marker) => `${marker.token} (line ${marker.line})`).join(", ");
+    super(
+      `Ambiguous OMS managed MCP markers in ${configPath}: ${locations}. `
+      + "No changes were made. Manually remove every OMS managed MCP block and its markers, then rerun oms install or uninstall.",
+    );
+    this.name = "CodexManagedBlockAmbiguousError";
+  }
+}
+
+function scanCodexManagedMarkers(content: string): CodexManagedMarker[] {
+  const markers: CodexManagedMarker[] = [];
+  let offset = 0;
+  let line = 1;
+  for (const sourceLine of content.split(/(?<=\n)/)) {
+    let position = 0;
+    while (position < sourceLine.length) {
+      const start = sourceLine.indexOf(MANAGED_CODEX_START, position);
+      const end = sourceLine.indexOf(MANAGED_CODEX_END, position);
+      if (start === -1 && end === -1) break;
+      const isStart = start !== -1 && (end === -1 || start < end);
+      const token = isStart ? MANAGED_CODEX_START : MANAGED_CODEX_END;
+      const tokenOffset = isStart ? start : end;
+      markers.push({ token, line, offset: offset + tokenOffset });
+      position = tokenOffset + token.length;
+    }
+    offset += sourceLine.length;
+    line++;
+  }
+  return markers;
+}
+
+function managedCodexBlock(content: string, configPath: string): ManagedCodexBlock | undefined {
+  const markers = scanCodexManagedMarkers(content);
+  if (markers.length === 0) return undefined;
+  if (
+    markers.length !== 2
+    || markers[0]?.token !== MANAGED_CODEX_START
+    || markers[1]?.token !== MANAGED_CODEX_END
+  ) {
+    throw new CodexManagedBlockAmbiguousError(configPath, markers);
+  }
+  const start = markers[0];
+  const end = markers[1];
+  if (
+    start === undefined
+    || end === undefined
+    || start.offset >= end.offset
+    || start.line >= end.line
+    || !content.slice(start.offset, end.offset).includes("[mcp_servers.oms]")
+  ) {
+    throw new CodexManagedBlockAmbiguousError(configPath, markers);
+  }
+
+  let blockEnd = end.offset + MANAGED_CODEX_END.length;
+  if (content.slice(blockEnd, blockEnd + 2) === "\r\n") blockEnd += 2;
+  else if (content[blockEnd] === "\n") blockEnd++;
+  return { start: start.offset, end: blockEnd };
+}
+
+function removeManagedCodexBlock(
+  content: string,
+  configPath: string,
+): { content: string; removed: boolean; block: ManagedCodexBlock | undefined } {
+  const block = managedCodexBlock(content, configPath);
+  const withoutMarkers = block === undefined
+    ? content
+    : `${content.slice(0, block.start)}${content.slice(block.end)}`;
+  const markerRemoved = block !== undefined;
   const lines = withoutMarkers.split(/\r?\n/);
   const output: string[] = [];
   let removedLegacy = false;
@@ -65,7 +142,14 @@ function removeManagedCodexBlock(content: string): { content: string; removed: b
     }
     output.push(line);
   }
-  return { content: `${output.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`, removed: markerRemoved || removedLegacy };
+  if (markerRemoved && !removedLegacy) {
+    return { content: withoutMarkers, removed: true, block };
+  }
+  return {
+    content: `${output.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`,
+    removed: markerRemoved || removedLegacy,
+    block,
+  };
 }
 
 async function installCodexNativeArtifacts(
@@ -119,8 +203,10 @@ export async function installCodex(options: HostOperationOptions, host: HarnessH
   const guidanceTarget = path.join(codexDir, "plugins", "oms", "AGENTS.md");
   const configPath = path.join(codexDir, "config.toml");
   const original = existsSync(configPath) ? await readFile(configPath, "utf-8") : "";
-  const stripped = removeManagedCodexBlock(original).content;
-  const next = `${stripped.trimEnd()}\n\n${codexManagedBlock(options)}`;
+  const removed = removeManagedCodexBlock(original, configPath);
+  const next = removed.block === undefined
+    ? `${removed.content.trimEnd()}\n\n${codexManagedBlock(options)}`
+    : `${original.slice(0, removed.block.start)}${codexManagedBlock(options)}${original.slice(removed.block.end)}`;
   let nativePaths: string[] = [];
   if (!options.dryRun) {
     await mkdir(path.dirname(configPath), { recursive: true });
@@ -155,7 +241,7 @@ export async function uninstallCodex(options: HostOperationOptions): Promise<Hos
   let changed = false;
   if (existsSync(configPath)) {
     const original = await readFile(configPath, "utf-8");
-    const removed = removeManagedCodexBlock(original);
+    const removed = removeManagedCodexBlock(original, configPath);
     changed = removed.removed;
     if (removed.removed && !options.dryRun) await writeFile(configPath, removed.content, "utf-8");
   }

--- a/src/vendors/hermes/hermes.test.ts
+++ b/src/vendors/hermes/hermes.test.ts
@@ -1,0 +1,36 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { harnessSurfaceRegistry } from "../../kernel/harness/surface-registry.js";
+import { installHermes } from "./hermes.js";
+
+const temporaryDirectories: string[] = [];
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("installHermes transaction", () => {
+  it("rejects an unsafe config before writing OMS-owned targets", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const hermes = path.join(home, ".hermes");
+    const config = path.join(hermes, "config.yaml");
+    const original = "mcp_servers: &servers {}\n";
+    await mkdir(hermes);
+    await writeFile(config, original);
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+
+    await expect(installHermes({
+      action: "install",
+      runtime: "hermes",
+      vault: "/vault",
+      homeDir: home,
+      adapterRoot: path.resolve("."),
+    }, host)).rejects.toThrow("unsafe YAML edit");
+
+    expect(await readFile(config, "utf8")).toBe(original);
+    await expect(readFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"))).rejects.toThrow();
+  });
+});

--- a/src/vendors/hermes/hermes.ts
+++ b/src/vendors/hermes/hermes.ts
@@ -1,10 +1,17 @@
-import { existsSync } from "node:fs";
-import { cp, mkdir, rm } from "node:fs/promises";
+import { existsSync, lstatSync } from "node:fs";
+import { cp, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { parseDocument } from "yaml";
 import type { HarnessHostSurface } from "../../kernel/harness/surface-registry.js";
 import { resolveHostAdapterSource } from "../../kernel/install/adapter-source.js";
 import { resolveSharedSkillsSource } from "../../assets/shared-skills.js";
-import { editYamlEntryPreservingComments, hostHome, mcpServerEntry, replaceDirectory } from "../../kernel/install/common.js";
+import {
+  InstallTargetSymlinkError,
+  hostHome,
+  mcpServerEntry,
+  renderYamlEntryPreservingComments,
+  replaceDirectory,
+} from "../../kernel/install/common.js";
 import type { HostOperationOptions, HostOperationResult } from "../../kernel/install/types.js";
 
 const HERMES_SKILL_CATEGORY = "knowledge-management";
@@ -12,17 +19,35 @@ const HERMES_SKILL_NAME = "oms";
 
 const HERMES_MCP_ENTRY_PATH = ["mcp_servers", "oms"] as const;
 
-async function upsertHermesMcp(options: HostOperationOptions, hermesConfig: string): Promise<boolean> {
-  if (options.dryRun) return false;
-  return editYamlEntryPreservingComments(hermesConfig, HERMES_MCP_ENTRY_PATH, {
-    kind: "set",
-    value: { ...mcpServerEntry(options), enabled: true },
-  });
+function refuseSymlink(target: string): void {
+  if (existsSync(target) && lstatSync(target).isSymbolicLink()) {
+    throw new InstallTargetSymlinkError(target);
+  }
 }
 
-async function removeHermesMcp(options: HostOperationOptions, hermesConfig: string): Promise<boolean> {
-  if (options.dryRun) return false;
-  return editYamlEntryPreservingComments(hermesConfig, HERMES_MCP_ENTRY_PATH, { kind: "delete" });
+async function atomicWrite(file: string, content: Buffer): Promise<void> {
+  await mkdir(path.dirname(file), { recursive: true });
+  const temporary = path.join(path.dirname(file), `.${path.basename(file)}.oms-${process.pid}-${Date.now()}`);
+  await writeFile(temporary, content);
+  await rename(temporary, file);
+}
+
+async function rollbackConfig(configPath: string, preImage: Buffer | undefined, original: unknown): Promise<never> {
+  try {
+    if (preImage === undefined) await rm(configPath, { force: true });
+    else await atomicWrite(configPath, preImage);
+  } catch (rollbackError) {
+    throw new AggregateError([original, rollbackError], "Hermes operation failed and config rollback also failed");
+  }
+  throw original;
+}
+
+async function verifyHermesMcp(configPath: string): Promise<void> {
+  const raw = existsSync(configPath) ? await readFile(configPath) : Buffer.alloc(0);
+  const document = parseDocument(raw.toString("utf8"));
+  if (document.errors.length > 0 || !document.hasIn(HERMES_MCP_ENTRY_PATH)) {
+    throw new Error("Hermes config verification failed: mcp_servers.oms is missing");
+  }
 }
 
 export async function installHermes(options: HostOperationOptions, host: HarnessHostSurface): Promise<HostOperationResult> {
@@ -39,16 +64,32 @@ export async function installHermes(options: HostOperationOptions, host: Harness
   const readmeTarget = path.join(adapterTarget, "README.md");
   const messages = ["Installed Hermes-native Oh My Second Brain skill bundle and registered mcp_servers.oms in ~/.hermes/config.yaml."];
   if (!options.dryRun) {
-    await rm(legacyPluginTarget, { recursive: true, force: true });
-    await rm(legacyMcpPath, { force: true });
-    await rm(adapterTarget, { recursive: true, force: true });
-    await mkdir(adapterTarget, { recursive: true });
-    await cp(path.join(adapterSource, "hermes-manifest.json"), adapterManifestTarget);
-    await cp(path.join(adapterSource, "hermes", "SOUL.md"), guidanceTarget);
-    await cp(path.join(adapterSource, "hermes", "README.md"), readmeTarget);
-    await replaceDirectory(skillSource, skillTarget, false);
-    if (!(await upsertHermesMcp(options, configPath))) {
-      messages.push(`WARNING: ${configPath} is not a supported YAML mapping; mcp_servers.oms was not registered. Add it manually.`);
+    // Prepare + admission: all input and host safety checks precede every write.
+    for (const source of [skillSource, path.join(adapterSource, "hermes-manifest.json"), path.join(adapterSource, "hermes", "SOUL.md"), path.join(adapterSource, "hermes", "README.md")]) {
+      if (!existsSync(source)) throw new Error(`Hermes install source is missing: ${source}`);
+    }
+    for (const target of [legacyPluginTarget, legacyMcpPath, adapterTarget, skillTarget, configPath]) refuseSymlink(target);
+    const preImage = existsSync(configPath) ? await readFile(configPath) : undefined;
+    const configRaw = preImage?.toString("utf8") ?? "";
+    if (preImage && !preImage.equals(Buffer.from(configRaw, "utf8"))) throw new Error("Hermes config.yaml is not valid UTF-8");
+    const config = renderYamlEntryPreservingComments(configRaw, HERMES_MCP_ENTRY_PATH, {
+      kind: "set",
+      value: { ...mcpServerEntry(options), enabled: true },
+    });
+    try {
+      // OMS-owned files commit first. config.yaml is deliberately the final commit.
+      await rm(legacyPluginTarget, { recursive: true, force: true });
+      await rm(legacyMcpPath, { force: true });
+      await rm(adapterTarget, { recursive: true, force: true });
+      await mkdir(adapterTarget, { recursive: true });
+      await cp(path.join(adapterSource, "hermes-manifest.json"), adapterManifestTarget);
+      await cp(path.join(adapterSource, "hermes", "SOUL.md"), guidanceTarget);
+      await cp(path.join(adapterSource, "hermes", "README.md"), readmeTarget);
+      await replaceDirectory(skillSource, skillTarget, false);
+      if (config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
+      await verifyHermesMcp(configPath);
+    } catch (error) {
+      await rollbackConfig(configPath, preImage, error);
     }
   }
   return {
@@ -69,12 +110,26 @@ export async function uninstallHermes(options: HostOperationOptions): Promise<Ho
   const legacyPluginTarget = path.join(hermesDir, "plugins", "oms");
   const legacyMcpPath = path.join(hermesDir, "mcp", "oms.json");
   const configPath = path.join(hermesDir, "config.yaml");
+  const preImage = existsSync(configPath) ? await readFile(configPath) : undefined;
+  const configRaw = preImage?.toString("utf8") ?? "";
+  if (preImage && !preImage.equals(Buffer.from(configRaw, "utf8"))) throw new Error("Hermes config.yaml is not valid UTF-8");
+  for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath, configPath]) refuseSymlink(target);
+  const config = renderYamlEntryPreservingComments(configRaw, HERMES_MCP_ENTRY_PATH, { kind: "delete" });
   let changed = false;
-  if (existsSync(configPath)) changed = (await removeHermesMcp(options, configPath)) || changed;
+  changed = config.changed;
   for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath]) {
     if (existsSync(target)) {
       changed = true;
-      if (!options.dryRun) await rm(target, { recursive: true, force: true });
+    }
+  }
+  if (!options.dryRun) {
+    try {
+      for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath]) {
+        await rm(target, { recursive: true, force: true });
+      }
+      if (config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
+    } catch (error) {
+      await rollbackConfig(configPath, preImage, error);
     }
   }
   return {


### PR DESCRIPTION
Safety patch for oms-v0.10.1 (release R1 of the approved consensus plan).

Closes #54, closes #55, closes #67, closes #89.

- #89: surgical YAML entry splicing (character-range, UTF-8 gated, unsafe YAML rejected) + Hermes install/uninstall as a Prepare→Admission→Apply→Verify transaction with pre-imaged atomic config commit last and byte-exact rollback.
- #54: Codex managed markers fail closed on orphan/duplicate/reversed/nested pairs with 1-based line diagnostics; legacy marker-free cleanup preserved.
- #55: --help/-h are first-class and side-effect-free across all commands, exit 0, no vault/host/MCP/update-notice access; unknown command + --help still exits 1.
- #67: external Obsidian/Templater template folders are exclusion-only (never migration candidates; approval digests unchanged), malformed notes downgrade to diagnostics, setup dry-run reports blocked without a digest.

No new dependencies. Verification: npm run lint, npm run build, npm test (1343 passed / 11 skipped), focused vitest per issue.
