### PR TITLE
R1 boundary-review fixes: fail-closed marker/YAML ownership, Hermes transaction hardening (#54 #55 #67 #89)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -43,7 +43,12 @@ oms mcp        stdio MCP 서버 시작
 oms hook       Claude pre/post tool-use 볼트 가드 실행
 ```
 
-`oh-my-second-brain`이 전체 명령이고 `oms`는 짧은 별칭이다.
+`oh-my-second-brain`은 전체 명령이고 `oms`는 짧은 별칭이다.
+
+### 도움말 계약
+
+인식된 모든 명령은 `--help`와 `-h`를 받아들이며, exit 0으로 종료하고
+부작용을 수행하지 않는다. 알 수 없는 명령에 `--help`를 함께 주면 exit 1로 종료한다.
 
 `oms search <text>`는 lexical-only다. `--vec`, `--hyde`는 각각의 typed
 channel을 선택하고, `--expand`는 G004 expansion을 명시적으로 켜며,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ oms hook       Run Claude pre/post tool-use vault guards
 
 `oh-my-second-brain` is the full command; `oms` is its short alias.
 
+### Help contract
+
+Every recognized command accepts `--help` and `-h`, exits 0, and performs no
+side effects. An unknown command combined with `--help` exits 1.
+
 `oms search <text>` is lexical-only. `--vec` and `--hyde` select their respective
 typed channels; `--expand` explicitly enables G004 expansion, `--max-queries`
 accepts an integer from 1 through 32, and `--rerank` is opt-in. `oms embed` is

--- a/src/cli/host-operations.test.ts
+++ b/src/cli/host-operations.test.ts
@@ -128,6 +128,11 @@ describe("host installer/uninstaller", () => {
         content: "# END OMS MANAGED MCP\n[mcp_servers.oms]\n# BEGIN OMS MANAGED MCP\n",
         markerLines: [1, 3],
       },
+      {
+        name: "marker token inside a TOML string",
+        content: 'model = "# BEGIN OMS MANAGED MCP"\n',
+        markerLines: [1],
+      },
     ];
 
     for (const fixture of fixtures) {
@@ -157,13 +162,13 @@ describe("host installer/uninstaller", () => {
 
   it("replaces one valid Codex managed block in place and removes legacy-only config", async () => {
     const prefix = 'model = "gpt-5"\n\n';
-    const suffix = '[other]\nvalue = "preserve me"\n';
+    const suffix = '[mcp_servers.oms.unmanaged]\nvalue = "preserve me"\n\n[other]\nvalue = "preserve me too"\n';
     const managedBlock = [
-      "# BEGIN OMS MANAGED MCP",
+      "  # BEGIN OMS MANAGED MCP",
       "# OMS MCP hookup for Codex CLI. Managed by `oms install/uninstall`.",
       "[mcp_servers.oms]",
       'command = "old-oms"',
-      "# END OMS MANAGED MCP",
+      "  # END OMS MANAGED MCP",
       "",
     ].join("\n");
     const home = await mkdtemp(path.join(tmpdir(), "oms-codex-valid-marker-"));

--- a/src/cli/oms-dispatch.test.ts
+++ b/src/cli/oms-dispatch.test.ts
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
+import { mainUsageCommandNames } from "./usage.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -143,12 +144,7 @@ describe("oms CLI dispatch", () => {
 
   it.each([
     { command: [] },
-    { command: ["setup"] },
-    { command: ["doctor"] },
-    { command: ["index"] },
-    { command: ["search"] },
-    { command: ["mcp"] },
-    { command: ["install"] },
+    ...mainUsageCommandNames().map((command) => ({ command: [command] })),
   ])("prints usage without side effects for $command --help", async ({ command }) => {
     const vault = await makeVault();
     const beforeVault = snapshotDir(vault);
@@ -213,6 +209,28 @@ describe("oms CLI dispatch", () => {
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("[oms] Unsupported update option: --bogus");
+  });
+
+  it("does not print an update notice after blocked setup", async () => {
+    const vault = await makeVault();
+    await mkdir(path.join(vault, ".obsidian"), { recursive: true });
+    await writeFile(path.join(vault, ".obsidian", "types.json"), JSON.stringify({ types: { title: "text" } }));
+    await mkdir(path.join(vault, "Notes"), { recursive: true });
+    await writeFile(path.join(vault, "Notes", "broken.md"), "---\ntitle: [unterminated\n---\n");
+
+    const result = runCli(
+      ["setup", "--vault", vault, "--yes", "--approved-digest", `sha256:${"0".repeat(64)}`],
+      undefined,
+      {
+        OMS_UPDATE_NOTICE: "1",
+        OMS_NO_UPDATE_NOTICE: "0",
+        OMS_UPDATE_LATEST_VERSION: "99.0.0",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('"status": "blocked"');
+    expect(result.stderr).not.toContain("Update available");
   });
 
   it("emits doctor and lint JSON for an empty temp vault", async () => {

--- a/src/cli/oms.ts
+++ b/src/cli/oms.ts
@@ -27,7 +27,7 @@ import { isSearchCliCommand, runSearchCli } from "./search.js";
 import { runSetup } from "./setup-command.js";
 import { searchUsage } from "./search-usage.js";
 import { maybePrintUpdateNotice } from "./update-notice.js";
-import { printUsage } from "./usage.js";
+import { mainUsageCommandNames, printUsage } from "./usage.js";
 
 export { buildClaudeInstallPlan } from "./claude-install-plan.js";
 export type { ClaudeInstallPlan } from "./claude-install-plan.js";
@@ -59,22 +59,7 @@ function shouldResolveBridgeVault(command: string | undefined, vaultExplicit: bo
 }
 
 function isKnownCommand(command: string | undefined): boolean {
-  return (
-    command === undefined ||
-    command === "setup" ||
-    command === "link" ||
-    command === "install" ||
-    command === "uninstall" ||
-    command === "update" ||
-    command === "reconcile" ||
-    command === "doctor" ||
-    command === "audit" ||
-    command === "linkify" ||
-    command === "lint" ||
-    command === "mcp" ||
-    command === "hook" ||
-    isSearchCliCommand(command)
-  );
+  return command === undefined || mainUsageCommandNames().includes(command);
 }
 
 async function main(): Promise<void> {
@@ -186,7 +171,7 @@ async function main(): Promise<void> {
         },
       };
     }
-    await runSetup({
+    const outcome = await runSetup({
       vault,
       yes,
       approvedDigest: approvedDigest as `sha256:${string}` | undefined,
@@ -196,7 +181,7 @@ async function main(): Promise<void> {
       modelSetManifest,
       modelsNoDefault,
     });
-    if (!dryRun) await maybePrintUpdateNotice();
+    if (!dryRun && outcome === "completed") await maybePrintUpdateNotice();
   } else if (command === "link") {
     process.exitCode = await runLink({
       cwd: process.cwd(),

--- a/src/cli/setup-command.ts
+++ b/src/cli/setup-command.ts
@@ -21,6 +21,8 @@ export interface SetupPrompt {
   close(): void;
 }
 
+export type SetupOutcome = "blocked" | "completed";
+
 export async function runSetup(opts: {
   vault: string;
   yes: boolean;
@@ -37,7 +39,7 @@ export async function runSetup(opts: {
   modelsNoDefault?: boolean;
   /** Fetch seam for setup tests; production uses global fetch. */
   modelFetchImpl?: typeof fetch;
-}): Promise<void> {
+}): Promise<SetupOutcome> {
   const {
     vault,
     yes,
@@ -70,7 +72,7 @@ export async function runSetup(opts: {
       })),
     }, null, 2));
     process.exitCode = 1;
-    return;
+    return "blocked";
   }
   const decision = await decideNonInteractiveSetup(state);
   const manifest = await composeSetup(decision, { base: { fields: {} } });
@@ -83,7 +85,7 @@ export async function runSetup(opts: {
       ...(proposedModelsConfig === undefined ? {} : { modelsConfig: proposedModelsConfig }),
       receipt,
     }, null, 2));
-    return;
+    return "completed";
   }
   if (approvedDigest === undefined) throw new Error("Setup apply requires approvedDigest from a shown dry-run proposal.");
   const receipt = await applySetup(decision, manifest, { approvedDigest });
@@ -106,4 +108,5 @@ export async function runSetup(opts: {
   console.log(`Oh My Second Brain setup complete. Approval: ${manifest.approvalDigest}`);
   if (modelsNoDefault) console.log("Models: no default (explicit waiver)");
   if (installClaude) printClaudeInstallPlan(buildClaudeInstallPlan({ vault }));
+  return "completed";
 }

--- a/src/cli/setup.e2e.test.ts
+++ b/src/cli/setup.e2e.test.ts
@@ -151,6 +151,37 @@ describe("template-first setup", () => {
     }
   });
 
+  it("keeps the dry-run approval digest unchanged when external template settings are present", async () => {
+    const withSettings = await fresh();
+    const withoutSettings = await mkdtemp(path.join(tmpdir(), "oms-setup-"));
+    try {
+      for (const root of [withSettings, withoutSettings]) {
+        await authority(root);
+        await noteTemplate(root);
+      }
+      await mkdir(path.join(withSettings, "External", "Templater"), { recursive: true });
+      await writeFile(path.join(withSettings, "External", "Templater", "source.template.md"), "{{ unsupported }}\n");
+      await mkdir(path.join(withSettings, ".obsidian", "plugins", "templater-obsidian"), { recursive: true });
+      await writeFile(path.join(withSettings, ".obsidian", "templates.json"), JSON.stringify({ folder: "External/Obsidian" }));
+      await writeFile(path.join(withSettings, ".obsidian", "plugins", "templater-obsidian", "data.json"), JSON.stringify({
+        templates_folder: "External/Templater",
+      }));
+      const digest = async (root: string): Promise<string> => {
+        const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+        try {
+          await runSetup({ vault: root, yes: true, dryRun: true });
+          const output = log.mock.calls.map(call => call.join(" ")).join("\n");
+          return output.match(/"approvalDigest":\s*"([^"]+)"/)?.[1] ?? "";
+        } finally {
+          log.mockRestore();
+        }
+      };
+      expect(await digest(withSettings)).toBe(await digest(withoutSettings));
+    } finally {
+      await rm(withoutSettings, { recursive: true, force: true });
+    }
+  });
+
   it("fails loudly without Obsidian type authority", async () => {
     const root = await fresh(); await noteTemplate(root);
     await expect(runSetup({ vault: root, yes: true, dryRun: true })).rejects.toThrow("MIGRATION_CONTROL_MISSING");

--- a/src/kernel/install/common.ts
+++ b/src/kernel/install/common.ts
@@ -153,8 +153,6 @@ function pairSpan(text: string, pair: YamlPair): readonly [number, number] {
   const value = pair.value as { range?: readonly number[] };
   if (!value.range || value.range.length < 3) throw new UnsafeYamlEditError("entry value has no source range");
   const start = lineStart(text, pair.key.range[0]);
-  const valueEnd = value.range[1] ?? value.range[2];
-  if (valueEnd === undefined) throw new UnsafeYamlEditError("entry value has no source range");
   const indent = text.slice(start, pair.key.range[0]);
   const end = entryEnd(text, start, indent);
   const beforeKey = text.slice(start, pair.key.range[0]);
@@ -167,6 +165,36 @@ function pairSpan(text: string, pair: YamlPair): readonly [number, number] {
 function indentation(text: string, pair: YamlPair): string {
   if (!isScalar(pair.key) || !pair.key.range) throw new UnsafeYamlEditError("mapping key has no source range");
   return text.slice(lineStart(text, pair.key.range[0]), pair.key.range[0]);
+}
+
+function rejectCommentedPair(pair: YamlPair, text?: string): void {
+  for (const node of [pair, pair.key, pair.value]) {
+    if (node && typeof node === "object") {
+      const comments = node as { comment?: unknown; commentBefore?: unknown };
+      if (typeof comments.comment === "string" || typeof comments.commentBefore === "string") {
+        throw new UnsafeYamlEditError("target entry has comments with ambiguous ownership");
+      }
+    }
+  }
+  if (text !== undefined) {
+    const [start, end] = pairSpan(text, pair);
+    let commentStart = start;
+    while (commentStart > 0) {
+      const previousEnd = commentStart - 1;
+      const previousStart = lineStart(text, previousEnd);
+      const line = text.slice(previousStart, previousEnd).trim();
+      if (!line.startsWith("#")) break;
+      commentStart = previousStart;
+    }
+    if (text.slice(commentStart, end).includes("#")) {
+      throw new UnsafeYamlEditError("target entry has comments with ambiguous ownership");
+    }
+  }
+}
+
+function insertFragment(raw: string, offset: number, fragment: string, eol: string): string {
+  const prefix = raw.slice(0, offset);
+  return `${prefix}${prefix.endsWith("\n") || prefix === "" ? "" : eol}${fragment}${raw.slice(offset)}`;
 }
 
 function sectionWithEntry(
@@ -195,7 +223,8 @@ export function renderYamlEntryPreservingComments(
   entryPath: readonly [string, string],
   edit: YamlEntryEdit,
 ): YamlEntryRender {
-  if (!Buffer.from(raw, "utf8").equals(Buffer.from(Buffer.from(raw, "utf8").toString("utf8"), "utf8"))) {
+  const bytes = Buffer.from(raw, "utf8");
+  if (!bytes.equals(Buffer.from(bytes.toString("utf8"), "utf8"))) {
     throw new UnsafeYamlEditError("file is not losslessly representable as UTF-8");
   }
   if (/(^|\n)[ ]*\t/m.test(raw)) throw new UnsafeYamlEditError("tab indentation is not supported");
@@ -216,7 +245,7 @@ export function renderYamlEntryPreservingComments(
   const root = doc.contents;
   const section = root === null ? undefined : pairFor(root, entryPath[0]);
 
-  if (section && section.value !== null && !isMap(section.value)) {
+  if (section && !isMap(section.value)) {
     throw new UnsafeYamlEditError(`${entryPath[0]} must be a mapping`);
   }
   const sectionMap = section && isMap(section.value) ? section.value : undefined;
@@ -224,17 +253,20 @@ export function renderYamlEntryPreservingComments(
   if (edit.kind === "delete") {
     if (!entry) return { changed: false, text: raw };
     if (section && sectionMap && sectionMap.items.length === 1) {
+      rejectCommentedPair(section, raw);
+      rejectCommentedPair(entry, raw);
       const [start, end] = pairSpan(raw, section);
-      const indent = indentation(raw, section);
-      const replacement = `${indent}${entryPath[0]}: {}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
-      return { changed: true, text: `${raw.slice(0, start)}${replacement}${raw.slice(end)}` };
+      const prefix = raw.slice(0, start);
+      const restoredPrefix = !raw.endsWith("\n") && prefix.endsWith(eol) ? prefix.slice(0, -eol.length) : prefix;
+      return { changed: true, text: `${restoredPrefix}${raw.slice(end)}` };
     }
