### PR TITLE
R1 generation-3 fixes: YAML byte round-trips + Hermes tree-digest Verify (#89)

### DIFF
--- a/src/kernel/install/common.ts
+++ b/src/kernel/install/common.ts
@@ -262,8 +262,14 @@ export function renderYamlEntryPreservingComments(
     }
     rejectCommentedPair(entry, raw);
     const [start, end] = pairSpan(raw, entry);
-    const text = `${raw.slice(0, start)}${raw.slice(end)}`;
-    return { changed: true, text };
+    const prefix = raw.slice(0, start);
+    // Deleting the trailing entry of a document that has no final newline must
+    // also remove the separator EOL that the matching insertion added, so an
+    // absent-entry set -> delete round-trip restores the original bytes.
+    const restoredPrefix = raw.slice(end) === "" && !raw.endsWith("\n") && prefix.endsWith(eol)
+      ? prefix.slice(0, -eol.length)
+      : prefix;
+    return { changed: true, text: `${restoredPrefix}${raw.slice(end)}` };
   }
   if (entry) {
     rejectCommentedPair(entry, raw);

--- a/src/kernel/install/yaml-edit.test.ts
+++ b/src/kernel/install/yaml-edit.test.ts
@@ -58,6 +58,50 @@ describe("renderYamlEntryPreservingComments", () => {
     }
   });
 
