### PR TITLE
VB002 generation-3 fixes: real R1 legacy adoption + single provenance boundary + Xia fault matrix (#90)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -108,6 +108,8 @@ oms serve
 A plain `oms search <text>` is lexical-only. Every non-lexical channel is
 explicit: `--vec`, `--hyde`, G004 `--expand`, and `--rerank`. G004 expansion is
 available only when selected; no replacement, parity, or outperformance claim
+is made.
+
 `oms embed` is the sole embedding command, and `oms index` has no
 embedding subcommand.
 

--- a/src/cli/doctor-lint.test.ts
+++ b/src/cli/doctor-lint.test.ts
@@ -1,0 +1,70 @@
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { computeTreeDigest } from "../kernel/install/provenance.js";
+
+vi.mock("../kernel/templates/index.js", () => ({
+  diagnoseTemplates: vi.fn(async () => ({
+    status: "healthy",
+    migrationMarker: "none",
+    managedSourceExclusions: [],
+    unresolvedLegacyNotes: [],
+    diagnostics: [],
+  })),
+}));
+
+import { runDoctor } from "./doctor-lint.js";
+
+const packageVersion = (JSON.parse(await readFile(path.resolve("package.json"), "utf8")) as { version: string }).version;
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+  vi.restoreAllMocks();
+});
+
+describe("doctor Hermes provenance", () => {
+  it.each(["not-installed", "match", "drift"] as const)("reports %s provenance in JSON and text", async state => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-doctor-hermes-"));
+    roots.push(root);
+    const skillRoot = path.join(root, "skills", "knowledge-management", "oms");
+    const provenancePath = path.join(root, "adapters", "oms", "oms-provenance.json");
+    const originalOverride = process.env.OMS_HERMES_HOME;
+    process.env.OMS_HERMES_HOME = root;
+    try {
+      if (state !== "not-installed") {
+        await mkdir(skillRoot, { recursive: true });
+        await mkdir(path.dirname(provenancePath), { recursive: true });
+        await writeFile(path.join(skillRoot, "SKILL.md"), "# OMS\n");
+        await writeFile(provenancePath, `${JSON.stringify({
+          schemaVersion: 1,
+          source: "npm",
+          version: state === "match" ? packageVersion : "0.10.1",
+          skillTreeDigest: await computeTreeDigest(skillRoot),
+          installedAt: "2026-01-01T00:00:00.000Z",
+        })}\n`);
+      }
+
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      expect(await runDoctor({ vault: "/vault", json: true })).toBe(0);
+      const json = JSON.parse(String(log.mock.calls[0]?.[0])) as { hermesProvenance: unknown };
+      expect(json.hermesProvenance).toEqual(
+        state === "not-installed"
+          ? { state, packageVersion, recordedVersion: null, digestMatch: null }
+          : { state, packageVersion, recordedVersion: state === "match" ? packageVersion : "0.10.1", digestMatch: true },
+      );
+
+      log.mockClear();
+      expect(await runDoctor({ vault: "/vault" })).toBe(0);
+      expect(log.mock.calls.map(call => call[0]).filter(line => typeof line === "string" && line.startsWith("Hermes provenance:"))).toEqual([
+        `Hermes provenance: ${state} (package ${packageVersion}, recorded ${state === "not-installed" ? "none" : state === "match" ? packageVersion : "0.10.1"}).`,
+      ]);
+      expect(existsSync(root)).toBe(true);
+    } finally {
+      if (originalOverride === undefined) delete process.env.OMS_HERMES_HOME;
+      else process.env.OMS_HERMES_HOME = originalOverride;
+    }
+  });
+});

--- a/src/cli/host-operations.test.ts
+++ b/src/cli/host-operations.test.ts
@@ -1027,28 +1027,34 @@ describe("upsertClaudeHooks / removeClaudeHooks", () => {
     expect(await readFile(mcpPath, "utf-8")).toBe("[]\n");
   });
 