+    rejectCommentedPair(entry, raw);
     const [start, end] = pairSpan(raw, entry);
     const text = `${raw.slice(0, start)}${raw.slice(end)}`;
-    if (`${raw.slice(0, start)}${raw.slice(end)}` !== text) throw new UnsafeYamlEditError("splice integrity check failed");
     return { changed: true, text };
   }
   if (entry) {
+    rejectCommentedPair(entry, raw);
     const [start, end] = pairSpan(raw, entry);
     const indent = indentation(raw, entry);
     const replacement = `${indent}${entryPath[1]}:${eol}${renderValue(edit.value, indent, eol)}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
@@ -250,6 +282,7 @@ export function renderYamlEntryPreservingComments(
   }
   if (!root) throw new UnsafeYamlEditError("empty document was not handled");
   if (section && sectionMap && sectionMap.items.length === 0) {
+    rejectCommentedPair(section, raw);
     const [start, end] = pairSpan(raw, section);
     const indent = indentation(raw, section);
     const replacement = `${indent}${entryPath[0]}:${eol}${indent}  ${entryPath[1]}:${eol}${renderValue(edit.value, `${indent}  `, eol)}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
@@ -260,31 +293,15 @@ export function renderYamlEntryPreservingComments(
     const [, end] = pairSpan(raw, last);
     const indent = indentation(raw, last);
     const fragment = `${indent}${entryPath[1]}:${eol}${renderValue(edit.value, indent, eol)}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
-    return { changed: true, text: `${raw.slice(0, end)}${fragment}${raw.slice(end)}` };
+    return { changed: true, text: insertFragment(raw, end, fragment, eol) };
   }
   const rootLast = root.items.at(-1) as YamlPair;
   const [, end] = pairSpan(raw, rootLast);
+  if (raw.slice(end).trim() !== "") {
+    throw new UnsafeYamlEditError("root insertion with document terminator or trailing comment is not supported");
+  }
   const fragment = `${sectionWithEntry(entryPath, edit.value, "", eol)}${raw.slice(end - 1, end) === "\n" ? eol : ""}`;
-  return { changed: true, text: `${raw.slice(0, end)}${fragment}${raw.slice(end)}` };
-}
-
-/**
- * Applies one `section.key` edit to a YAML file while leaving every other byte,
- * comment, and key ordering the document already had in place.
- */
-export async function editYamlEntryPreservingComments(
-  file: string,
-  entryPath: readonly [string, string],
-  edit: YamlEntryEdit,
-): Promise<boolean> {
-  const rawBytes = existsSync(file) ? await readFile(file) : Buffer.alloc(0);
-  const raw = rawBytes.toString("utf8");
-  if (!rawBytes.equals(Buffer.from(raw, "utf8"))) throw new UnsafeYamlEditError("file is not valid UTF-8");
-  const rendered = renderYamlEntryPreservingComments(raw, entryPath, edit);
-  if (!rendered.changed) return false;
-  await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, rendered.text, "utf-8");
-  return true;
+  return { changed: true, text: insertFragment(raw, end, fragment, eol) };
 }
 
 export function mcpServerEntry(options: HostOperationOptions): Record<string, unknown> {

--- a/src/kernel/install/yaml-edit.test.ts
+++ b/src/kernel/install/yaml-edit.test.ts
@@ -26,10 +26,43 @@ describe("renderYamlEntryPreservingComments", () => {
     expect(removed.text).toBe(raw);
   });
 
+  it("rejects null, scalar, and sequence mcp_servers sections for either edit", () => {
+    for (const raw of ["mcp_servers: null\n", "mcp_servers: disabled\n", "mcp_servers: []\n"]) {
+      for (const edit of [{ kind: "set", value: entry } as const, { kind: "delete" } as const]) {
+        expect(() => renderYamlEntryPreservingComments(raw, path, edit)).toThrow(UnsafeYamlEditError);
+      }
+    }
+  });
+
+  it("adds a leading EOL when appending to a file without a final newline", () => {
+    const raw = "mcp_servers:\n  other: keep";
+    const result = renderYamlEntryPreservingComments(raw, path, { kind: "set", value: entry });
+    expect(result.text).toBe("mcp_servers:\n  other: keep\n  oms:\n    command: oms\n    args:\n      - mcp\n      - --vault\n      - /vault\n    enabled: true");
+  });
+
+  it("restores the original bytes when a newly-created section is deleted", () => {
+    const raw = "name: 한글";
+    const inserted = renderYamlEntryPreservingComments(raw, path, { kind: "set", value: entry });
+    const removed = renderYamlEntryPreservingComments(inserted.text, path, { kind: "delete" });
+    expect(removed.text).toBe(raw);
+  });
+
+  it("rejects target comments and root insertion around terminators or trailing comments", () => {
+    for (const raw of [
+      "mcp_servers:\n  oms: # owned\n    command: old\n",
+      "mcp_servers:\n  # owned\n  oms:\n    command: old\n",
+      "name: keep\n...\n",
+      "name: keep\n# trailing\n",
+    ]) {
+      expect(() => renderYamlEntryPreservingComments(raw, path, { kind: "set", value: entry })).toThrow(UnsafeYamlEditError);
+    }
+  });
+
   it("rejects ambiguous YAML constructs before any write", () => {
     for (const raw of [
       "mcp_servers: &servers {}\n",
       "mcp_servers: *servers\n",
+      "mcp_servers:\n  <<: { oms: {} }\n",
       "mcp_servers:\n\toms: {}\n",
       "mcp_servers:\n  oms: {}\n  oms: {}\n",
     ]) {

--- a/src/kernel/templates/migration.test.ts
+++ b/src/kernel/templates/migration.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { applyTemplateMigration, buildMigrationManifest, planTemplateMigration } from "./migration.js";
+import { diagnoseTemplates } from "./doctor.js";
 import { loadResolvedTemplates } from "./resolver.js";
 import type { Digest, TemplateCompositionManifest } from "./types.js";
 
@@ -60,14 +61,30 @@ describe("template migration planner", () => {
     expect(defaultManifest.approvalDigest).toBe(explicitManifest.approvalDigest);
   });
 
-  it("reports malformed ordinary notes instead of throwing and still rejects activation", async () => {
+  it("isolates external Templater sources while reporting a malformed ordinary note through doctor", async () => {
     const root = await fresh();
+    await template(root, "External/Templater/source.template.md", "{{ unsupported }}\n");
+    await mkdir(path.join(root, ".obsidian", "plugins", "templater-obsidian"), { recursive: true });
+    await writeFile(path.join(root, ".obsidian", "plugins", "templater-obsidian", "data.json"), JSON.stringify({
+      templates_folder: "External/Templater",
+    }));
     await template(root, "Notes/broken.md", "---\ntitle: [unterminated\n---\n");
     const proposal = await planTemplateMigration(root);
     expect(proposal.unresolved).toContainEqual(expect.objectContaining({
       code: "MIGRATION_NOTE_INVALID",
       path: "Notes/broken.md",
     }));
+    for (const paths of [
+      proposal.candidates.map(candidate => candidate.sourcePath),
+      proposal.diagnostics.map(diagnostic => diagnostic.path),
+      proposal.unresolved.map(unresolved => unresolved.path),
+    ]) expect(paths).not.toContain("External/Templater/source.template.md");
+    const diagnosis = await diagnoseTemplates({ vault: root });
+    expect(diagnosis.diagnostics).toContainEqual(expect.objectContaining({
+      code: "MIGRATION_NOTE_INVALID",
+      path: "Notes/broken.md",
+    }));
+    expect(diagnosis.diagnostics.map(diagnostic => diagnostic.path)).not.toContain("External/Templater/source.template.md");
     await expect(applyTemplateMigration(root, proposal, noManifest, { approvedDigest: approval })).rejects.toThrow("MIGRATION_UNRESOLVED_MAPPING");
   });
 

--- a/src/vendors/codex/codex.ts
+++ b/src/vendors/codex/codex.ts
@@ -36,7 +36,9 @@ function isCodexOMSTable(line: string): boolean {
 type CodexManagedMarker = {
   readonly token: typeof MANAGED_CODEX_START | typeof MANAGED_CODEX_END;
   readonly line: number;
+  readonly lineStart: number;
   readonly offset: number;
+  readonly valid: boolean;
 };
 
 type ManagedCodexBlock = {
@@ -44,7 +46,7 @@ type ManagedCodexBlock = {
   readonly end: number;
 };
 
-export class CodexManagedBlockAmbiguousError extends Error {
+class CodexManagedBlockAmbiguousError extends Error {
   constructor(configPath: string, markers: readonly CodexManagedMarker[]) {
     const locations = markers.length === 0
       ? "none"
@@ -62,6 +64,7 @@ function scanCodexManagedMarkers(content: string): CodexManagedMarker[] {
   let offset = 0;
   let line = 1;
   for (const sourceLine of content.split(/(?<=\n)/)) {
+    const lineContent = sourceLine.replace(/\r?\n$/, "");
     let position = 0;
     while (position < sourceLine.length) {
       const start = sourceLine.indexOf(MANAGED_CODEX_START, position);
@@ -70,7 +73,14 @@ function scanCodexManagedMarkers(content: string): CodexManagedMarker[] {
       const isStart = start !== -1 && (end === -1 || start < end);
       const token = isStart ? MANAGED_CODEX_START : MANAGED_CODEX_END;
       const tokenOffset = isStart ? start : end;
-      markers.push({ token, line, offset: offset + tokenOffset });
+      markers.push({
+        token,
+        line,
+        lineStart: offset,
+        offset: offset + tokenOffset,
+        valid: lineContent === `${sourceLine.slice(0, tokenOffset)}${token}`
+          && /^[ \t]*$/.test(sourceLine.slice(0, tokenOffset)),
+      });
       position = tokenOffset + token.length;
     }
     offset += sourceLine.length;
@@ -84,6 +94,7 @@ function managedCodexBlock(content: string, configPath: string): ManagedCodexBlo
   if (markers.length === 0) return undefined;
   if (
     markers.length !== 2
+    || markers.some((marker) => !marker.valid)
     || markers[0]?.token !== MANAGED_CODEX_START
     || markers[1]?.token !== MANAGED_CODEX_END
   ) {
@@ -96,7 +107,6 @@ function managedCodexBlock(content: string, configPath: string): ManagedCodexBlo
     || end === undefined
     || start.offset >= end.offset
     || start.line >= end.line
-    || !content.slice(start.offset, end.offset).includes("[mcp_servers.oms]")
   ) {
     throw new CodexManagedBlockAmbiguousError(configPath, markers);
   }
@@ -104,7 +114,7 @@ function managedCodexBlock(content: string, configPath: string): ManagedCodexBlo
   let blockEnd = end.offset + MANAGED_CODEX_END.length;
   if (content.slice(blockEnd, blockEnd + 2) === "\r\n") blockEnd += 2;
   else if (content[blockEnd] === "\n") blockEnd++;
-  return { start: start.offset, end: blockEnd };
+  return { start: start.lineStart, end: blockEnd };
 }
 
 function removeManagedCodexBlock(
@@ -112,11 +122,14 @@ function removeManagedCodexBlock(
   configPath: string,
 ): { content: string; removed: boolean; block: ManagedCodexBlock | undefined } {
   const block = managedCodexBlock(content, configPath);
-  const withoutMarkers = block === undefined
-    ? content
-    : `${content.slice(0, block.start)}${content.slice(block.end)}`;
-  const markerRemoved = block !== undefined;
-  const lines = withoutMarkers.split(/\r?\n/);
+  if (block !== undefined) {
+    return {
+      content: `${content.slice(0, block.start)}${content.slice(block.end)}`,
+      removed: true,
+      block,
+    };
+  }
+  const lines = content.split(/\r?\n/);
   const output: string[] = [];
   let removedLegacy = false;
   for (let i = 0; i < lines.length; i++) {
@@ -142,13 +155,10 @@ function removeManagedCodexBlock(
     }
     output.push(line);
   }
-  if (markerRemoved && !removedLegacy) {
-    return { content: withoutMarkers, removed: true, block };
-  }
   return {
     content: `${output.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`,
-    removed: markerRemoved || removedLegacy,
-    block,
+    removed: removedLegacy,
+    block: undefined,
   };
 }
 
@@ -189,12 +199,7 @@ async function installCodexNativeArtifacts(
   return [rulesTarget, ...paths];
 }
 
-/**
- * Codex install stays file-copy based on purpose.
- *
- * Codex install stays file-copy based on purpose. Its native rules and skills
- * are installed directly so they use Codex's expected destinations.
- */
+/** Codex install uses native file copies for its rules and skills. */
 export async function installCodex(options: HostOperationOptions, host: HarnessHostSurface): Promise<HostOperationResult> {
   const codexDir = hostHome(options.homeDir, ".codex", "OMS_CODEX_HOME");
   const packageRoot = resolveHostAdapterSource(options.adapterRoot, host);

--- a/src/vendors/hermes/hermes.test.ts
+++ b/src/vendors/hermes/hermes.test.ts
@@ -1,10 +1,23 @@
+import * as fsPromises from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { harnessSurfaceRegistry } from "../../kernel/harness/surface-registry.js";
-import { installHermes } from "./hermes.js";
+import { installHermes, uninstallHermes } from "./hermes.js";
 
+vi.mock("node:fs/promises", async importOriginal => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    cp: vi.fn(actual.cp),
+    readdir: vi.fn(actual.readdir),
+    writeFile: vi.fn(actual.writeFile),
+  };
+});
+
+const originalFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
 const temporaryDirectories: string[] = [];
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
@@ -33,4 +46,85 @@ describe("installHermes transaction", () => {
     expect(await readFile(config, "utf8")).toBe(original);
     await expect(readFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"))).rejects.toThrow();
   });
+
+  it.each([
+    ["skills copy", (api: typeof fsPromises) => vi.mocked(api.cp).mockRejectedValueOnce(new Error("skills copy failed"))],
+    ["adapter copy", (api: typeof fsPromises) => vi.mocked(api.cp).mockImplementation(async (source, destination, options) => {
+      if (String(source).endsWith("hermes-manifest.json")) throw new Error("adapter copy failed");
+      return await originalCp(source, destination, options);
+    })],
+    ["config atomic write", (api: typeof fsPromises) => {
+      const write = vi.mocked(api.writeFile);
+      write.mockImplementationOnce(async () => { throw new Error("config write failed"); });
+      return write;
+    }],
+    ["install verification", (api: typeof fsPromises) => vi.mocked(api.readdir).mockRejectedValueOnce(new Error("verification failed"))],
+  ])("restores config and converges after a %s failure", async (_name, inject) => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const hermes = path.join(home, ".hermes");
+    const config = path.join(hermes, "config.yaml");
+    const original = "mcp_servers:\n  other: keep\n";
+    await mkdir(hermes);
+    await writeFile(config, original);
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+    const options = { action: "install" as const, runtime: "hermes" as const, vault: "/vault", homeDir: home, adapterRoot: path.resolve(".") };
+    const restore = inject(fsPromises);
+    try {
+      await expect(installHermes(options, host)).rejects.toThrow();
+      expect(await readFile(config, "utf8")).toBe(original);
+    } finally {
+      restore.mockRestore();
+    }
+    await expect(installHermes(options, host)).resolves.toMatchObject({ changed: true });
+  });
+
+  it("preserves both errors when config rollback fails", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const hermes = path.join(home, ".hermes");
+    const config = path.join(hermes, "config.yaml");
+    await mkdir(hermes);
+    await writeFile(config, "mcp_servers:\n  other: keep\n");
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+    const readdir = vi.mocked(fsPromises.readdir).mockRejectedValueOnce(new Error("verification failed"));
+    const write = vi.mocked(fsPromises.writeFile);
+    let temporaryWrites = 0;
+    write.mockImplementation(async (file, data, options) => {
+      if (path.basename(String(file)).startsWith(".config.yaml.oms-") && ++temporaryWrites === 2) {
+        throw new Error("rollback write failed");
+      }
+      return await originalWriteFile(file, data, options);
+    });
+    try {
+      await expect(installHermes({
+        action: "install", runtime: "hermes", vault: "/vault", homeDir: home, adapterRoot: path.resolve("."),
+      }, host)).rejects.toSatisfy((error: unknown) =>
+        error instanceof AggregateError &&
+        error.errors.some(item => item instanceof Error && item.message === "verification failed") &&
+        error.errors.some(item => item instanceof Error && item.message === "rollback write failed"),
+      );
+    } finally {
+      readdir.mockRestore();
+      write.mockRestore();
+    }
+  });
+
+  it("verifies uninstall removes the config entry and all owned paths", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+    const options = { action: "install" as const, runtime: "hermes" as const, vault: "/vault", homeDir: home, adapterRoot: path.resolve(".") };
+    await installHermes(options, host);
+    await expect(uninstallHermes({ ...options, action: "uninstall" })).resolves.toMatchObject({ changed: true });
+    await expect(readFile(path.join(home, ".hermes", "config.yaml"), "utf8")).resolves.not.toContain("oms:");
+    expect(existsSync(path.join(home, ".hermes", "adapters", "oms"))).toBe(false);
+    expect(existsSync(path.join(home, ".hermes", "skills", "knowledge-management", "oms"))).toBe(false);
+  });
 });
+
+const originalCp = originalFs.cp;
+const originalWriteFile = originalFs.writeFile;

--- a/src/vendors/hermes/hermes.ts
+++ b/src/vendors/hermes/hermes.ts
@@ -1,5 +1,5 @@
 import { existsSync, lstatSync } from "node:fs";
-import { cp, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseDocument } from "yaml";
 import type { HarnessHostSurface } from "../../kernel/harness/surface-registry.js";
@@ -18,6 +18,7 @@ const HERMES_SKILL_CATEGORY = "knowledge-management";
 const HERMES_SKILL_NAME = "oms";
 
 const HERMES_MCP_ENTRY_PATH = ["mcp_servers", "oms"] as const;
+const HERMES_SKILLS = ["distill", "doctor", "link", "search", "status", "template", "write"] as const;
 
 function refuseSymlink(target: string): void {
   if (existsSync(target) && lstatSync(target).isSymbolicLink()) {
@@ -42,11 +43,39 @@ async function rollbackConfig(configPath: string, preImage: Buffer | undefined, 
   throw original;
 }
 
-async function verifyHermesMcp(configPath: string): Promise<void> {
+async function verifyHermesInstall(configPath: string, skillTarget: string, options: HostOperationOptions): Promise<void> {
   const raw = existsSync(configPath) ? await readFile(configPath) : Buffer.alloc(0);
   const document = parseDocument(raw.toString("utf8"));
-  if (document.errors.length > 0 || !document.hasIn(HERMES_MCP_ENTRY_PATH)) {
-    throw new Error("Hermes config verification failed: mcp_servers.oms is missing");
+  const parsed = document.toJS() as Record<string, unknown> | null;
+  const servers = parsed?.mcp_servers;
+  const entry = servers && typeof servers === "object" ? (servers as Record<string, unknown>).oms : undefined;
+  const expected = mcpServerEntry(options);
+  const actual = entry as Record<string, unknown>;
+  if (
+    document.errors.length > 0 ||
+    !entry ||
+    typeof entry !== "object" ||
+    actual.command !== expected.command ||
+    actual.enabled !== true ||
+    !Array.isArray(actual.args) ||
+    actual.args.join("\0") !== (expected.args as string[]).join("\0")
+  ) {
+    throw new Error("Hermes config verification failed: mcp_servers.oms does not match the expected entry");
+  }
+  const installed = new Set(await readdir(skillTarget));
+  if (!HERMES_SKILLS.every(skill => installed.has(skill) && existsSync(path.join(skillTarget, skill, "SKILL.md")))) {
+    throw new Error("Hermes install verification failed: skill bundle is incomplete");
+  }
+}
+
+async function verifyHermesUninstall(configPath: string, targets: readonly string[]): Promise<void> {
+  const raw = existsSync(configPath) ? await readFile(configPath) : Buffer.alloc(0);
+  const document = parseDocument(raw.toString("utf8"));
+  if (document.errors.length > 0 || document.hasIn(HERMES_MCP_ENTRY_PATH)) {
+    throw new Error("Hermes uninstall verification failed: mcp_servers.oms remains");
+  }
+  if (targets.some(existsSync)) {
+    throw new Error("Hermes uninstall verification failed: OMS-owned paths remain");
   }
 }
 
@@ -80,14 +109,14 @@ export async function installHermes(options: HostOperationOptions, host: Harness
       // OMS-owned files commit first. config.yaml is deliberately the final commit.
       await rm(legacyPluginTarget, { recursive: true, force: true });
       await rm(legacyMcpPath, { force: true });
+      await replaceDirectory(skillSource, skillTarget, false);
       await rm(adapterTarget, { recursive: true, force: true });
       await mkdir(adapterTarget, { recursive: true });
       await cp(path.join(adapterSource, "hermes-manifest.json"), adapterManifestTarget);
       await cp(path.join(adapterSource, "hermes", "SOUL.md"), guidanceTarget);
       await cp(path.join(adapterSource, "hermes", "README.md"), readmeTarget);
-      await replaceDirectory(skillSource, skillTarget, false);
       if (config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
-      await verifyHermesMcp(configPath);
+      await verifyHermesInstall(configPath, skillTarget, options);
     } catch (error) {
       await rollbackConfig(configPath, preImage, error);
     }
@@ -128,6 +157,7 @@ export async function uninstallHermes(options: HostOperationOptions): Promise<Ho
         await rm(target, { recursive: true, force: true });
       }
       if (config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
+      await verifyHermesUninstall(configPath, [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath]);
     } catch (error) {
       await rollbackConfig(configPath, preImage, error);
     }


### PR DESCRIPTION
Consolidated fix batch for the VB001 boundary cohort review (generation 1 blockers). Marker ownership is line-exact and fail-closed; YAML surgical edits reject ambiguous ownership and restore round-trip bytes; Hermes install/uninstall is a verified ordered transaction with fault-injection coverage; blocked setup is side-effect-free; README EN/KO document the help contract. Verification: npm run lint, npm run build, npm test, npm run check:docs all green.