+  it("creates a full section from an empty file and treats empty-file deletion as a no-op", () => {
+    const created = renderYamlEntryPreservingComments("", path, { kind: "set", value: entry });
+    expect(created.changed).toBe(true);
+    expect(created.text).toBe("mcp_servers:\n  oms:\n    command: oms\n    args:\n      - mcp\n      - --vault\n      - /vault\n    enabled: true\n");
+    const removedFromEmpty = renderYamlEntryPreservingComments("", path, { kind: "delete" });
+    expect(removedFromEmpty.changed).toBe(false);
+    expect(removedFromEmpty.text).toBe("");
+  });
+
+  it("expands an explicit empty root mapping in place", () => {
+    const result = renderYamlEntryPreservingComments("{}\n", path, { kind: "set", value: entry });
+    expect(result.changed).toBe(true);
+    expect(result.text).toContain("mcp_servers:\n  oms:\n");
+  });
+
+  it("rejects multi-document YAML for either edit", () => {
+    const raw = "name: one\n---\nname: two\n";
+    for (const edit of [{ kind: "set", value: entry } as const, { kind: "delete" } as const]) {
+      expect(() => renderYamlEntryPreservingComments(raw, path, edit)).toThrow(UnsafeYamlEditError);
+    }
+  });
+
+  it("rejects anchors and aliases for either edit", () => {
+    for (const raw of ["mcp_servers: &servers {}\n", "defaults: &d {}\nmcp_servers: *d\n"]) {
+      for (const edit of [{ kind: "set", value: entry } as const, { kind: "delete" } as const]) {
+        expect(() => renderYamlEntryPreservingComments(raw, path, edit)).toThrow(UnsafeYamlEditError);
+      }
+    }
+  });
+
+  it("round-trips set then delete byte-for-byte on a populated section without a final newline", () => {
+    const raw = "mcp_servers:\n  other: keep";
+    const inserted = renderYamlEntryPreservingComments(raw, path, { kind: "set", value: entry });
+    const removed = renderYamlEntryPreservingComments(inserted.text, path, { kind: "delete" });
+    expect(removed.text).toBe(raw);
+  });
+
+  it("round-trips set then delete byte-for-byte when the section is missing and the file lacks a final newline", () => {
+    const raw = "name: keep";
+    const inserted = renderYamlEntryPreservingComments(raw, path, { kind: "set", value: entry });
+    const removed = renderYamlEntryPreservingComments(inserted.text, path, { kind: "delete" });
+    expect(removed.text).toBe(raw);
+  });
+
   it("rejects ambiguous YAML constructs before any write", () => {
     for (const raw of [
       "mcp_servers: &servers {}\n",

--- a/src/vendors/hermes/hermes.test.ts
+++ b/src/vendors/hermes/hermes.test.ts
@@ -112,6 +112,33 @@ describe("installHermes transaction", () => {
     }
   });
 
+  it("rejects a tampered installed skill tree at Verify and restores the config", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const hermes = path.join(home, ".hermes");
+    const config = path.join(hermes, "config.yaml");
+    const original = "mcp_servers:\n  other: keep\n";
+    await mkdir(hermes);
+    await writeFile(config, original);
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+    const skillTarget = path.join(hermes, "skills", "knowledge-management", "oms");
+    const cpMock = vi.mocked(fsPromises.cp).mockImplementation(async (source, destination, options) => {
+      await originalCp(source, destination, options);
+      if (String(destination) === skillTarget) {
+        await originalWriteFile(path.join(skillTarget, "write", "SKILL.md"), "tampered\n");
+      }
+    });
+    try {
+      await expect(installHermes({
+        action: "install", runtime: "hermes", vault: "/vault", homeDir: home, adapterRoot: path.resolve("."),
+      }, host)).rejects.toThrow("installed skill tree does not match");
+      expect(await readFile(config, "utf8")).toBe(original);
+    } finally {
+      cpMock.mockRestore();
+    }
+  });
+
   it("verifies uninstall removes the config entry and all owned paths", async () => {
     const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
     temporaryDirectories.push(home);

--- a/src/vendors/hermes/hermes.ts
+++ b/src/vendors/hermes/hermes.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, lstatSync } from "node:fs";
 import { cp, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -43,6 +44,31 @@ async function rollbackConfig(configPath: string, preImage: Buffer | undefined, 
   throw original;
 }
 
+/** Deterministic content digest of a file tree: sorted relative paths + bytes. */
+async function treeDigest(root: string): Promise<string> {
+  const hash = createHash("sha256");
+  const walk = async (directory: string): Promise<void> => {
+    const entries = (await readdir(directory, { withFileTypes: true })).sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absolute);
+      } else {
+        hash.update(path.relative(root, absolute));
+        hash.update("\0");
+        hash.update(await readFile(absolute));
+        hash.update("\0");
+      }
+    }
+  };
+  await walk(root);
+  return hash.digest("hex");
+}
+
+async function fileDigest(file: string): Promise<string> {
+  return createHash("sha256").update(await readFile(file)).digest("hex");
+}
+
 async function verifyHermesInstall(configPath: string, skillTarget: string, options: HostOperationOptions): Promise<void> {
   const raw = existsSync(configPath) ? await readFile(configPath) : Buffer.alloc(0);
   const document = parseDocument(raw.toString("utf8"));
@@ -65,6 +91,21 @@ async function verifyHermesInstall(configPath: string, skillTarget: string, opti
   const installed = new Set(await readdir(skillTarget));
   if (!HERMES_SKILLS.every(skill => installed.has(skill) && existsSync(path.join(skillTarget, skill, "SKILL.md")))) {
     throw new Error("Hermes install verification failed: skill bundle is incomplete");
+  }
+}
+
+async function verifyHermesTrees(
+  skillSource: string,
+  skillTarget: string,
+  adapterFiles: readonly { readonly source: string; readonly target: string }[],
+): Promise<void> {
+  if ((await treeDigest(skillSource)) !== (await treeDigest(skillTarget))) {
+    throw new Error("Hermes install verification failed: installed skill tree does not match the prepared source");
+  }
+  for (const file of adapterFiles) {
+    if ((await fileDigest(file.source)) !== (await fileDigest(file.target))) {
+      throw new Error(`Hermes install verification failed: installed adapter asset does not match its source: ${file.target}`);
+    }
   }
 }
 
@@ -117,6 +158,11 @@ export async function installHermes(options: HostOperationOptions, host: Harness
       await cp(path.join(adapterSource, "hermes", "README.md"), readmeTarget);
       if (config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
       await verifyHermesInstall(configPath, skillTarget, options);
+      await verifyHermesTrees(skillSource, skillTarget, [
+        { source: path.join(adapterSource, "hermes-manifest.json"), target: adapterManifestTarget },
+        { source: path.join(adapterSource, "hermes", "SOUL.md"), target: guidanceTarget },
+        { source: path.join(adapterSource, "hermes", "README.md"), target: readmeTarget },
+      ]);
     } catch (error) {
       await rollbackConfig(configPath, preImage, error);
     }


### PR DESCRIPTION
Closes the two generation-2 carryover blockers from the VB001 boundary review: absent-entry set→delete now restores original bytes on no-final-newline documents, and Hermes Verify compares deterministic tree digests (skills + adapter assets) against prepared sources with a tamper fixture. Plus the remaining YAML acceptance-matrix fixtures (empty file, {} root, multi-doc, anchor/alias both directions). Verification: npm run lint, npm test full suite green.