-  it("reconciles managed host stamps while retaining a provenance-validated Hermes install", async () => {
+  it.each(["default", "profiles/xia"])("%s root reconciles managed host stamps while retaining a provenance-validated Hermes install", async root => {
     const home = await mkdtemp(path.join(tmpdir(), "oms-host-pointer-"));
     const first = path.join(home, "Vault A");
     const second = path.join(home, "Vault B");
-    await runHostOperation({ action: "install", runtime: "all", vault: first, homeDir: home, adapterRoot });
-    await runHostOperation({ action: "install", runtime: "all", vault: second, homeDir: home, adapterRoot });
+    const hermesRoot = path.join(home, ".hermes", ...(root === "default" ? [] : root.split("/")));
+    const originalOverride = process.env.OMS_HERMES_HOME;
+    if (root !== "default") process.env.OMS_HERMES_HOME = hermesRoot;
+    try {
+      await runHostOperation({ action: "install", runtime: "all", vault: first, homeDir: home, adapterRoot });
+      await runHostOperation({ action: "install", runtime: "all", vault: second, homeDir: home, adapterRoot });
 
-    const claudeMcp = await readFile(path.join(home, ".claude.json"), "utf-8");
-    const claudeHooks = await readFile(path.join(home, ".claude", "settings.json"), "utf-8");
-    const codex = await readFile(path.join(home, ".codex", "config.toml"), "utf-8");
-    const hermes = await readFile(path.join(home, ".hermes", "config.yaml"), "utf-8");
-    for (const managed of [claudeMcp, codex]) {
-      expect(managed).toContain(second);
-      expect(managed).not.toContain(first);
+      const claudeMcp = await readFile(path.join(home, ".claude.json"), "utf-8");
+      const claudeHooks = await readFile(path.join(home, ".claude", "settings.json"), "utf-8");
+      const codex = await readFile(path.join(home, ".codex", "config.toml"), "utf-8");
+      const hermes = await readFile(path.join(hermesRoot, "config.yaml"), "utf-8");
+      for (const managed of [claudeMcp, codex]) {
+        expect(managed).toContain(second);
+        expect(managed).not.toContain(first);
+      }
+      const hermesConfig = parse(hermes) as { readonly mcp_servers: { readonly oms: { readonly args: readonly string[] } } };
+      expect(hermesConfig.mcp_servers.oms.args).toEqual(["mcp", "--vault", second]);
+      expect(claudeHooks).toContain("Vault B");
+      expect(claudeHooks).not.toContain("Vault A");
+      expect(existsSync(path.join(home, ".oms"))).toBe(false);
+    } finally {
+      if (originalOverride === undefined) delete process.env.OMS_HERMES_HOME;
+      else process.env.OMS_HERMES_HOME = originalOverride;
     }
-    const hermesConfig = parse(hermes) as { readonly mcp_servers: { readonly oms: { readonly args: readonly string[] } } };
-    // Identical assets are a provenance no-op, but the MCP registration must
-    // still reconcile to the newly selected vault.
-    expect(hermesConfig.mcp_servers.oms.args).toEqual(["mcp", "--vault", second]);
-    expect(claudeHooks).toContain("Vault B");
-    expect(claudeHooks).not.toContain("Vault A");
-    expect(existsSync(path.join(home, ".oms"))).toBe(false);
   });
 
   it("install+uninstall Claude runtime writes and then removes hooks from settings.json", async () => {

--- a/src/vendors/hermes/hermes.test.ts
+++ b/src/vendors/hermes/hermes.test.ts
@@ -19,6 +19,7 @@ vi.mock("node:fs/promises", async importOriginal => {
 });
 
 const originalFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+const packageVersion = (JSON.parse(await readFile(path.resolve("package.json"), "utf8")) as { version: string }).version;
 const temporaryDirectories: string[] = [];
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
@@ -48,40 +49,47 @@ describe("installHermes transaction", () => {
     await expect(readFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"))).rejects.toThrow();
   });
 
-  it.each([
-    ["skills copy", (api: typeof fsPromises) => vi.mocked(api.cp).mockRejectedValueOnce(new Error("skills copy failed"))],
-    ["adapter copy", (api: typeof fsPromises) => vi.mocked(api.cp).mockImplementation(async (source, destination, options) => {
+  it.each(["default", "profiles/xia"].flatMap(root => [
+    [root, "skills copy", (api: typeof fsPromises) => vi.mocked(api.cp).mockRejectedValueOnce(new Error("skills copy failed"))],
+    [root, "adapter copy", (api: typeof fsPromises) => vi.mocked(api.cp).mockImplementation(async (source, destination, options) => {
       if (String(source).endsWith("hermes-manifest.json")) throw new Error("adapter copy failed");
       return await originalCp(source, destination, options);
     })],
-    ["config atomic write", (api: typeof fsPromises) => {
+    [root, "config atomic write", (api: typeof fsPromises) => {
       const write = vi.mocked(api.writeFile);
       write.mockImplementationOnce(async () => { throw new Error("config write failed"); });
       return write;
     }],
-    ["install verification", (api: typeof fsPromises) => vi.mocked(api.readdir).mockImplementation(async (directory, options) => {
-      if (String(directory).includes(".hermes/skills/knowledge-management/oms")) throw new Error("verification failed");
+    [root, "install verification", (api: typeof fsPromises) => vi.mocked(api.readdir).mockImplementation(async (directory, options) => {
+      if (String(directory).includes("skills/knowledge-management/oms")) throw new Error("verification failed");
       return await originalFs.readdir(directory, options);
     })],
-  ])("restores config and converges after a %s failure", async (_name, inject) => {
+  ]))("%s root restores config and converges after a %s failure", async (root, _name, inject) => {
     const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
     temporaryDirectories.push(home);
-    const hermes = path.join(home, ".hermes");
+    const hermes = path.join(home, ".hermes", ...(root === "default" ? [] : root.split("/")));
     const config = path.join(hermes, "config.yaml");
     const original = "mcp_servers:\n  other: keep\n";
-    await mkdir(hermes);
-    await writeFile(config, original);
     const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
     if (!host) throw new Error("Hermes surface missing");
     const options = { action: "install" as const, runtime: "hermes" as const, vault: "/vault", homeDir: home, adapterRoot: path.resolve(".") };
-    const restore = inject(fsPromises);
+    const originalOverride = process.env.OMS_HERMES_HOME;
+    if (root !== "default") process.env.OMS_HERMES_HOME = hermes;
     try {
-      await expect(installHermes(options, host)).rejects.toThrow();
-      expect(await readFile(config, "utf8")).toBe(original);
+      await mkdir(hermes, { recursive: true });
+      await writeFile(config, original);
+      const restore = inject(fsPromises);
+      try {
+        await expect(installHermes(options, host)).rejects.toThrow();
+        expect(await readFile(config, "utf8")).toBe(original);
+      } finally {
+        restore.mockRestore();
+      }
+      await expect(installHermes(options, host)).resolves.toMatchObject({ changed: true });
     } finally {
-      restore.mockRestore();
+      if (originalOverride === undefined) delete process.env.OMS_HERMES_HOME;
+      else process.env.OMS_HERMES_HOME = originalOverride;
     }
-    await expect(installHermes(options, host)).resolves.toMatchObject({ changed: true });
   });
 
   it("preserves both errors when config rollback fails", async () => {
@@ -171,15 +179,10 @@ describe("installHermes transaction", () => {
     const provenanceFile = path.join(hermes, "adapters", "oms", "oms-provenance.json");
     const provenance = parseProvenance(await readFile(provenanceFile, "utf8"));
     expect(await readdir(skills)).toHaveLength(7);
-    const packageVersion = (JSON.parse(await readFile(path.resolve("package.json"), "utf8")) as { version: string }).version;
     expect(provenance).toMatchObject({ source: "npm", version: packageVersion, skillTreeDigest: await computeTreeDigest(skills) });
     const before = await readFile(provenanceFile, "utf8");
     await expect(installHermes(options, host)).resolves.toMatchObject({ changed: false, skipped: true });
     expect(await readFile(provenanceFile, "utf8")).toBe(before);
-    const staleFile = path.join(hermes, "adapters", "oms", ".oms-provenance.json");
-    await writeFile(staleFile, "stale metadata\n");
-    await expect(installHermes(options, host)).resolves.toMatchObject({ changed: true, skipped: false });
-    expect(existsSync(staleFile)).toBe(false);
   });
 
   it("refuses foreign provenance without changing the pre-existing tree", async () => {
@@ -200,7 +203,7 @@ describe("installHermes transaction", () => {
     expect(await readFile(path.join(skills, "foreign.txt"), "utf8")).toBe("foreign\n");
   });
 
-  it("adopts only the exact legacy seven-skill layout", async () => {
+  it("adopts a prior semver legacy layout and replaces its adapter directory", async () => {
     const home = await mkdtemp(path.join(tmpdir(), "oms-hermes-"));
     temporaryDirectories.push(home);
     const host = harnessSurfaceRegistry.hosts.find((candidate) => candidate.runtime === "hermes");
@@ -211,16 +214,20 @@ describe("installHermes transaction", () => {
     const skills = path.join(hermes, "skills", "knowledge-management", "oms");
     const provenance = path.join(hermes, "adapters", "oms", "oms-provenance.json");
     await rm(provenance);
-    await writeFile(path.join(skills, "write", "SKILL.md"), "legacy\n");
+    await writeFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"), '{"version":"0.10.1"}\n');
+    await writeFile(path.join(hermes, "adapters", "oms", ".oms-provenance.json"), "stale metadata\n");
     await expect(installHermes(options, host)).resolves.toMatchObject({ changed: true });
     expect(parseProvenance(await readFile(provenance, "utf8"))).not.toBeNull();
+    expect(await readdir(path.join(hermes, "adapters", "oms"))).toEqual(["README.md", "SOUL.md", "hermes-manifest.json", "oms-provenance.json"]);
     await rm(provenance);
     await mkdir(path.join(skills, "unexpected"));
     await expect(installHermes(options, host)).rejects.toThrow("exact legacy OMS layout");
   });
 
   it.each([
-    ["a wrong manifest version", async (hermes: string) => writeFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"), '{"version":"0.0.0"}\n')],
+    ["the current manifest version", async (hermes: string) => writeFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"), `{"version":"${packageVersion}"}\n`)],
+    ["a higher manifest version", async (hermes: string) => writeFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"), '{"version":"99.0.0"}\n')],
+    ["an invalid semver manifest", async (hermes: string) => writeFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"), '{"version":"legacy"}\n')],
     ["a malformed manifest", async (hermes: string) => writeFile(path.join(hermes, "adapters", "oms", "hermes-manifest.json"), "{not json\n")],
     ["a file in place of a canonical skill directory", async (hermes: string) => {
       const skill = path.join(hermes, "skills", "knowledge-management", "oms", "write");

--- a/src/vendors/hermes/hermes.ts
+++ b/src/vendors/hermes/hermes.ts
@@ -106,11 +106,55 @@ function canonicalSkillLayout(entries: readonly string[]): boolean {
     entries.every(entry => HERMES_SKILLS.includes(entry as (typeof HERMES_SKILLS)[number]));
 }
 
+type Semver = {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+  readonly prerelease: readonly string[];
+};
+
+function parseSemver(version: string): Semver | null {
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(version);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4]?.split(".") ?? [],
+  };
+}
+
+function compareSemver(left: Semver, right: Semver): number {
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (left[key] !== right[key]) return left[key] < right[key] ? -1 : 1;
+  }
+  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+    return left.prerelease.length === right.prerelease.length ? 0 : left.prerelease.length === 0 ? 1 : -1;
+  }
+  for (let index = 0; index < Math.max(left.prerelease.length, right.prerelease.length); index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+    if (leftIdentifier === undefined || rightIdentifier === undefined) {
+      return leftIdentifier === undefined ? -1 : 1;
+    }
+    if (leftIdentifier === rightIdentifier) continue;
+    const leftNumeric = /^\d+$/.test(leftIdentifier);
+    const rightNumeric = /^\d+$/.test(rightIdentifier);
+    if (leftNumeric && rightNumeric) return Number(leftIdentifier) < Number(rightIdentifier) ? -1 : 1;
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return leftIdentifier < rightIdentifier ? -1 : 1;
+  }
+  return 0;
+}
+
 async function legacyOwnershipEvidence(skillTarget: string, adapterManifestTarget: string, expectedVersion: string): Promise<boolean> {
   if (!existsSync(skillTarget) || !existsSync(adapterManifestTarget)) return false;
   try {
     const manifest = JSON.parse(await readFile(adapterManifestTarget, "utf8")) as { version?: unknown };
-    if (typeof manifest.version !== "string" || manifest.version !== expectedVersion) return false;
+    if (typeof manifest.version !== "string") return false;
+    const legacyVersion = parseSemver(manifest.version);
+    const currentVersion = parseSemver(expectedVersion);
+    if (legacyVersion === null || currentVersion === null || compareSemver(legacyVersion, currentVersion) >= 0) return false;
     const entries = await readdir(skillTarget, { withFileTypes: true });
     if (!canonicalSkillLayout(entries.map(entry => entry.name)) || entries.some(entry => !entry.isDirectory())) return false;
     return HERMES_SKILLS.every(skill => {
@@ -145,7 +189,6 @@ export async function installHermes(options: HostOperationOptions, host: Harness
   const guidanceTarget = path.join(adapterTarget, "SOUL.md");
   const readmeTarget = path.join(adapterTarget, "README.md");
   const provenanceTarget = path.join(adapterTarget, "oms-provenance.json");
-  const staleProvenanceTarget = path.join(adapterTarget, ".oms-provenance.json");
   const messages = ["Installed Hermes-native Oh My Second Brain skill bundle and registered mcp_servers.oms in ~/.hermes/config.yaml."];
   const manifest = JSON.parse(await readFile(path.join(adapterSource, "hermes-manifest.json"), "utf8")) as { version?: unknown };
   const packageMetadata = JSON.parse(await readFile(new URL("../../../package.json", import.meta.url), "utf8")) as { version?: unknown };
@@ -158,7 +201,7 @@ export async function installHermes(options: HostOperationOptions, host: Harness
     for (const source of [skillSource, path.join(adapterSource, "hermes-manifest.json"), path.join(adapterSource, "hermes", "SOUL.md"), path.join(adapterSource, "hermes", "README.md")]) {
       if (!existsSync(source)) throw new Error(`Hermes install source is missing: ${source}`);
     }
-    for (const target of [legacyPluginTarget, legacyMcpPath, adapterTarget, skillTarget, configPath, provenanceTarget, staleProvenanceTarget]) refuseSymlink(target);
+    for (const target of [legacyPluginTarget, legacyMcpPath, adapterTarget, skillTarget, configPath, provenanceTarget]) refuseSymlink(target);
     const recorded = await readProvenance(provenanceTarget);
     const actualTreeDigest = existsSync(skillTarget) ? await computeTreeDigest(skillTarget) : null;
     if (recorded.raw !== null && recorded.provenance === null) {
@@ -185,7 +228,7 @@ export async function installHermes(options: HostOperationOptions, host: Harness
     if (ownership.action === "noop") {
       // Assets are identical; the MCP registration may still differ (for example a
       // new vault). Reconcile only the config commit under the same rollback rule.
-      if (!config.changed && !existsSync(staleProvenanceTarget)) {
+      if (!config.changed) {
         return {
           runtime: "hermes", action: "install", changed: false, skipped: true,
           paths: [adapterTarget, guidanceTarget, readmeTarget, skillTarget, provenanceTarget, configPath],
@@ -193,7 +236,6 @@ export async function installHermes(options: HostOperationOptions, host: Harness
         };
       }
       try {
-        if (existsSync(staleProvenanceTarget)) await rm(staleProvenanceTarget, { force: true });
         if (config.changed) await atomicWrite(configPath, Buffer.from(config.text, "utf8"));
         await verifyHermesInstall(configPath, skillTarget, options);
       } catch (error) {
@@ -255,7 +297,6 @@ export async function uninstallHermes(options: HostOperationOptions): Promise<Ho
   const configPath = path.join(hermesDir, "config.yaml");
   const adapterManifestTarget = path.join(adapterTarget, "hermes-manifest.json");
   const provenanceTarget = path.join(adapterTarget, "oms-provenance.json");
-  const staleProvenanceTarget = path.join(adapterTarget, ".oms-provenance.json");
   const recorded = await readProvenance(provenanceTarget);
   const actualTreeDigest = existsSync(skillTarget) ? await computeTreeDigest(skillTarget) : null;
   const packageMetadata = JSON.parse(await readFile(new URL("../../../package.json", import.meta.url), "utf8")) as { version?: unknown };
@@ -268,7 +309,7 @@ export async function uninstallHermes(options: HostOperationOptions): Promise<Ho
   const preImage = existsSync(configPath) ? await readFile(configPath) : undefined;
   const configRaw = preImage?.toString("utf8") ?? "";
   if (preImage && !preImage.equals(Buffer.from(configRaw, "utf8"))) throw new Error("Hermes config.yaml is not valid UTF-8");
-  for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath, configPath, provenanceTarget, staleProvenanceTarget]) refuseSymlink(target);
+  for (const target of [adapterTarget, skillTarget, legacyPluginTarget, legacyMcpPath, configPath, provenanceTarget]) refuseSymlink(target);
   const config = renderYamlEntryPreservingComments(configRaw, HERMES_MCP_ENTRY_PATH, { kind: "delete" });
   let changed = false;
   changed = ownsInstall && config.changed;


### PR DESCRIPTION
Closes the VB002 generation-2 carryovers: legacy adoption accepts only a genuine older-version R1 layout (forged same-version manifests rejected), the stale .oms-provenance.json compatibility path is removed (directory replacement owns cleanup), fault/reconcile matrices are parametrized over default and Xia roots, doctor provenance 3-state outputs are pinned, and the docs sentence is restored. Verification: lint, full vitest, check:docs green.