### PR TITLE
R2 lifecycle/API: update consumer contract, index repair, MCP op errors, graph cap, Hermes provenance (#64 #65 #69 #88 #90)

### DIFF
--- a/CHANGELOG-cli.md
+++ b/CHANGELOG-cli.md
@@ -4,6 +4,15 @@ Changes to the `oms` command surface belong here.
 
 ## [Unreleased]
 
+### Added
+
+- **`oms index repair --mode rebuild|drop [--dry-run]`.** (#88) Repairs run before any engine session opens, so corrupt stores never block their own recovery; `oms index status` cites the exact repair command when it detects a corrupt or incompatible store; dry-run prints the plan with zero file changes.
+- **`oms doctor` reports Hermes install provenance in one read-only line.** (#90) Not-installed, match, or drift between the package version and the installed provenance for the resolved `OMS_HERMES_HOME` root.
+
+### Changed
+
+- **`oms update` refuses ambiguous install topologies and always reconciles.** (#64) Mismatched running-binary and `npm prefix -g` locations are reported with both paths and exact manual commands instead of silently updating the wrong copy.
+
 ## [0.10.1] - 2026-09-01
 
 ### Fixed

--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -4,6 +4,16 @@ Domain logic changes belong here.
 
 ## [Unreleased]
 
+### Added
+
+- **Install provenance is now a first-class kernel contract.** (#64, #90) A dependency-leaf module owns provenance parsing/serialization, deterministic tree digests, and a pure six-state ownership decision shared by update, install, and doctor.
+- **Legacy engine stores have a supported recovery path.** (#88) A dedicated repair service moves legacy or incompatible engine stores to timestamped backups without opening them: rebuild recreates the current empty schema, drop only retires, and neither mode ever writes vault Markdown or `.oms` authority files.
+
+### Changed
+
+- **Update follows a consumer-side contract.** (#64) The updater resolves the npm prefix that owns the running binary and refuses destructively ambiguous topologies with exact manual commands; reconciliation always runs even when the package is already current; cross-version handoff invokes the freshly installed binary's public reconcile command so a new release can never call a removed internal subcommand.
+- **Graph tier-4 type-affinity is bounded.** (#69) Groups above 64 members skip pairwise edges and emit a deterministic build-report warning; `OMS_TYPE_AFFINITY_UNBOUNDED=1` restores exhaustive pairing; behavior at or below the cap is unchanged.
+
 ## [0.10.1] - 2026-09-01
 
 ### Fixed

--- a/CHANGELOG-mcp.md
+++ b/CHANGELOG-mcp.md
@@ -4,6 +4,10 @@ MCP server tools and resources belong here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A missing or unknown `op` now names the supported operations.** (#65) Instead of a bare unknown-operation error, every public tool lists its supported operations in deterministic order; `oms_status` remains the only op-free direct route, and supplying an operation to it is rejected explicitly.
+
 ## [0.10.1] - 2026-09-01
 
 ## [0.10.0] - 2026-09-01

--- a/CHANGELOG-vendors.md
+++ b/CHANGELOG-vendors.md
@@ -4,6 +4,10 @@ Per-host adapter and installer changes belong here.
 
 ## [Unreleased]
 
+### Changed
+
+- **Hermes installation is provenance-aware and one-root.** (#90) Each install targets exactly the resolved `OMS_HERMES_HOME` root (Sari: `~/.hermes`; Xia: `~/.hermes/profiles/xia`), records npm provenance (version + deterministic skill-tree digest) under `adapters/oms/`, no-ops on three-way identity while still reconciling a changed vault registration, replaces owned drift atomically, fails closed on foreign or tampered trees with explicit resolution guidance, adopts only the exact legacy layout, and keeps uninstall symmetric — foreign trees are never blind-deleted.
+
 ## [0.10.1] - 2026-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This aggregate changelog contains changes that span multiple layers.
 
 ## [Unreleased]
 
+### Added
+
+- **Lifecycle, API, and delivery-channel release across kernel, CLI, MCP, and vendors.** Update gains a consumer-side topology/provenance contract (#64), legacy engine stores gain `oms index repair` (#88), MCP op errors become self-describing (#65), graph type-affinity is bounded (#69), and Hermes delivery becomes provenance-aware with version lockstep across both agent profiles (#90).
+
 ## [0.10.1] - 2026-09-01
 
 ### Fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,7 +36,7 @@ oms doctor     템플릿 권위와 파생 상태 진단
 oms lint       깨진 [[wikilink]]와 고아 노트 점검
 oms search <text>  일반 lexical 검색; --vec, --hyde, --expand, --max-queries 1..32, --rerank은 명시적 선택
 oms embed      색인된 노트의 임베딩 생성
-oms index sync|status|cleanup|collections|contexts
+oms index sync|status|repair|cleanup|collections|contexts
 oms doc get|multi-get
 oms serve      로컬 검색 HTTP 서버 시작
 oms mcp        stdio MCP 서버 시작

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ oms doctor     Diagnose template authority and derived state
 oms lint       Check broken [[wikilinks]] and orphan notes
 oms search <text>  Plain lexical search; --vec, --hyde, --expand, --max-queries 1..32, and --rerank are explicit
 oms embed      Generate embeddings for indexed notes
-oms index sync|status|cleanup|collections|contexts
+oms index sync|status|repair|cleanup|collections|contexts
 oms doc get|multi-get
 oms serve      Start the local search HTTP server
 oms mcp        Start the stdio MCP server

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,6 +35,23 @@ stamp; uninstall removes the pointer last after host cleanup succeeds.
 
 This is an installation detail, not a target-resolution rule. Installing or uninstalling a host does not alter runtime precedence.
 
+### Hermes roots and provenance
+
+Each Hermes command operates on exactly one root. With `OMS_HERMES_HOME` unset,
+that root is `~/.hermes` (for example, Sari). To install for a named Hermes
+profile such as Xia, run the command separately with that profile directory:
+
+```bash
+OMS_HERMES_HOME=~/.hermes/profiles/xia oms install --runtime hermes --vault /path/to/vault --yes
+```
+
+This does not enumerate or modify other profiles; a `hermes -p xia` wrapper
+uses the same profile root. Hermes stores npm installation provenance at
+`adapters/oms/.oms-provenance.json`, outside the skill scan tree. Reinstall
+does nothing when the package version and installed skill digest match. A
+foreign, incomplete, or tampered install is refused rather than overwritten;
+remove or migrate that installation before retrying.
+
 ## Target resolution
 
 At runtime, target resolution is ordered as follows:
@@ -81,7 +98,7 @@ pair fails loudly.
 ```text
 oms search <text> [--vec <text>] [--hyde <text>] [--expand] [--max-queries <1..32>] [--rerank]
 oms embed
-oms index sync|status|cleanup|collections|contexts
+oms index sync|status|repair|cleanup|collections|contexts
 oms doc get|multi-get
 oms serve
 ```
@@ -89,8 +106,13 @@ oms serve
 A plain `oms search <text>` is lexical-only. Every non-lexical channel is
 explicit: `--vec`, `--hyde`, G004 `--expand`, and `--rerank`. G004 expansion is
 available only when selected; no replacement, parity, or outperformance claim
-is made. `oms embed` is the sole embedding command, and `oms index` has no
+`oms embed` is the sole embedding command, and `oms index` has no
 embedding subcommand.
+
+When `oms index status` reports a corrupt or incompatible legacy store, inspect
+the non-mutating plan with `oms index repair --mode rebuild --dry-run`, then run
+`oms index repair --mode rebuild` and `oms index sync`. `--mode drop` only moves
+the store to a timestamped backup; it does not create a replacement.
 
 ## Skills and MCP tools
 
@@ -109,3 +131,7 @@ oms uninstall --runtime all --yes
 ```
 
 Uninstall removes OMS host registrations and installed host assets. It does not modify vault notes, templates, or vault convention files.
+
+For Hermes, uninstall removes only an installation with valid OMS npm
+provenance (or the exact legacy seven-skill layout). It refuses to delete a
+foreign or tampered skill tree.

--- a/src/cli/doctor-lint.ts
+++ b/src/cli/doctor-lint.ts
@@ -1,6 +1,29 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { detectLinkIssues } from "../kernel/conventions/lint.js";
 import { formatLintReport } from "../kernel/conventions/report.js";
+import { hostHome } from "../kernel/install/common.js";
+import { computeTreeDigest, parseProvenance } from "../kernel/install/provenance.js";
 import { diagnoseTemplates } from "../kernel/templates/index.js";
+import path from "node:path";
+
+async function hermesProvenanceSummary(): Promise<string> {
+  const hermesRoot = hostHome(undefined, ".hermes", "OMS_HERMES_HOME");
+  const skillRoot = path.join(hermesRoot, "skills", "knowledge-management", "oms");
+  const provenancePath = path.join(hermesRoot, "adapters", "oms", ".oms-provenance.json");
+  if (!existsSync(provenancePath) || !existsSync(skillRoot)) return "Hermes provenance: not installed.";
+  try {
+    const provenance = parseProvenance(await readFile(provenancePath, "utf8"));
+    const packageVersion = JSON.parse(await readFile(new URL("../../package.json", import.meta.url), "utf8")) as { version?: unknown };
+    if (provenance !== null && typeof packageVersion.version === "string" &&
+      provenance.version === packageVersion.version && provenance.treeDigest === await computeTreeDigest(skillRoot)) {
+      return "Hermes provenance: package and installed tree match.";
+    }
+  } catch {
+    return "Hermes provenance: drift detected.";
+  }
+  return "Hermes provenance: drift detected.";
+}
 
 export async function runDoctor(opts: {
   vault: string;
@@ -17,6 +40,7 @@ export async function runDoctor(opts: {
     console.log(`\nOh My Second Brain doctor: ${diagnosis.status}.`);
     console.log(`Migration marker: ${diagnosis.migrationMarker}.`);
     console.log(`Managed template sources excluded: ${diagnosis.managedSourceExclusions.length}.`);
+    console.log(await hermesProvenanceSummary());
     if (diagnosis.unresolvedLegacyNotes.length > 0) {
       console.log(`Unresolved legacy notes: ${diagnosis.unresolvedLegacyNotes.length}.`);
     }

--- a/src/cli/host-operations.test.ts
+++ b/src/cli/host-operations.test.ts
@@ -998,7 +998,7 @@ describe("upsertClaudeHooks / removeClaudeHooks", () => {
     expect(await readFile(mcpPath, "utf-8")).toBe("[]\n");
   });
 
-  it("reconciles every managed host stamp to the latest selected vault without a legacy .oms registry", async () => {
+  it("reconciles managed host stamps while retaining a provenance-validated Hermes install", async () => {
     const home = await mkdtemp(path.join(tmpdir(), "oms-host-pointer-"));
     const first = path.join(home, "Vault A");
     const second = path.join(home, "Vault B");
@@ -1014,6 +1014,8 @@ describe("upsertClaudeHooks / removeClaudeHooks", () => {
       expect(managed).not.toContain(first);
     }
     const hermesConfig = parse(hermes) as { readonly mcp_servers: { readonly oms: { readonly args: readonly string[] } } };
+    // Identical assets are a provenance no-op, but the MCP registration must
+    // still reconcile to the newly selected vault.
     expect(hermesConfig.mcp_servers.oms.args).toEqual(["mcp", "--vault", second]);
     expect(claudeHooks).toContain("Vault B");
     expect(claudeHooks).not.toContain("Vault A");

--- a/src/cli/index-command.test.ts
+++ b/src/cli/index-command.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { engineStorePath } from "../kernel/engine/paths.js";
+import { runSearchCli } from "./search.js";
+
+const roots: string[] = [];
+
+async function makeVault(): Promise<string> {
+  const vault = path.join(tmpdir(), `oms-index-command-${crypto.randomUUID()}`);
+  await mkdir(path.join(vault, ".oms"), { recursive: true });
+  roots.push(vault);
+  return vault;
+}
+
+function createCorruptStore(vault: string): void {
+  const db = new Database(engineStorePath(vault));
+  try {
+    db.exec("CREATE TABLE engine_meta (id INTEGER PRIMARY KEY);");
+  } finally {
+    db.close();
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("oms index repair", () => {
+  it("requires the space-form closed mode enum with no duplicate or positional values", async () => {
+    const vault = await makeVault();
+    for (const argv of [
+      ["index", "repair"],
+      ["index", "repair", "--mode=rebuild"],
+      ["index", "repair", "--mode", "rebuild", "--mode", "drop"],
+      ["index", "repair", "--mode", "other"],
+      ["index", "repair", "--mode", "rebuild", "extra"],
+    ]) {
+      const writeError = vi.fn();
+      expect(await runSearchCli({ argv, vault, write: vi.fn(), writeError })).toBe(1);
+      expect(writeError).toHaveBeenCalled();
+    }
+  });
+
+  it("accepts --dry-run and reports the repair plan without opening the store", async () => {
+    const vault = await makeVault();
+    createCorruptStore(vault);
+    const write = vi.fn();
+    expect(await runSearchCli({
+      argv: ["index", "repair", "--mode", "rebuild", "--dry-run"],
+      vault,
+      write,
+      writeError: vi.fn(),
+    })).toBe(0);
+    expect(JSON.parse(write.mock.calls[0]![0] as string)).toMatchObject({
+      mode: "rebuild",
+      dryRun: true,
+      reindexRequired: true,
+      backupPath: expect.any(String),
+    });
+  });
+
+  it("quotes the rebuild command when status detects a corrupt legacy store", async () => {
+    const vault = await makeVault();
+    createCorruptStore(vault);
+    const writeError = vi.fn();
+    expect(await runSearchCli({ argv: ["index", "status"], vault, write: vi.fn(), writeError })).toBe(1);
+    expect(writeError).toHaveBeenCalledWith(expect.stringContaining("oms index repair --mode rebuild"));
+  });
+
+  it("removes the corrupt-store status failure after rebuild", async () => {
+    const vault = await makeVault();
+    createCorruptStore(vault);
+    expect(await runSearchCli({
+      argv: ["index", "repair", "--mode", "rebuild"],
+      vault,
+      write: vi.fn(),
+      writeError: vi.fn(),
+    })).toBe(0);
+    const writeError = vi.fn();
+    await runSearchCli({ argv: ["index", "status"], vault, write: vi.fn(), writeError });
+    expect(writeError).not.toHaveBeenCalledWith(expect.stringContaining("oms index repair --mode rebuild"));
+  });
+});

--- a/src/cli/index-command.ts
+++ b/src/cli/index-command.ts
@@ -7,6 +7,8 @@ import {
 } from "./search-args.js";
 import { runEngineSession } from "./engine-session.js";
 import { searchUsage } from "./search-usage.js";
+import { repairEngineStore } from "../kernel/engine/embed/repair.js";
+import { engineStoreDiagnostic } from "../kernel/engine/embed/store.js";
 
 export interface IndexCommandOptions {
   readonly args: ParsedSearchArgs;
@@ -18,6 +20,37 @@ export interface IndexCommandOptions {
 export async function runIndexCommand(options: IndexCommandOptions): Promise<number> {
   const { args, vault, write, writeError } = options;
   const command = args.positional[1];
+
+  if (command === "repair") {
+    const mode = stringOption(args, "mode");
+    if (args.positional.some((value) => value.startsWith("--mode="))) {
+      writeError('CLI "--mode=rebuild" is unsupported; use "--mode rebuild".');
+      return 1;
+    }
+    if (args.positional.length !== 2) {
+      writeError("Usage: oms index repair --mode rebuild|drop [--dry-run]");
+      return 1;
+    }
+    if (typeof args.options["mode"] === "string" && args.options["mode"].includes("\u0000")) {
+      writeError('CLI "--mode" may be specified only once.');
+      return 1;
+    }
+    if (mode === undefined) {
+      writeError('CLI "oms index repair" requires "--mode rebuild" or "--mode drop".');
+      return 1;
+    }
+    if (mode !== "rebuild" && mode !== "drop") {
+      writeError('CLI "oms index repair --mode" must be "rebuild" or "drop".');
+      return 1;
+    }
+    const unsupported = Object.keys(args.options).filter((key) => key !== "mode" && key !== "dryRun");
+    if (unsupported.length > 0) {
+      writeError(`[oms] Unsupported index repair option: --${unsupported[0]!.replace(/[A-Z]/gu, (letter) => `-${letter.toLowerCase()}`)}`);
+      return 1;
+    }
+    printJson(write, repairEngineStore({ vault, mode, dryRun: booleanOption(args, "dryRun") }));
+    return 0;
+  }
 
   if (command === "sync") {
     return runEngineSession(vault, { write: true, embed: false }, async (adapter) => {
@@ -37,11 +70,19 @@ export async function runIndexCommand(options: IndexCommandOptions): Promise<num
   }
 
   if (command === "status") {
-    return runEngineSession(vault, { write: false }, async (adapter) => {
-      const result = await adapter.semanticStatus({ vault, index: stringOption(args, "index") });
-      printJson(write, result);
-      return result.available ? 0 : 1;
-    });
+    try {
+      return await runEngineSession(vault, { write: false }, async (adapter) => {
+        const result = await adapter.semanticStatus({ vault, index: stringOption(args, "index") });
+        printJson(write, result);
+        return result.available ? 0 : 1;
+      });
+    } catch (error) {
+      if (engineStoreDiagnostic(error) === "corrupt-or-incompatible" && error instanceof Error) {
+        writeError(`${error.message} Run "oms index repair --mode rebuild" to create a fresh store.`);
+        return 1;
+      }
+      throw error;
+    }
   }
 
   if (command === "cleanup") {

--- a/src/cli/search-args.ts
+++ b/src/cli/search-args.ts
@@ -64,7 +64,7 @@ export function parseSearchArgs(argv: readonly string[]): ParsedSearchArgs {
       options["includeDefault"] = true;
     } else if (arg === "--no-include-default") {
       options["includeDefault"] = false;
-    } else if (arg === "--line-numbers" || arg === "--full-path" || arg === "--force" || arg === "--all" || arg === "--full" || arg === "--pull" || arg === "--update" || arg === "--embed" || arg === "--expand" || arg === "--rerank") {
+    } else if (arg === "--line-numbers" || arg === "--full-path" || arg === "--force" || arg === "--all" || arg === "--full" || arg === "--pull" || arg === "--update" || arg === "--embed" || arg === "--expand" || arg === "--rerank" || arg === "--dry-run") {
       options[camelOption(arg)] = true;
     } else if (arg === "--no-rerank") {
       options["rerank"] = false;

--- a/src/cli/search-usage.ts
+++ b/src/cli/search-usage.ts
@@ -4,6 +4,7 @@ export function searchUsage(): string {
   oms embed [--collection <name>] [--index <path>] [--force]
   oms index sync [--collection <name>] [--index <path>] [--force]
   oms index status [--index <path>]
+  oms index repair --mode rebuild|drop [--dry-run]
   oms index cleanup [--index <path>]
   oms index collections [name]
   oms index contexts

--- a/src/kernel/engine/embed/repair.test.ts
+++ b/src/kernel/engine/embed/repair.test.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { engineStorePath } from "../paths.js";
+import { ENGINE_EMBED_META_VERSION, openEngineStoreCoreReadOnly } from "./store.js";
+import { repairEngineStore } from "./repair.js";
+import { syncEngineStore } from "./sync.js";
+
+const roots: string[] = [];
+
+async function makeVault(): Promise<string> {
+  const root = await (async () => {
+    const directory = path.join(tmpdir(), `oms-repair-${crypto.randomUUID()}`);
+    await mkdir(path.join(directory, ".oms"), { recursive: true });
+    roots.push(directory);
+    await writeFile(path.join(directory, "note.md"), "# Note\n", "utf8");
+    await writeFile(path.join(directory, ".oms", "taxonomy.json"), "{}\n", "utf8");
+    await writeFile(path.join(directory, ".oms", "template-policy.json"), '{"templates":{}}\n', "utf8");
+    await writeFile(path.join(directory, ".oms", "types.json"), "{}\n", "utf8");
+    await writeFile(path.join(directory, ".oms", "models.json"), "{}\n", "utf8");
+    return directory;
+  })();
+  return root;
+}
+
+async function authorityHashes(vault: string): Promise<Map<string, string>> {
+  const files = [
+    "note.md",
+    ".oms/taxonomy.json",
+    ".oms/template-policy.json",
+    ".oms/types.json",
+    ".oms/models.json",
+  ];
+  return new Map(await Promise.all(files.map(async (file) => [
+    file,
+    createHash("sha256").update(await readFile(path.join(vault, file))).digest("hex"),
+  ] as const)));
+}
+
+function legacyStore(vault: string, kind: "missing-tables" | "missing-meta-column" | "normal"): void {
+  const db = new Database(engineStorePath(vault));
+  try {
+    if (kind === "missing-tables") {
+      db.exec("CREATE TABLE engine_meta (id INTEGER PRIMARY KEY);");
+    } else if (kind === "missing-meta-column") {
+      db.exec(`
+        CREATE TABLE engine_meta (id INTEGER PRIMARY KEY, embedding_schema_version TEXT NOT NULL);
+        INSERT INTO engine_meta (id, embedding_schema_version) VALUES (1, '${ENGINE_EMBED_META_VERSION}');
+        CREATE TABLE engine_chunk_meta (id INTEGER PRIMARY KEY);
+        CREATE VIRTUAL TABLE engine_chunk_fts USING fts5(text);
+      `);
+    } else {
+      db.exec(`
+        CREATE TABLE engine_meta (
+          id INTEGER PRIMARY KEY,
+          embedding_provider TEXT,
+          embedding_model TEXT,
+          embedding_revision TEXT,
+          embedding_sha256 TEXT,
+          embedding_dimensions INTEGER,
+          embedding_context_length INTEGER,
+          embedding_mrl_dim INTEGER,
+          embedding_normalization TEXT,
+          embedding_prefix_scheme TEXT,
+          embedding_fingerprint TEXT,
+          embedding_schema_version TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+        INSERT INTO engine_meta (id, embedding_schema_version, updated_at)
+        VALUES (1, '${ENGINE_EMBED_META_VERSION}', '2020-01-01T00:00:00.000Z');
+        CREATE TABLE engine_chunk_meta (rowid INTEGER PRIMARY KEY, doc_path TEXT NOT NULL, ordinal INTEGER NOT NULL, text TEXT NOT NULL, sha TEXT NOT NULL);
+        CREATE VIRTUAL TABLE engine_chunk_fts USING fts5(doc_path UNINDEXED, ordinal UNINDEXED, text);
+      `);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("repairEngineStore", () => {
+  it.each(["missing-tables", "missing-meta-column", "normal"] as const)(
+    "%s dry-run is non-mutating and rebuild preserves vault authority",
+    async (kind) => {
+      const vault = await makeVault();
+      legacyStore(vault, kind);
+      const before = await authorityHashes(vault);
+      const storePath = engineStorePath(vault);
+
+      const dryRun = repairEngineStore({
+        vault,
+        mode: "rebuild",
+        dryRun: true,
+        now: () => new Date("2026-09-01T10:00:00.000Z"),
+      });
+      expect(dryRun).toMatchObject({
+        storePath,
+        backupPath: `${storePath}.backup-20260901T100000000Z`,
+        reindexRequired: true,
+        dryRun: true,
+      });
+      await expect(stat(storePath)).resolves.toBeDefined();
+      expect(await authorityHashes(vault)).toEqual(before);
+
+      const rebuilt = repairEngineStore({
+        vault,
+        mode: "rebuild",
+        now: () => new Date("2026-09-01T10:00:00.000Z"),
+      });
+      expect(rebuilt.backupPath).not.toBeNull();
+      await expect(stat(rebuilt.backupPath!)).resolves.toBeDefined();
+      const store = openEngineStoreCoreReadOnly(storePath);
+      expect(store).not.toBeNull();
+      store?.close();
+      const db = new Database(storePath, { readonly: true });
+      try {
+        expect(db.prepare("SELECT embedding_schema_version FROM engine_meta WHERE id = 1").get())
+          .toEqual({ embedding_schema_version: ENGINE_EMBED_META_VERSION });
+      } finally {
+        db.close();
+      }
+      await syncEngineStore({ vault, embed: false });
+      const reindexed = openEngineStoreCoreReadOnly(storePath);
+      expect(reindexed?.listDocPaths()).toEqual(["note.md"]);
+      reindexed?.close();
+      expect(await authorityHashes(vault)).toEqual(before);
+    },
+  );
+
+  it("drop moves the store aside without creating a replacement or touching vault authority", async () => {
+    const vault = await makeVault();
+    legacyStore(vault, "normal");
+    const before = await authorityHashes(vault);
+    const result = repairEngineStore({
+      vault,
+      mode: "drop",
+      now: () => new Date("2026-09-01T10:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({ reindexRequired: true, dryRun: false });
+    await expect(stat(result.backupPath!)).resolves.toBeDefined();
+    await expect(stat(engineStorePath(vault))).rejects.toThrow();
+    expect(openEngineStoreCoreReadOnly(engineStorePath(vault))).toBeNull();
+    expect(await authorityHashes(vault)).toEqual(before);
+  });
+});

--- a/src/kernel/engine/embed/repair.ts
+++ b/src/kernel/engine/embed/repair.ts
@@ -1,0 +1,57 @@
+import { existsSync, renameSync } from "node:fs";
+import { openEngineStoreCore } from "./store.js";
+import { engineStorePath } from "../paths.js";
+
+export type EngineStoreRepairMode = "rebuild" | "drop";
+
+export interface EngineStoreRepairPlan {
+  readonly mode: EngineStoreRepairMode;
+  readonly storePath: string;
+  readonly backupPath: string | null;
+  readonly reindexRequired: boolean;
+  readonly dryRun: boolean;
+}
+
+export interface RepairEngineStoreOptions {
+  readonly vault: string;
+  readonly mode: EngineStoreRepairMode;
+  readonly dryRun?: boolean;
+  readonly now?: () => Date;
+}
+
+/**
+ * This service owns only the engine SQLite file and its SQLite sidecars. It
+ * never opens a legacy store and never writes vault Markdown or authoritative
+ * `.oms` files (taxonomy, template-policy, types, or models).
+ */
+export function repairEngineStore(options: RepairEngineStoreOptions): EngineStoreRepairPlan {
+  const storePath = engineStorePath(options.vault);
+  const backupPath = existsSync(storePath) ? backupStorePath(storePath, options.now?.() ?? new Date()) : null;
+  const plan: EngineStoreRepairPlan = {
+    mode: options.mode,
+    storePath,
+    backupPath,
+    reindexRequired: true,
+    dryRun: options.dryRun === true,
+  };
+  if (options.dryRun) return plan;
+
+  if (backupPath !== null) moveStoreWithSidecars(storePath, backupPath);
+  if (options.mode === "rebuild") {
+    const store = openEngineStoreCore(storePath);
+    store.close();
+  }
+  return plan;
+}
+
+function backupStorePath(storePath: string, now: Date): string {
+  const timestamp = now.toISOString().replace(/[-:.]/gu, "").replace("Z", "Z");
+  return `${storePath}.backup-${timestamp}`;
+}
+
+function moveStoreWithSidecars(storePath: string, backupPath: string): void {
+  renameSync(storePath, backupPath);
+  for (const suffix of ["-wal", "-shm"] as const) {
+    if (existsSync(`${storePath}${suffix}`)) renameSync(`${storePath}${suffix}`, `${backupPath}${suffix}`);
+  }
+}

--- a/src/kernel/engine/embed/store.ts
+++ b/src/kernel/engine/embed/store.ts
@@ -31,6 +31,22 @@ export interface EngineStoreCapabilities {
   readonly vecAvailable: boolean;
 }
 
+export type EngineStoreDiagnostic = "corrupt-or-incompatible";
+
+export class EngineStoreOpenError extends Error {
+  readonly diagnostic: EngineStoreDiagnostic;
+
+  constructor(diagnostic: EngineStoreDiagnostic, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "EngineStoreOpenError";
+    this.diagnostic = diagnostic;
+  }
+}
+
+export function engineStoreDiagnostic(error: unknown): EngineStoreDiagnostic | null {
+  return error instanceof EngineStoreOpenError ? error.diagnostic : null;
+}
+
 export interface EmbeddingIdentity {
   readonly provider: string;
   readonly model: string;
@@ -813,7 +829,8 @@ function openExistingCoreStore(dbPath: string): Database.Database | null {
   try {
     db = new Database(dbPath, { fileMustExist: true });
   } catch (error) {
-    throw new Error(
+    throw new EngineStoreOpenError(
+      "corrupt-or-incompatible",
       `Engine store is unavailable at "${dbPath}": ${error instanceof Error ? error.message : String(error)}`,
       { cause: error },
     );
@@ -824,7 +841,10 @@ function openExistingCoreStore(dbPath: string): Database.Database | null {
       "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?)",
     ).all(...REQUIRED_CORE_TABLES) as Array<{ name: string }>;
     if (rows.length !== REQUIRED_CORE_TABLES.length) {
-      throw new Error(`Engine store at "${dbPath}" is corrupt or incompatible: required core tables are missing.`);
+      throw new EngineStoreOpenError(
+        "corrupt-or-incompatible",
+        `Engine store at "${dbPath}" is corrupt or incompatible: required core tables are missing.`,
+      );
     }
     const metaColumns = new Set(
       (db.prepare("PRAGMA table_info(engine_meta)").all() as Array<{ name: string }>).map(
@@ -845,22 +865,27 @@ function openExistingCoreStore(dbPath: string): Database.Database | null {
       "embedding_schema_version",
     ];
     if (requiredMetaColumns.some((column) => !metaColumns.has(column))) {
-      throw new Error(`Engine store at "${dbPath}" is corrupt or incompatible: required metadata columns are missing.`);
+      throw new EngineStoreOpenError(
+        "corrupt-or-incompatible",
+        `Engine store at "${dbPath}" is corrupt or incompatible: required metadata columns are missing.`,
+      );
     }
     const version = db.prepare("SELECT embedding_schema_version FROM engine_meta WHERE id = 1")
       .get() as { embedding_schema_version: string } | undefined;
     if (!version || version.embedding_schema_version !== ENGINE_EMBED_META_VERSION) {
-      throw new Error(
+      throw new EngineStoreOpenError(
+        "corrupt-or-incompatible",
         `Embedding metadata version "${version?.embedding_schema_version}" is incompatible; expected "${ENGINE_EMBED_META_VERSION}".`,
       );
     }
     return db;
   } catch (error) {
     db.close();
-    if (error instanceof Error && error.message.startsWith(`Engine store at "${dbPath}"`)) {
+    if (error instanceof EngineStoreOpenError) {
       throw error;
     }
-    throw new Error(
+    throw new EngineStoreOpenError(
+      "corrupt-or-incompatible",
       `Engine store at "${dbPath}" is corrupt or unreadable: ${error instanceof Error ? error.message : String(error)}`,
       { cause: error },
     );

--- a/src/kernel/engine/graph/builder.test.ts
+++ b/src/kernel/engine/graph/builder.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { access, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { buildGraph, buildNodeIndex, loadCachedGraph, loadNodeIndex, nodeSourceSignature, saveCachedGraph, saveNodeIndex } from "./builder.js";
+import { buildGraph, buildNodeIndex, loadCachedGraph, loadNodeIndex, nodeSourceSignature, saveCachedGraph, saveNodeIndex, TYPE_AFFINITY_MAX_GROUP, typeAffinityCapWarnings } from "./builder.js";
 import type { Digest, ResolvedConvention, TemplateFolderPath, TemplateId, TemplateSourcePath } from "../../templates/types.js";
 
 let vault: string;
@@ -43,6 +43,12 @@ async function note(file: string, frontmatter: string, body = ""): Promise<void>
   const destination = path.join(vault, file);
   await mkdir(path.dirname(destination), { recursive: true });
   await writeFile(destination, `---\n${frontmatter}\n---\n${body}`, "utf8");
+}
+
+async function typeAffinityGroup(templateId: string, count: number, directory = templateId): Promise<void> {
+  await Promise.all([...Array(count)].map((_, index) =>
+    note(`notes/${directory}/${index.toString().padStart(3, "0")}.md`, `template: ${templateId}`, "body"),
+  ));
 }
 
 beforeEach(async () => {
@@ -109,6 +115,48 @@ describe("template-bound graph construction", () => {
     const resolved = convention();
     expect((await buildNodeIndex({ vaultPath: vault, convention: resolved })).map(node => node.path)).toEqual(["notes/a.md", "notes/z.md"]);
     expect(await nodeSourceSignature(vault, resolved)).toBe(await nodeSourceSignature(vault, resolved));
+  });
+
+  it.each([63, 64, 65])("caps type-affinity groups at the %i-note boundary", async (count) => {
+    await typeAffinityGroup("note", count);
+    const graph = await buildGraph({ vaultPath: vault, convention: convention() });
+    const affinity = graph.filter((edge) => edge.kind === "type-affinity");
+    expect(affinity).toHaveLength(count <= TYPE_AFFINITY_MAX_GROUP ? count * (count - 1) : 0);
+    const groups = new Map([["note", Array.from({ length: count }, (_, index) => String(index))]]);
+    expect(typeAffinityCapWarnings(groups)).toEqual(count <= TYPE_AFFINITY_MAX_GROUP
+      ? []
+      : ['Skipped type-affinity edges for template "note": 65 notes exceeds the 64-note limit.']);
+  });
+
+  it("restores unbounded type-affinity only with its explicit environment opt-in", async () => {
+    await typeAffinityGroup("note", 65);
+    const previous = process.env["OMS_TYPE_AFFINITY_UNBOUNDED"];
+    process.env["OMS_TYPE_AFFINITY_UNBOUNDED"] = "1";
+    try {
+      const graph = await buildGraph({ vaultPath: vault, convention: convention() });
+      expect(graph.filter((edge) => edge.kind === "type-affinity")).toHaveLength(65 * 64);
+      expect(typeAffinityCapWarnings(new Map([["note", Array.from({ length: 65 }, (_, index) => String(index))]]))).toEqual([]);
+    } finally {
+      if (previous === undefined) delete process.env["OMS_TYPE_AFFINITY_UNBOUNDED"];
+      else process.env["OMS_TYPE_AFFINITY_UNBOUNDED"] = previous;
+    }
+  });
+
+  it("counts only eligible groups in a mixed type-affinity build", async () => {
+    const resolved = convention();
+    const task = "task" as TemplateId;
+    const taskTemplate = {
+      ...resolved.templates[template]!,
+      id: task,
+      sourcePath: "Templates/task.md" as TemplateSourcePath,
+    };
+    await typeAffinityGroup("note", 63);
+    await typeAffinityGroup(task, 65);
+    const graph = await buildGraph({
+      vaultPath: vault,
+      convention: convention({ templates: { ...resolved.templates, [task]: taskTemplate } }),
+    });
+    expect(graph.filter((edge) => edge.kind === "type-affinity")).toHaveLength(63 * 62);
   });
 });
 

--- a/src/kernel/engine/graph/builder.ts
+++ b/src/kernel/engine/graph/builder.ts
@@ -12,6 +12,7 @@ import { buildWikilinkIndexWithFrontmatter, resolveWikilink } from "./resolver.j
 
 const CACHE_VERSION = 2;
 const NODE_CACHE_VERSION = 3;
+export const TYPE_AFFINITY_MAX_GROUP = 64;
 
 interface ParsedDoc {
   readonly docPath: string;
@@ -133,6 +134,26 @@ function selectedDocs(docs: readonly ParsedDoc[], convention: ResolvedConvention
 
 function adamicAdarContribution(degree: number): number { return degree <= 1 ? 0 : 1 / Math.log(degree); }
 
+export function typeAffinityCapWarnings(
+  groups: ReadonlyMap<string, readonly string[]>,
+  unbounded = process.env["OMS_TYPE_AFFINITY_UNBOUNDED"] === "1",
+): string[] {
+  return typeAffinityCappedTemplates(groups, unbounded)
+    .map(([template, members]) =>
+      `Skipped type-affinity edges for template "${template}": ${members.length} notes exceeds the ${TYPE_AFFINITY_MAX_GROUP}-note limit.`,
+    );
+}
+
+function typeAffinityCappedTemplates(
+  groups: ReadonlyMap<string, readonly string[]>,
+  unbounded: boolean,
+): [string, readonly string[]][] {
+  if (unbounded) return [];
+  return [...groups.entries()]
+    .filter(([, members]) => members.length > TYPE_AFFINITY_MAX_GROUP)
+    .sort(([left], [right]) => left.localeCompare(right));
+}
+
 /** Build graph edges from the current resolved template projection without writing vault state. */
 export async function buildGraph(opts: { readonly vaultPath: string; readonly convention: ResolvedConvention; readonly files?: readonly string[] }): Promise<GraphEdge[]> {
   const vault = path.resolve(opts.vaultPath);
@@ -186,8 +207,15 @@ export async function buildGraph(opts: { readonly vaultPath: string; readonly co
     members.push(doc.docPath);
     groups.set(id, members);
   }
-  for (const members of groups.values()) for (let left = 0; left < members.length; left++) for (let right = left + 1; right < members.length; right++) {
+  const cappedTemplates = new Set(typeAffinityCappedTemplates(
+    groups,
+    process.env["OMS_TYPE_AFFINITY_UNBOUNDED"] === "1",
+  ).map(([template]) => template));
+  for (const [template, members] of groups) {
+    if (cappedTemplates.has(template)) continue;
+    for (let left = 0; left < members.length; left++) for (let right = left + 1; right < members.length; right++) {
     edges.push({ from: members[left]!, to: members[right]!, weight: 1, kind: "type-affinity" }, { from: members[right]!, to: members[left]!, weight: 1, kind: "type-affinity" });
+  }
   }
   return edges.sort((left, right) => left.from.localeCompare(right.from) || left.to.localeCompare(right.to) || left.kind.localeCompare(right.kind) || left.weight - right.weight);
 }

--- a/src/kernel/install/provenance.test.ts
+++ b/src/kernel/install/provenance.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  computeTreeDigest,
+  decideOwnership,
+  parseProvenance,
+  serializeProvenance,
+  type OmsInstallProvenance,
+} from "./provenance.js";
+
+const roots: string[] = [];
+const expected = { version: "0.11.0", treeDigest: "expected-digest" };
+const matching: OmsInstallProvenance = {
+  schemaVersion: 1,
+  source: "npm",
+  version: expected.version,
+  treeDigest: expected.treeDigest,
+  installedAt: "2026-09-01T00:00:00.000Z",
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => import("node:fs/promises").then(({ rm }) => rm(root, { recursive: true, force: true }))));
+});
+
+describe("OMS install provenance", () => {
+  it("round-trips valid records and tolerates unknown fields", () => {
+    const serialized = serializeProvenance(matching);
+    expect(parseProvenance(serialized)).toEqual(matching);
+    expect(parseProvenance('{"schemaVersion":1,"source":"npm","version":"0.11.0","treeDigest":"x","installedAt":"now","future":true}')).toMatchObject({ version: "0.11.0" });
+    expect(parseProvenance("not json")).toBeNull();
+    expect(parseProvenance('{"schemaVersion":2}')).toBeNull();
+  });
+
+  it("hashes sorted relative paths and bytes", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-provenance-"));
+    roots.push(root);
+    await mkdir(path.join(root, "nested"));
+    await writeFile(path.join(root, "z.txt"), "z");
+    await writeFile(path.join(root, "nested", "a.txt"), "a");
+
+    expect(await computeTreeDigest(root)).toBe("11931989af15faac33fe84458ebc88e766673f121a4d5de4ab3bbaeefbb8df9d");
+  });
+
+  it.each([
+    ["installs an absent tree", null, null, "install"],
+    ["adopts a matching unrecorded legacy tree", null, expected.treeDigest, "adopt-legacy-candidate"],
+    ["rejects an unrecorded foreign tree", null, "foreign-digest", "reject-foreign"],
+    ["accepts a complete matching npm identity", matching, expected.treeDigest, "noop"],
+    ["replaces a stale npm version", { ...matching, version: "0.10.1" }, expected.treeDigest, "replace"],
+    ["replaces a tampered npm tree", matching, "tampered-digest", "replace"],
+  ] as const)("%s", (_name, existing, actualTreeDigest, action) => {
+    expect(decideOwnership(existing, expected, actualTreeDigest).action).toBe(action);
+  });
+});

--- a/src/kernel/install/provenance.ts
+++ b/src/kernel/install/provenance.ts
@@ -1,0 +1,102 @@
+import { createHash } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+export interface OmsInstallProvenance {
+  readonly schemaVersion: 1;
+  readonly source: "npm";
+  readonly version: string;
+  readonly treeDigest: string;
+  readonly installedAt: string;
+}
+
+/** Parses a provenance record without rejecting harmless unknown fields. */
+export function parseProvenance(raw: string): OmsInstallProvenance | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    record["schemaVersion"] !== 1 ||
+    record["source"] !== "npm" ||
+    typeof record["version"] !== "string" ||
+    typeof record["treeDigest"] !== "string" ||
+    typeof record["installedAt"] !== "string"
+  ) {
+    return null;
+  }
+  return {
+    schemaVersion: 1,
+    source: "npm",
+    version: record["version"],
+    treeDigest: record["treeDigest"],
+    installedAt: record["installedAt"],
+  };
+}
+
+export function serializeProvenance(provenance: OmsInstallProvenance): string {
+  return `${JSON.stringify(provenance, null, 2)}\n`;
+}
+
+/** Deterministic content digest of a file tree: sorted relative paths + bytes. */
+export async function computeTreeDigest(root: string): Promise<string> {
+  const hash = createHash("sha256");
+  const walk = async (directory: string): Promise<void> => {
+    const entries = (await readdir(directory, { withFileTypes: true }))
+      .sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absolute);
+      } else {
+        hash.update(path.relative(root, absolute));
+        hash.update("\0");
+        hash.update(await readFile(absolute));
+        hash.update("\0");
+      }
+    }
+  };
+  await walk(root);
+  return hash.digest("hex");
+}
+
+export type OwnershipDecision = {
+  readonly action: "install" | "noop" | "replace" | "reject-foreign" | "adopt-legacy-candidate";
+  readonly reason: string;
+};
+
+/** Decides whether an existing install can be safely reconciled. */
+export function decideOwnership(
+  existing: OmsInstallProvenance | null,
+  expected: { readonly version: string; readonly treeDigest: string },
+  actualTreeDigest: string | null,
+): OwnershipDecision {
+  if (existing === null) {
+    if (actualTreeDigest === null) {
+      return { action: "install", reason: "No installed tree or provenance record exists." };
+    }
+    if (actualTreeDigest === expected.treeDigest) {
+      return {
+        action: "adopt-legacy-candidate",
+        reason: "The unrecorded installed tree matches the expected package tree.",
+      };
+    }
+    return {
+      action: "reject-foreign",
+      reason: "An installed tree exists without valid OMS npm provenance.",
+    };
+  }
+
+  if (
+    existing.version === expected.version &&
+    existing.treeDigest === expected.treeDigest &&
+    actualTreeDigest === expected.treeDigest
+  ) {
+    return { action: "noop", reason: "Recorded and observed npm install identities match." };
+  }
+  return { action: "replace", reason: "Recorded or observed npm install identity has drifted." };
+}

--- a/src/kernel/update/update.test.ts
+++ b/src/kernel/update/update.test.ts
@@ -5,6 +5,7 @@ import {
   formatUpdateNotice,
   formatUpdateResult,
   runUpdate,
+  type RunUpdateOptions,
   type UpdateRunnerCall,
 } from "./update.js";
 
@@ -16,250 +17,159 @@ function failCall(stderr: string): UpdateRunnerCall {
   return { exitCode: 1, stdout: "", stderr };
 }
 
+const runningPrefix = "/opt/oms";
+const entrypoint = "/launch/oms.js";
+const realpath = () => `${runningPrefix}/lib/node_modules/oh-my-second-brain/dist/cli/oms.js`;
+function updateOptions(overrides: Partial<RunUpdateOptions> = {}): RunUpdateOptions {
+  return {
+    currentVersion: "0.1.7",
+    latestVersion: "0.1.8",
+    runtime: "codex",
+    vault: "/tmp/Vault",
+    yes: true,
+    entrypoint,
+    realpath,
+    ...overrides,
+  };
+}
+
+function matchingRunner(calls: string[], reconcileResult = okCall()): (command: string, args: readonly string[]) => UpdateRunnerCall {
+  return (command, args) => {
+    calls.push([command, ...args].join(" "));
+    if (command === "npm" && args.join(" ") === "prefix -g") return okCall(`${runningPrefix}\n`);
+    if (command === "npm") return okCall();
+    return reconcileResult;
+  };
+}
+
 describe("oms update", () => {
-  it("UPD-001 refuses a non-TTY update without mutating", async () => {
+  it("refuses a non-TTY update without mutating", async () => {
     const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runtime: "all",
-      vault: "/tmp/Vault",
-      interactive: false,
-      runner: (command, args) => {
-        calls.push([command, ...args].join(" "));
-        return okCall("0.1.8");
-      },
-    });
+    const result = await runUpdate(updateOptions({ yes: false, interactive: false, runner: matchingRunner(calls) }));
 
     expect(result.success).toBe(false);
-    expect(result.updateAvailable).toBe(true);
     expect(result.mutated).toBe(false);
     expect(calls).toEqual([]);
     expect(formatUpdateResult(result)).toContain("oms update --yes");
   });
 
-  it("UPD-001b prompts on a TTY and updates only after confirmation", async () => {
+  it("keeps dry-run non-mutating without resolving topology", async () => {
     const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runtime: "all",
-      vault: "/tmp/Vault",
-      interactive: true,
-      confirm: async () => true,
-      runner: (command, args) => {
-        calls.push([command, ...args].join(" "));
-        return okCall();
-      },
-    });
+    const result = await runUpdate(updateOptions({ dryRun: true, runner: matchingRunner(calls) }));
 
     expect(result.success).toBe(true);
-    expect(result.mutated).toBe(true);
-    expect(calls).toHaveLength(2);
-  });
-
-  it("UPD-001c leaves a TTY update untouched when confirmation is declined", async () => {
-    const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runtime: "all",
-      vault: "/tmp/Vault",
-      interactive: true,
-      confirm: async () => false,
-      runner: (command, args) => {
-        calls.push([command, ...args].join(" "));
-        return okCall();
-      },
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.mutated).toBe(false);
-    expect(calls).toEqual([]);
-  });
-
-  it("UPD-001e treats a closed TTY prompt as a declined confirmation", async () => {
-    const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runtime: "all",
-      vault: "/tmp/Vault",
-      interactive: true,
-      confirm: async () => {
-        throw new Error("stdin closed");
-      },
-      runner: (command, args) => {
-        calls.push([command, ...args].join(" "));
-        return okCall();
-      },
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.mutated).toBe(false);
-    expect(calls).toEqual([]);
-  });
-
-  it("UPD-001d keeps dry-run non-mutating regardless of TTY state", async () => {
-    const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runtime: "all",
-      vault: "/tmp/Vault",
-      interactive: true,
-      dryRun: true,
-      confirm: async () => {
-        throw new Error("dry-run must not prompt");
-      },
-      runner: (command, args) => {
-        calls.push([command, ...args].join(" "));
-        return okCall();
-      },
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.mutated).toBe(false);
-    expect(calls).toEqual([]);
-  });
-
-  it("UPD-002 compares SemVer prerelease identifiers before stable releases", () => {
-    const ordered = [
-      "1.0.0-alpha",
-      "1.0.0-alpha.1",
-      "1.0.0-alpha.beta",
-      "1.0.0-beta",
-      "1.0.0-beta.2",
-      "1.0.0-beta.11",
-      "1.0.0-rc.1",
-      "1.0.0",
-    ];
-
-    for (let index = 1; index < ordered.length; index++) {
-      expect(compareVersions(ordered[index - 1] as string, ordered[index] as string)).toBeLessThan(0);
-    }
-    expect(compareVersions("v1.0.0+build.1", "1.0.0+build.2")).toBe(0);
-  });
-
-  it("UPD-002 reports dry-run plan without invoking the runner", async () => {
-    const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runtime: "codex",
-      vault: "/tmp/Vault",
-      dryRun: true,
-      runner: (command, args) => {
-        calls.push([command, ...args].join(" "));
-        return okCall();
-      },
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.mutated).toBe(false);
-    expect(result.commands).toContain("npm install -g oh-my-second-brain@latest");
-    expect(result.commands.some((command) => command.includes("reconcile --runtime codex"))).toBe(true);
-    expect(calls).toEqual([]);
-  });
-
-  it("UPD-003 executes npm update and re-exec reconciliation only with yes", async () => {
-    const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runtime: "codex",
-      vault: "/tmp/Vault",
-      yes: true,
-      executeExternal: true,
-      reconcileCommand: { command: "node", argsPrefix: ["/pkg/dist/cli/oms.js"] },
-      runner: (command, args) => {
-        calls.push([command, ...args].join(" "));
-        return okCall();
-      },
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.mutated).toBe(true);
-    expect(calls).toEqual([
+    expect(result.commands).toEqual([
       "npm install -g oh-my-second-brain@latest",
-      "node /pkg/dist/cli/oms.js reconcile --runtime codex --vault /tmp/Vault --execute",
+      "oms reconcile --runtime codex --vault /tmp/Vault",
+    ]);
+    expect(calls).toEqual([]);
+  });
+
+  it("plans but does not execute reconciliation in check mode when already current", async () => {
+    const calls: string[] = [];
+    const result = await runUpdate(updateOptions({
+      currentVersion: "0.1.8",
+      latestVersion: "0.1.8",
+      check: true,
+      runner: matchingRunner(calls),
+    }));
+
+    expect(result.success).toBe(true);
+    expect(result.commands).toEqual(["oms reconcile --runtime codex --vault /tmp/Vault"]);
+    expect(calls).toEqual([]);
+  });
+
+  it("uses npm prefix matching the real running binary before installing", async () => {
+    const calls: string[] = [];
+    const result = await runUpdate(updateOptions({ runner: matchingRunner(calls), executeExternal: true }));
+
+    expect(result.success).toBe(true);
+    expect(calls).toEqual([
+      "npm prefix -g",
+      "npm install -g oh-my-second-brain@latest",
+      "/opt/oms/bin/oms reconcile --runtime codex --vault /tmp/Vault --execute",
     ]);
   });
 
-  it("UPD-004 skips reconciliation when npm update fails", async () => {
+  it("rejects an npm prefix mismatch without attempting installation", async () => {
     const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runtime: "all",
-      vault: "/tmp/Vault",
-      yes: true,
+    const result = await runUpdate(updateOptions({
       runner: (command, args) => {
         calls.push([command, ...args].join(" "));
-        return failCall("registry unavailable");
+        return okCall("/other/prefix\n");
       },
-    });
+    }));
 
     expect(result.success).toBe(false);
     expect(result.mutated).toBe(false);
-    expect(result.message).toContain("npm update failed");
-    expect(calls).toEqual(["npm install -g oh-my-second-brain@latest"]);
+    expect(calls).toEqual(["npm prefix -g"]);
+    expect(result.message).toContain("/opt/oms");
+    expect(result.message).toContain("/other/prefix");
+    expect(result.message).toContain("npm --prefix /opt/oms install -g oh-my-second-brain@latest");
   });
 
-  it("UPD-005 reports partial success when reconciliation fails after npm update", async () => {
+  it("rejects an unresolvable running binary without attempting installation", async () => {
     const calls: string[] = [];
-    const result = await runUpdate({
-      currentVersion: "0.1.7",
+    const result = await runUpdate(updateOptions({
+      realpath: () => { throw new Error("ENOENT"); },
+      runner: matchingRunner(calls),
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.mutated).toBe(false);
+    expect(calls).toEqual([]);
+    expect(result.message).toContain("ENOENT");
+  });
+
+  it("reconciles even when the installed package is already latest", async () => {
+    const calls: string[] = [];
+    const result = await runUpdate(updateOptions({
+      currentVersion: "0.1.8",
       latestVersion: "0.1.8",
-      runtime: "all",
-      vault: "/tmp/Vault",
-      yes: true,
-      reconcileCommand: { command: "node", argsPrefix: ["/pkg/dist/cli/oms.js"] },
+      runner: matchingRunner(calls),
+    }));
+
+    expect(result.success).toBe(true);
+    expect(result.updateAvailable).toBe(false);
+    expect(result.mutated).toBe(false);
+    expect(result.message).toContain("already up to date");
+    expect(result.message).toContain("reconciliation completed");
+    expect(calls).toEqual([
+      "npm prefix -g",
+      "/opt/oms/bin/oms reconcile --runtime codex --vault /tmp/Vault",
+    ]);
+  });
+
+  it("does not reconcile when installation fails", async () => {
+    const calls: string[] = [];
+    const result = await runUpdate(updateOptions({
       runner: (command, args) => {
         calls.push([command, ...args].join(" "));
-        return calls.length === 1 ? okCall() : failCall("host config refused");
+        return command === "npm" && args[0] === "prefix" ? okCall(`${runningPrefix}\n`) : failCall("registry unavailable");
       },
-    });
+    }));
+
+    expect(result.success).toBe(false);
+    expect(calls).toEqual(["npm prefix -g", "npm install -g oh-my-second-brain@latest"]);
+  });
+
+  it("reports the exact installed-bin resume command when reconciliation fails", async () => {
+    const calls: string[] = [];
+    const result = await runUpdate(updateOptions({ runner: matchingRunner(calls, failCall("host config refused")) }));
 
     expect(result.success).toBe(false);
     expect(result.mutated).toBe(true);
-    expect(result.message).toContain("reconciliation failed");
-    expect(calls).toHaveLength(2);
+    expect(result.message).toContain("Resume with `/opt/oms/bin/oms reconcile --runtime codex --vault /tmp/Vault`");
   });
 
-  it("UPD-NOTICE-001 reports an update notice without mutating", async () => {
-    const calls: string[] = [];
-    const notice = await checkUpdateNotice({
-      currentVersion: "0.1.7",
-      latestVersion: "0.1.8",
-      runner: (command, args) => {
-        calls.push([command, ...args].join(" "));
-        return okCall();
-      },
-    });
+  it("compares SemVer prerelease identifiers before stable releases", () => {
+    expect(compareVersions("1.0.0-rc.1", "1.0.0")).toBeLessThan(0);
+    expect(compareVersions("v1.0.0+build.1", "1.0.0+build.2")).toBe(0);
+  });
 
-    expect(notice).not.toBeNull();
-    expect(notice?.currentVersion).toBe("0.1.7");
-    expect(notice?.latestVersion).toBe("0.1.8");
-    expect(calls).toEqual([]);
+  it("reports an update notice without mutating", async () => {
+    const notice = await checkUpdateNotice({ currentVersion: "0.1.7", latestVersion: "0.1.8" });
+    expect(notice).toMatchObject({ currentVersion: "0.1.7", latestVersion: "0.1.8" });
     expect(formatUpdateNotice(notice)).toContain("oms update --yes");
-  });
-
-  it("UPD-NOTICE-002 stays silent when current version is already latest", async () => {
-    await expect(
-      checkUpdateNotice({
-        currentVersion: "0.1.8",
-        latestVersion: "0.1.8",
-      }),
-    ).resolves.toBeNull();
-  });
-
-  it("UPD-NOTICE-003 stays silent when registry lookup fails", async () => {
-    await expect(
-      checkUpdateNotice({
-        currentVersion: "0.1.7",
-        runner: () => failCall("registry unavailable"),
-      }),
-    ).resolves.toBeNull();
   });
 });

--- a/src/kernel/update/update.ts
+++ b/src/kernel/update/update.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import type { RuntimeSelection } from "../install/hosts.js";
 
@@ -43,6 +45,10 @@ export interface RunUpdateOptions {
   readonly executeExternal?: boolean;
   readonly timeoutMs?: number;
   readonly runner?: UpdateRunner;
+  /** Injectable only to make ownership topology deterministic in tests. */
+  readonly entrypoint?: string;
+  readonly realpath?: (target: string) => string;
+  /** Retained until #90 updates the host-command caller; topology intentionally ignores it. */
   readonly reconcileCommand?: ReconcileCommand;
 }
 
@@ -220,9 +226,56 @@ function buildReconcileArgs(options: {
 }
 
 function buildReconcileCommand(options: RunUpdateOptions): ReconcileCommand {
-  if (options.reconcileCommand !== undefined) return options.reconcileCommand;
-  const entrypoint = process.argv[1] ?? "oms";
-  return { command: process.execPath, argsPrefix: [entrypoint] };
+  const entrypoint = options.entrypoint ?? process.argv[1];
+  if (entrypoint === undefined) {
+    throw new Error("The running OMS binary path is unavailable.");
+  }
+  const binary = (options.realpath ?? realpathSync)(entrypoint);
+  const nodeModules = `${path.sep}lib${path.sep}node_modules${path.sep}`;
+  const index = binary.indexOf(nodeModules);
+  if (index === -1) {
+    throw new Error(`The running OMS binary is not owned by a global npm prefix: ${binary}`);
+  }
+  return {
+    command: path.join(binary.slice(0, index), "bin", "oms"),
+    argsPrefix: [],
+  };
+}
+
+async function resolveNpmTopology(
+  options: RunUpdateOptions,
+  runner: UpdateRunner,
+  timeoutMs: number,
+): Promise<
+  | { readonly ok: true; readonly reconcile: ReconcileCommand }
+  | { readonly ok: false; readonly error: string }
+> {
+  let reconcile: ReconcileCommand;
+  try {
+    reconcile = buildReconcileCommand(options);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `${detail} Run \`npm prefix -g\` and use that installation's \`oms reconcile\` command manually.` };
+  }
+
+  const prefixResult = await runner("npm", ["prefix", "-g"], { timeoutMs });
+  const npmPrefix = prefixResult.stdout.trim();
+  if (prefixResult.exitCode !== 0 || npmPrefix.length === 0) {
+    const detail = prefixResult.stderr.trim() || prefixResult.stdout.trim() || "npm prefix -g failed";
+    return {
+      ok: false,
+      error: `Unable to resolve npm's global prefix: ${detail}. Run \`npm prefix -g\` and then \`${reconcile.command} reconcile\` manually.`,
+    };
+  }
+
+  const runningPrefix = path.dirname(path.dirname(reconcile.command));
+  if (path.resolve(runningPrefix) !== path.resolve(npmPrefix)) {
+    return {
+      ok: false,
+      error: `Refusing to update: running OMS binary belongs to ${runningPrefix} (version ${options.currentVersion ?? "unknown"}), but npm prefix -g resolved ${npmPrefix} (target version ${options.latestVersion ?? "latest"}). Run \`npm --prefix ${runningPrefix} install -g ${options.packageName ?? DEFAULT_PACKAGE_NAME}@latest\` and then \`${reconcile.command} reconcile --runtime ${options.runtime} --vault ${options.vault}\` manually.`,
+    };
+  }
+  return { ok: true, reconcile };
 }
 
 export async function runUpdate(options: RunUpdateOptions): Promise<UpdateResult> {
@@ -252,47 +305,32 @@ export async function runUpdate(options: RunUpdateOptions): Promise<UpdateResult
   const updateAvailable =
     currentVersion === null || compareVersions(currentVersion, latest.version) < 0;
   const npmArgs = ["install", "-g", `${packageName}@latest`];
-  const reconcile = buildReconcileCommand(options);
-  const reconcileArgs = [
-    ...reconcile.argsPrefix,
-    ...buildReconcileArgs({
-      runtime: options.runtime,
-      vault: options.vault,
-      executeExternal: options.executeExternal === true,
-    }),
-  ];
+  const reconcileArgs = buildReconcileArgs({
+    runtime: options.runtime,
+    vault: options.vault,
+    executeExternal: options.executeExternal === true,
+  });
   const commands = [
     formatCommand("npm", npmArgs),
-    formatCommand(reconcile.command, reconcileArgs),
+    formatCommand("oms", reconcileArgs),
   ];
-
-  if (!updateAvailable) {
-    return {
-      success: true,
-      currentVersion,
-      latestVersion: latest.version,
-      updateAvailable: false,
-      mutated: false,
-      message: `Oh My Second Brain is already up to date (${currentVersion ?? latest.version}).`,
-      commands: [],
-      errors: [],
-    };
-  }
 
   if (options.dryRun === true || options.check === true) {
     return {
       success: true,
       currentVersion,
       latestVersion: latest.version,
-      updateAvailable: true,
+      updateAvailable,
       mutated: false,
-      message: `Update available: ${currentVersion ?? "unknown"} -> ${latest.version}.`,
-      commands,
+      message: updateAvailable
+        ? `Update available: ${currentVersion ?? "unknown"} -> ${latest.version}.`
+        : `Oh My Second Brain is already up to date (${currentVersion ?? latest.version}); reconciliation is planned.`,
+      commands: updateAvailable ? commands : [formatCommand("oms", reconcileArgs)],
       errors: [],
     };
   }
 
-  if (options.yes !== true) {
+  if (updateAvailable && options.yes !== true) {
     if (options.interactive !== true) {
       return {
         success: false,
@@ -326,22 +364,40 @@ export async function runUpdate(options: RunUpdateOptions): Promise<UpdateResult
     }
   }
 
-  const npmResult = await runner("npm", npmArgs, { timeoutMs });
-  if (npmResult.exitCode !== 0) {
-    const error = npmResult.stderr.trim() || npmResult.stdout.trim() || "npm install failed";
+  const topology = await resolveNpmTopology(options, runner, timeoutMs);
+  if (!topology.ok) {
     return {
       success: false,
       currentVersion,
       latestVersion: latest.version,
-      updateAvailable: true,
+      updateAvailable,
       mutated: false,
-      message: `npm update failed: ${error}`,
+      message: topology.error,
       commands,
-      errors: [error],
+      errors: [topology.error],
     };
   }
+  const reconcile = topology.reconcile;
+  const installedReconcileArgs = [...reconcile.argsPrefix, ...reconcileArgs];
 
-  const reconcileResult = await runner(reconcile.command, reconcileArgs, {
+  if (updateAvailable) {
+    const npmResult = await runner("npm", npmArgs, { timeoutMs });
+    if (npmResult.exitCode !== 0) {
+      const error = npmResult.stderr.trim() || npmResult.stdout.trim() || "npm install failed";
+      return {
+        success: false,
+        currentVersion,
+        latestVersion: latest.version,
+        updateAvailable: true,
+        mutated: false,
+        message: `npm update failed: ${error}`,
+        commands,
+        errors: [error],
+      };
+    }
+  }
+
+  const reconcileResult = await runner(reconcile.command, installedReconcileArgs, {
     timeoutMs,
     env: { OMS_UPDATE_RECONCILE: "1" },
   });
@@ -352,9 +408,9 @@ export async function runUpdate(options: RunUpdateOptions): Promise<UpdateResult
       success: false,
       currentVersion,
       latestVersion: latest.version,
-      updateAvailable: true,
-      mutated: true,
-      message: `Updated package to ${latest.version}, but reconciliation failed: ${error}`,
+      updateAvailable,
+      mutated: updateAvailable,
+      message: `${updateAvailable ? `Updated package to ${latest.version}, but` : "Package is already up to date, but"} reconciliation failed: ${error}. Resume with \`${reconcile.command} ${installedReconcileArgs.join(" ")}\`.`,
       commands,
       errors: [error],
     };
@@ -364,9 +420,11 @@ export async function runUpdate(options: RunUpdateOptions): Promise<UpdateResult
     success: true,
     currentVersion,
     latestVersion: latest.version,
-    updateAvailable: true,
-    mutated: true,
-    message: `Successfully updated Oh My Second Brain from ${currentVersion ?? "unknown"} to ${latest.version}.`,
+    updateAvailable,
+    mutated: updateAvailable,
+    message: updateAvailable
+      ? `Successfully updated Oh My Second Brain from ${currentVersion ?? "unknown"} to ${latest.version}.`
+      : `Oh My Second Brain is already up to date (${currentVersion ?? latest.version}); runtime reconciliation completed.`,
     commands,
     errors: [],
   };

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -11,7 +11,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
 import { parse } from "yaml";
 import { harnessSurfaceRegistry } from "../kernel/harness/surface-registry.js";
-import { omsMcpTools } from "./server.js";
+import { omsMcpTools, resolveOperation, unknownOperationMessage } from "./server.js";
 import { sourceSignature } from "../kernel/templates/index.js";
 import type { SourceDescriptor } from "../kernel/templates/types.js";
 
@@ -323,6 +323,40 @@ describe("Oh My Second Brain MCP stdio server", () => {
     expect(write({ op: "note", mode: "update", notePath: "notes/x.md", frontmatter: { title: "x" } }).valid).toBe(true);
     expect(write({ op: "note", templateId: "literature", mode: "create", folder: "references" }).valid).toBe(false);
     expect(JSON.stringify(toolByName.get("oms_search")!.inputSchema)).not.toContain("concept");
+  });
+
+  it("requires an op for routed tools and reports deterministic supported operations", () => {
+    const normalOperations = [
+      ["oms_write", "note", "write-note"],
+      ["oms_search", "query", "oms_semantic_query"],
+      ["oms_link", "suggest", "oms_link_suggest"],
+      ["oms_status", undefined, "oms_graph_status"],
+      ["oms_doctor", "audit", "oms_vault_audit"],
+    ] as const;
+    const schemas = new Map(omsMcpTools.map((tool) => [tool.name, tool.inputSchema as {
+      readonly required?: readonly string[];
+      readonly oneOf?: readonly { readonly required: readonly string[] }[];
+    }]));
+
+    for (const [tool, op, name] of normalOperations) {
+      expect(resolveOperation(tool, op), tool).toBe(name);
+      expect(resolveOperation(tool, "typo"), tool).toBeUndefined();
+      if (tool === "oms_status") {
+        expect(schemas.get(tool)?.required).not.toContain("op");
+        expect(unknownOperationMessage(tool, "typo")).toBe(
+          'Unknown operation "typo" for oms_status. Supported operations: (none).',
+        );
+      } else {
+        expect(resolveOperation(tool, undefined), tool).toBeUndefined();
+        expect(schemas.get(tool)?.oneOf?.every((branch) => branch.required.includes("op")), tool).toBe(true);
+        expect(unknownOperationMessage(tool, undefined), tool).toMatch(
+          new RegExp(`^Unknown operation "\\(missing\\)" for ${tool}\\. Supported operations: .+\\.$`),
+        );
+      }
+    }
+    expect(unknownOperationMessage("oms_search", undefined)).toBe(
+      'Unknown operation "(missing)" for oms_search. Supported operations: collections, context, contexts, get-document, lazy-load, multi-get-documents, query, status, templates.',
+    );
   });
 
   it("registers only the five public tools and retires detail aliases", () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -242,10 +242,18 @@ function operationSchema(tool: string): Tool["inputSchema"] {
   }
   return { type: "object", oneOf: branches };
 }
-function resolveOperation(tool: string, op: string | undefined): string | undefined {
+export function resolveOperation(tool: string, op: string | undefined): string | undefined {
   return operations[tool]?.find(
-    (operation) => operation.direct || operation.op === op,
+    (operation) => (operation.direct && op === undefined) || operation.op === op,
   )?.name;
+}
+
+export function unknownOperationMessage(tool: string, op: string | undefined): string {
+  const supported = (operations[tool] ?? [])
+    .map((operation) => operation.op)
+    .filter((operation): operation is string => operation !== undefined)
+    .sort();
+  return `Unknown operation "${op ?? "(missing)"}" for ${tool}. Supported operations: ${supported.join(", ") || "(none)"}.`;
 }
 
 export const omsMcpTools: Tool[] = [
@@ -473,7 +481,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     const publicName = request.params.name;
     const op = stringArg(args, "op");
     const name = resolveOperation(publicName, op);
-    if (!name) return errorText(`Unknown operation "${op ?? "(missing)"}" for ${publicName}.`);
+    if (!name) return errorText(unknownOperationMessage(publicName, op));
     if (publicName === "oms_search" && op === "query") {
       const searches = args?.["searches"];
       if (typeof args?.["query"] === "string" && Array.isArray(searches)) {

--- a/src/vendors/hermes/hermes.test.ts
+++ b/src/vendors/hermes/hermes.test.ts
@@ -1,10 +1,11 @@
 import * as fsPromises from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { harnessSurfaceRegistry } from "../../kernel/harness/surface-registry.js";
+import { computeTreeDigest, parseProvenance } from "../../kernel/install/provenance.js";
 import { installHermes, uninstallHermes } from "./hermes.js";
 
 vi.mock("node:fs/promises", async importOriginal => {
@@ -58,7 +59,10 @@ describe("installHermes transaction", () => {
       write.mockImplementationOnce(async () => { throw new Error("config write failed"); });
       return write;
     }],
-    ["install verification", (api: typeof fsPromises) => vi.mocked(api.readdir).mockRejectedValueOnce(new Error("verification failed"))],
+    ["install verification", (api: typeof fsPromises) => vi.mocked(api.readdir).mockImplementation(async (directory, options) => {
+      if (String(directory).includes(".hermes/skills/knowledge-management/oms")) throw new Error("verification failed");
+      return await originalFs.readdir(directory, options);
+    })],
   ])("restores config and converges after a %s failure", async (_name, inject) => {
     const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
     temporaryDirectories.push(home);
@@ -89,7 +93,10 @@ describe("installHermes transaction", () => {
     await writeFile(config, "mcp_servers:\n  other: keep\n");
     const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
     if (!host) throw new Error("Hermes surface missing");
-    const readdir = vi.mocked(fsPromises.readdir).mockRejectedValueOnce(new Error("verification failed"));
+    const readdir = vi.mocked(fsPromises.readdir).mockImplementation(async (directory, options) => {
+      if (String(directory).includes(".hermes/skills/knowledge-management/oms")) throw new Error("verification failed");
+      return await originalFs.readdir(directory, options);
+    });
     const write = vi.mocked(fsPromises.writeFile);
     let temporaryWrites = 0;
     write.mockImplementation(async (file, data, options) => {
@@ -150,6 +157,74 @@ describe("installHermes transaction", () => {
     await expect(readFile(path.join(home, ".hermes", "config.yaml"), "utf8")).resolves.not.toContain("oms:");
     expect(existsSync(path.join(home, ".hermes", "adapters", "oms"))).toBe(false);
     expect(existsSync(path.join(home, ".hermes", "skills", "knowledge-management", "oms"))).toBe(false);
+  });
+
+  it("records provenance outside the seven-skill layout and makes an identical reinstall a no-op", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+    const options = { action: "install" as const, runtime: "hermes" as const, vault: "/vault", homeDir: home, adapterRoot: path.resolve(".") };
+    await installHermes(options, host);
+    const hermes = path.join(home, ".hermes");
+    const skills = path.join(hermes, "skills", "knowledge-management", "oms");
+    const provenanceFile = path.join(hermes, "adapters", "oms", ".oms-provenance.json");
+    const provenance = parseProvenance(await readFile(provenanceFile, "utf8"));
+    expect(await readdir(skills)).toHaveLength(7);
+    expect(provenance).toMatchObject({ source: "npm", version: "0.10.1", treeDigest: await computeTreeDigest(skills) });
+    const before = await readFile(provenanceFile, "utf8");
+    await expect(installHermes(options, host)).resolves.toMatchObject({ changed: false, skipped: true });
+    expect(await readFile(provenanceFile, "utf8")).toBe(before);
+  });
+
+  it("refuses foreign provenance without changing the pre-existing tree", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const hermes = path.join(home, ".hermes");
+    const skills = path.join(hermes, "skills", "knowledge-management", "oms");
+    const provenance = path.join(hermes, "adapters", "oms", ".oms-provenance.json");
+    await mkdir(skills, { recursive: true });
+    await writeFile(path.join(skills, "foreign.txt"), "foreign\n");
+    await mkdir(path.dirname(provenance), { recursive: true });
+    await writeFile(provenance, '{"source":"tap"}\n');
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+    await expect(installHermes({
+      action: "install", runtime: "hermes", vault: "/vault", homeDir: home, adapterRoot: path.resolve("."),
+    }, host)).rejects.toThrow("not valid npm provenance");
+    expect(await readFile(path.join(skills, "foreign.txt"), "utf8")).toBe("foreign\n");
+  });
+
+  it("adopts only the exact legacy seven-skill layout", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+    const options = { action: "install" as const, runtime: "hermes" as const, vault: "/vault", homeDir: home, adapterRoot: path.resolve(".") };
+    await installHermes(options, host);
+    const hermes = path.join(home, ".hermes");
+    const skills = path.join(hermes, "skills", "knowledge-management", "oms");
+    const provenance = path.join(hermes, "adapters", "oms", ".oms-provenance.json");
+    await rm(provenance);
+    await writeFile(path.join(skills, "write", "SKILL.md"), "legacy\n");
+    await expect(installHermes(options, host)).resolves.toMatchObject({ changed: true });
+    expect(parseProvenance(await readFile(provenance, "utf8"))).not.toBeNull();
+    await rm(provenance);
+    await mkdir(path.join(skills, "unexpected"));
+    await expect(installHermes(options, host)).rejects.toThrow("exact legacy OMS layout");
+  });
+
+  it("refuses uninstall of a tampered npm-owned tree", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
+    temporaryDirectories.push(home);
+    const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
+    if (!host) throw new Error("Hermes surface missing");
+    const options = { action: "install" as const, runtime: "hermes" as const, vault: "/vault", homeDir: home, adapterRoot: path.resolve(".") };
+    await installHermes(options, host);
+    const skill = path.join(home, ".hermes", "skills", "knowledge-management", "oms", "write", "SKILL.md");
+    await writeFile(skill, "tampered\n");
+    await expect(uninstallHermes({ ...options, action: "uninstall" })).rejects.toThrow("not verified OMS npm ownership");
+    expect(existsSync(skill)).toBe(true);
   });
 });
 

--- a/src/vendors/hermes/hermes.ts
+++ b/src/vendors/hermes/hermes.ts
@@ -1,10 +1,16 @@
-import { createHash } from "node:crypto";
 import { existsSync, lstatSync } from "node:fs";
 import { cp, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseDocument } from "yaml";
 import type { HarnessHostSurface } from "../../kernel/harness/surface-registry.js";
 import { resolveHostAdapterSource } from "../../kernel/install/adapter-source.js";
+import {
+  computeTreeDigest,
+  decideOwnership,
+  parseProvenance,
+  serializeProvenance,
+  type OmsInstallProvenance,
+} from "../../kernel/install/provenance.js";
 import { resolveSharedSkillsSource } from "../../assets/shared-skills.js";
 import {
   InstallTargetSymlinkError,
@@ -44,31 +50,6 @@ async function rollbackConfig(configPath: string, preImage: Buffer | undefined, 
   throw original;
 }
 
-/** Deterministic content digest of a file tree: sorted relative paths + bytes. */
-async function treeDigest(root: string): Promise<string> {
-  const hash = createHash("sha256");
-  const walk = async (directory: string): Promise<void> => {
-    const entries = (await readdir(directory, { withFileTypes: true })).sort((left, right) => left.name.localeCompare(right.name));
-    for (const entry of entries) {
-      const absolute = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        await walk(absolute);
-      } else {
-        hash.update(path.relative(root, absolute));
-        hash.update("\0");
-        hash.update(await readFile(absolute));
-        hash.update("\0");
-      }
-    }
-  };
-  await walk(root);
-  return hash.digest("hex");
-}
-
-async function fileDigest(file: string): Promise<string> {
-  return createHash("sha256").update(await readFile(file)).digest("hex");
-}
-
 async function verifyHermesInstall(configPath: string, skillTarget: string, options: HostOperationOptions): Promise<void> {
   const raw = existsSync(configPath) ? await readFile(configPath) : Buffer.alloc(0);
   const document = parseDocument(raw.toString("utf8"));
@@ -99,11 +80,11 @@ async function verifyHermesTrees(
   skillTarget: string,
   adapterFiles: readonly { readonly source: string; readonly target: string }[],
 ): Promise<void> {
-  if ((await treeDigest(skillSource)) !== (await treeDigest(skillTarget))) {
+  if ((await computeTreeDigest(skillSource)) !== (await computeTreeDigest(skillTarget))) {
     throw new Error("Hermes install verification failed: installed skill tree does not match the prepared source");
   }
   for (const file of adapterFiles) {
-    if ((await fileDigest(file.source)) !== (await fileDigest(file.target))) {
+    if (!(await readFile(file.source)).equals(await readFile(file.target))) {
       throw new Error(`Hermes install verification failed: installed adapter asset does not match its source: ${file.target}`);
     }
   }
@@ -120,6 +101,26 @@ async function verifyHermesUninstall(configPath: string, targets: readonly strin
   }
 }
 
+function canonicalSkillLayout(entries: readonly string[]): boolean {
+  return entries.length === HERMES_SKILLS.length &&
+    entries.every(entry => HERMES_SKILLS.includes(entry as (typeof HERMES_SKILLS)[number]));
+}
+
+async function legacyOwnershipEvidence(skillTarget: string, adapterManifestTarget: string): Promise<boolean> {
+  return existsSync(skillTarget) && existsSync(adapterManifestTarget) &&
+    canonicalSkillLayout(await readdir(skillTarget));
+}
+
+async function readProvenance(file: string): Promise<{ readonly provenance: OmsInstallProvenance | null; readonly raw: string | null }> {
+  if (!existsSync(file)) return { provenance: null, raw: null };
+  const raw = await readFile(file, "utf8");
+  return { provenance: parseProvenance(raw), raw };
+}
+
+function foreignOwnershipError(reason: string): Error {
+  return new Error(`Refusing to replace Hermes OMS assets: ${reason} Remove or migrate the existing installation before retrying.`);
+}
+
 export async function installHermes(options: HostOperationOptions, host: HarnessHostSurface): Promise<HostOperationResult> {
   const hermesDir = hostHome(options.homeDir, ".hermes", "OMS_HERMES_HOME");
   const adapterSource = resolveHostAdapterSource(options.adapterRoot, host);
@@ -132,13 +133,35 @@ export async function installHermes(options: HostOperationOptions, host: Harness
   const adapterManifestTarget = path.join(adapterTarget, "hermes-manifest.json");
   const guidanceTarget = path.join(adapterTarget, "SOUL.md");
   const readmeTarget = path.join(adapterTarget, "README.md");
+  const provenanceTarget = path.join(adapterTarget, ".oms-provenance.json");
   const messages = ["Installed Hermes-native Oh My Second Brain skill bundle and registered mcp_servers.oms in ~/.hermes/config.yaml."];
+  const manifest = JSON.parse(await readFile(path.join(adapterSource, "hermes-manifest.json"), "utf8")) as { version?: unknown };
+  const packageMetadata = JSON.parse(await readFile(new URL("../../../package.json", import.meta.url), "utf8")) as { version?: unknown };
+  if (typeof packageMetadata.version !== "string" || manifest.version !== packageMetadata.version) {
+    throw new Error("Hermes install source package version does not match its manifest");
+  }
+  const expected = { version: packageMetadata.version, treeDigest: await computeTreeDigest(skillSource) };
   if (!options.dryRun) {
     // Prepare + admission: all input and host safety checks precede every write.
     for (const source of [skillSource, path.join(adapterSource, "hermes-manifest.json"), path.join(adapterSource, "hermes", "SOUL.md"), path.join(adapterSource, "hermes", "README.md")]) {
       if (!existsSync(source)) throw new Error(`Hermes install source is missing: ${source}`);
     }
-    for (const target of [legacyPluginTarget, legacyMcpPath, adapterTarget, skillTarget, configPath]) refuseSymlink(target);
+    for (const target of [legacyPluginTarget, legacyMcpPath, adapterTarget, skillTarget, configPath, provenanceTarget]) refuseSymlink(target);
+    const recorded = await readProvenance(provenanceTarget);
+    const actualTreeDigest = existsSync(skillTarget) ? await computeTreeDigest(skillTarget) : null;
+    if (recorded.raw !== null && recorded.provenance === null) {
+      throw foreignOwnershipError("the provenance record is not valid npm provenance.");
+    }
+    const ownership = decideOwnership(recorded.provenance, expected, actualTreeDigest);
+    if (ownership.action === "adopt-legacy-candidate" || ownership.action === "reject-foreign") {
+      if (!await legacyOwnershipEvidence(skillTarget, adapterManifestTarget)) {
+        throw foreignOwnershipError(
+          ownership.action === "adopt-legacy-candidate"
+            ? "the unrecorded skill tree does not have the exact legacy OMS layout."
+            : ownership.reason,
+        );
+      }
+    }
     const preImage = existsSync(configPath) ? await readFile(configPath) : undefined;
     const configRaw = preImage?.toString("utf8") ?? "";
     if (preImage && !preImage.equals(Buffer.from(configRaw, "utf8"))) throw new Error("Hermes config.yaml is not valid UTF-8");
@@ -146,6 +169,28 @@ export async function installHermes(options: HostOperationOptions, host: Harness
       kind: "set",
       value: { ...mcpServerEntry(options), enabled: true },
     });
+    if (ownership.action === "noop") {
+      // Assets are identical; the MCP registration may still differ (for example a
+      // new vault). Reconcile only the config commit under the same rollback rule.
+      if (!config.changed) {
+        return {
+          runtime: "hermes", action: "install", changed: false, skipped: true,
+          paths: [adapterTarget, guidanceTarget, readmeTarget, skillTarget, provenanceTarget, configPath],
+          commands: [`Hermes MCP config: ${configPath}`], messages,
+        };
+      }
+      try {
+        await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
+        await verifyHermesInstall(configPath, skillTarget, options);
+      } catch (error) {
+        await rollbackConfig(configPath, preImage, error);
+      }
+      return {
+        runtime: "hermes", action: "install", changed: true, skipped: false,
+        paths: [adapterTarget, guidanceTarget, readmeTarget, skillTarget, provenanceTarget, configPath],
+        commands: [`Hermes MCP config: ${configPath}`], messages,
+      };
+    }
     try {
       // OMS-owned files commit first. config.yaml is deliberately the final commit.
       await rm(legacyPluginTarget, { recursive: true, force: true });
@@ -156,6 +201,13 @@ export async function installHermes(options: HostOperationOptions, host: Harness
       await cp(path.join(adapterSource, "hermes-manifest.json"), adapterManifestTarget);
       await cp(path.join(adapterSource, "hermes", "SOUL.md"), guidanceTarget);
       await cp(path.join(adapterSource, "hermes", "README.md"), readmeTarget);
+      await atomicWrite(provenanceTarget, Buffer.from(serializeProvenance({
+        schemaVersion: 1,
+        source: "npm",
+        version: expected.version,
+        treeDigest: expected.treeDigest,
+        installedAt: new Date().toISOString(),
+      }), "utf8"));
       if (config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
       await verifyHermesInstall(configPath, skillTarget, options);
       await verifyHermesTrees(skillSource, skillTarget, [
@@ -164,6 +216,8 @@ export async function installHermes(options: HostOperationOptions, host: Harness
         { source: path.join(adapterSource, "hermes", "README.md"), target: readmeTarget },
       ]);
     } catch (error) {
+      await rm(skillTarget, { recursive: true, force: true });
+      await rm(adapterTarget, { recursive: true, force: true });
       await rollbackConfig(configPath, preImage, error);
     }
   }
@@ -172,7 +226,7 @@ export async function installHermes(options: HostOperationOptions, host: Harness
     action: "install",
     changed: !options.dryRun,
     skipped: false,
-    paths: [adapterTarget, guidanceTarget, readmeTarget, skillTarget, configPath],
+    paths: [adapterTarget, guidanceTarget, readmeTarget, skillTarget, provenanceTarget, configPath],
     commands: [`Hermes MCP config: ${configPath}`],
     messages,
   };
@@ -185,25 +239,36 @@ export async function uninstallHermes(options: HostOperationOptions): Promise<Ho
   const legacyPluginTarget = path.join(hermesDir, "plugins", "oms");
   const legacyMcpPath = path.join(hermesDir, "mcp", "oms.json");
   const configPath = path.join(hermesDir, "config.yaml");
+  const adapterManifestTarget = path.join(adapterTarget, "hermes-manifest.json");
+  const provenanceTarget = path.join(adapterTarget, ".oms-provenance.json");
+  const recorded = await readProvenance(provenanceTarget);
+  const actualTreeDigest = existsSync(skillTarget) ? await computeTreeDigest(skillTarget) : null;
+  const ownsInstall = (recorded.provenance !== null && actualTreeDigest === recorded.provenance.treeDigest) ||
+    (recorded.raw === null && await legacyOwnershipEvidence(skillTarget, adapterManifestTarget));
+  if ((existsSync(skillTarget) || existsSync(adapterTarget)) && !ownsInstall) {
+    throw foreignOwnershipError("the installed tree is not verified OMS npm ownership.");
+  }
   const preImage = existsSync(configPath) ? await readFile(configPath) : undefined;
   const configRaw = preImage?.toString("utf8") ?? "";
   if (preImage && !preImage.equals(Buffer.from(configRaw, "utf8"))) throw new Error("Hermes config.yaml is not valid UTF-8");
-  for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath, configPath]) refuseSymlink(target);
+  for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath, configPath, provenanceTarget]) refuseSymlink(target);
   const config = renderYamlEntryPreservingComments(configRaw, HERMES_MCP_ENTRY_PATH, { kind: "delete" });
   let changed = false;
-  changed = config.changed;
-  for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath]) {
+  changed = ownsInstall && config.changed;
+  for (const target of ownsInstall ? [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath] : []) {
     if (existsSync(target)) {
       changed = true;
     }
   }
   if (!options.dryRun) {
     try {
-      for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath]) {
+      for (const target of ownsInstall ? [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath] : []) {
         await rm(target, { recursive: true, force: true });
       }
-      if (config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
-      await verifyHermesUninstall(configPath, [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath]);
+      if (ownsInstall && config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
+      if (ownsInstall) {
+        await verifyHermesUninstall(configPath, [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath]);
+      }
     } catch (error) {
       await rollbackConfig(configPath, preImage, error);
     }
@@ -213,7 +278,7 @@ export async function uninstallHermes(options: HostOperationOptions): Promise<Ho
     action: "uninstall",
     changed: changed && !options.dryRun,
     skipped: !changed,
-    paths: [adapterTarget, skillTarget, configPath],
+    paths: [adapterTarget, skillTarget, provenanceTarget, configPath],
     commands: [],
     messages: ["Removed Hermes Oh My Second Brain skill bundle, adapter copy, legacy descriptor files, and mcp_servers.oms."],
   };

--- a/test/update-e2e.test.ts
+++ b/test/update-e2e.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -108,36 +108,22 @@ describe("oms update isolated e2e", () => {
     expect(readFileSync(path.join(omsDir, "user-owned.txt"), "utf-8")).toBe(before);
   });
 
-  it("propagates reconcile failure to the parent update exit code", () => {
-    const cwd = makeTempRoot("oms-reconcile-fail-");
+  it("rejects a source-tree binary before npm can mutate a global installation", () => {
+    const cwd = makeTempRoot("oms-update-source-tree-");
     const omsDir = path.join(cwd, ".oms");
-    const home = makeTempRoot("oms-reconcile-home-");
-    const fakeBin = path.join(home, "bin");
-    const fakeNpm = path.join(fakeBin, "npm");
-    const decoy = path.join(home, "decoy");
-    const symlinkTarget = path.join(home, ".hermes", "skills", "knowledge-management", "oms");
     mkdirSync(omsDir);
     writeFileSync(path.join(omsDir, "user-owned.txt"), "must remain unchanged\n", "utf-8");
     const beforeOmsHash = createHash("sha256")
       .update(readFileSync(path.join(omsDir, "user-owned.txt")))
       .digest("hex");
-    mkdirSync(fakeBin, { recursive: true });
-    writeFileSync(fakeNpm, "#!/bin/sh\nexit 0\n", "utf-8");
-    chmodSync(fakeNpm, 0o755);
-    mkdirSync(decoy);
-    mkdirSync(path.dirname(symlinkTarget), { recursive: true });
-    symlinkSync(decoy, symlinkTarget, "dir");
 
     const result = runCli(["update", "--runtime", "hermes", "--vault", cwd, "--yes"], cwd, {
-      HOME: home,
-      XDG_CONFIG_HOME: path.join(home, ".config"),
-      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
-      OMS_HERMES_HOME: path.join(home, ".hermes"),
+      HOME: makeTempRoot("oms-update-home-"),
     });
 
     expect(result.status).toBe(1);
-    expect(result.stdout).toContain("reconciliation failed");
-    expect(result.stdout).toContain("Refusing to replace symlinked");
+    expect(result.stdout).toContain("not owned by a global npm prefix");
+    expect(result.stdout).toContain("npm prefix -g");
     const afterOmsHash = createHash("sha256")
       .update(readFileSync(path.join(omsDir, "user-owned.txt")))
       .digest("hex");


### PR DESCRIPTION
R2 (oms-v0.11.0) implementation per the approved consensus plan.

Closes #64, closes #65, closes #69, closes #88, closes #90.

- #64: src/kernel/install/provenance.ts dependency leaf (schema, tree digest, pure ownership decision); update topology resolution (running-binary prefix vs npm prefix -g, fail-closed on mismatch); version-independent reconcile; cross-version handoff through the freshly installed bin's public reconcile command.
- #88: `oms index repair --mode rebuild|drop [--dry-run]` via a dedicated kernel repair service that never opens corrupt stores and never touches vault Markdown or .oms authority files; `index status` cites the exact repair command.
- #65: missing/unknown `op` errors list the tool's supported operations deterministically; five-tool surface unchanged.
- #69: tier-4 type-affinity capped at 64 per group with deterministic warnings and explicit `OMS_TYPE_AFFINITY_UNBOUNDED=1` opt-out; identical behavior at/below the cap.
- #90: provenance-aware one-root Hermes install (npm provenance under adapters/oms, ownership state machine, config-only reconcile on identical assets, foreign/tamper fail-closed, legacy adoption boundary, symmetric uninstall) plus a read-only doctor drift line.

No new dependencies. Verification: npm run lint, npm run build, npm test (1397 passed / 11 skipped), npm run check:docs, npx vitest run test/architecture all green.