### PR TITLE
R3: taxonomy.yaml -> taxonomy.json, no read fallback (breaking)

### DIFF
--- a/CHANGELOG-assets.md
+++ b/CHANGELOG-assets.md
@@ -4,6 +4,8 @@ Skills, agents, templates, and host guidance changes belong here.
 
 ## [Unreleased]
 
+- **Guidance now identifies `.oms/taxonomy.json` as the user-owned folder/link authority.**
+
 ## [0.11.1] - 2026-09-01
 
 ## [0.11.0] - 2026-09-01

--- a/CHANGELOG-cli.md
+++ b/CHANGELOG-cli.md
@@ -4,6 +4,8 @@ Changes to the `oms` command surface belong here.
 
 ## [Unreleased]
 
+- **Breaking: `oms doctor` no longer accepts `.oms/taxonomy.yaml`.** It reports one conversion error for a YAML-only vault (or cleanup guidance when both files remain); run `oms setup` and approve the returned digest to publish `.oms/taxonomy.json`.
+
 ## [0.11.1] - 2026-09-01
 
 ### Changed

--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -4,6 +4,8 @@ Domain logic changes belong here.
 
 ## [Unreleased]
 
+- **Breaking: template taxonomy authority moved from `.oms/taxonomy.yaml` to `.oms/taxonomy.json`.** Resolution, transaction manifests, signatures, and derived folder ontology read JSON only. Approved setup converts legacy YAML and removes it after publishing the JSON authority; rerun setup and approve its newly returned digest for existing vaults.
+
 ## [0.11.1] - 2026-09-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This aggregate changelog contains changes that span multiple layers.
 
 ## [Unreleased]
 
+- **Breaking: taxonomy authority is JSON-only across setup and validation.** Vaults now publish `.oms/taxonomy.json`; setup converts a legacy YAML taxonomy only after approval, removes it on apply, and requires a newly approved digest because the signed authority path changes.
+
 ## [0.11.1] - 2026-09-01
 
 ### Fixed

--- a/assets/claude/CLAUDE.md
+++ b/assets/claude/CLAUDE.md
@@ -5,7 +5,7 @@ This vault is governed by user-owned template conventions in `.oms/`.
 Before vault work:
 - Treat actual Obsidian `.md` templates as the note-shape and body source of truth.
 - Treat `.obsidian/types.json` as read-only property-type authority.
-- Read the user-owned ontology from `.oms/template-policy.json` for note/field meaning and policy, and `.oms/taxonomy.yaml` for folder/link meaning and placement.
+- Read the user-owned ontology from `.oms/template-policy.json` for note/field meaning and policy, and `.oms/taxonomy.json` for folder/link meaning and placement.
 - Never hand-edit derived `.oms/types.json`; use doctor diagnosis and an approved regeneration.
 - People and agents follow the same stable `templateId` rules.
 

--- a/assets/codex/AGENTS.md
+++ b/assets/codex/AGENTS.md
@@ -8,7 +8,7 @@ The vault is governed by user-owned template conventions in `.oms/`.
 
 - Actual Obsidian `.md` templates own note shape and body scaffolding.
 - `.obsidian/types.json` is read-only type authority.
-- The user-owned ontology remains active: `.oms/template-policy.json` records note/field meaning and policy; `.oms/taxonomy.yaml` records folder/link meaning and placement.
+- The user-owned ontology remains active: `.oms/template-policy.json` records note/field meaning and policy; `.oms/taxonomy.json` records folder/link meaning and placement.
 - `.oms/types.json` is derived; never hand-edit it.
 - Humans and agents use the same stable `templateId` rules.
 

--- a/assets/hermes/SOUL.md
+++ b/assets/hermes/SOUL.md
@@ -5,7 +5,7 @@ This vault uses user-owned template conventions in `.oms/`.
 Before vault work:
 - Actual Obsidian `.md` templates own note shape and body scaffolding.
 - `.obsidian/types.json` is read-only type authority.
-- The user-owned ontology remains active: `.oms/template-policy.json` records note/field meaning and policy; `.oms/taxonomy.yaml` records folder/link meaning and placement.
+- The user-owned ontology remains active: `.oms/template-policy.json` records note/field meaning and policy; `.oms/taxonomy.json` records folder/link meaning and placement.
 - `.oms/types.json` is derived and must never be hand-edited.
 - Humans and agents use identical stable `templateId` rules.
 

--- a/assets/skills/template/SKILL.md
+++ b/assets/skills/template/SKILL.md
@@ -12,7 +12,7 @@ Turn the user's natural-language note design into an actual Obsidian Markdown te
 - The actual `.md` template owns frontmatter order/default scaffolding and body shape.
 - `.obsidian/types.json` is read-only property-type authority.
 - The user-owned ontology remains active: `.oms/template-policy.json` owns note/field `intent` plus BaseContract inheritance, requiredness, formats, allowed values, naming, stable identity, and bindings.
-- `.oms/taxonomy.yaml` owns folder/link `intent`, note placement, and global axes.
+- `.oms/taxonomy.json` owns folder/link `intent`, note placement, and global axes.
 - `.oms/types.json` is derived state. Never edit it directly.
 
 Use an existing stable `templateId` when updating or moving a template. A path or digest change never creates a new identity. New OMS-managed templates default to `<templateFolder>/<templateId>.md`; registered existing templates keep their explicitly verified `sourcePath`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,14 +11,14 @@ vault Markdown templates ──> frontmatter/body shape ──> ResolvedTemplate
          │
 .obsidian/types.json ───────────────> read-only type authority
 .oms/template-policy.json ──────────> note/field ontology, naming, defaults
-.oms/taxonomy.yaml ─────────────────> folder/link ontology and placement
+.oms/taxonomy.json ─────────────────> folder/link ontology and placement
          │
          └───────────────────────────> .oms/types.json (validated derived projection)
 ```
 
 Vault-resident Obsidian Markdown templates own a managed note's shape and body. Each managed template has a stable `templateId`; moving or editing the file does not make identity path- or digest-derived. The BaseContract is inherited by every managed TemplateContract.
 
-`.obsidian/types.json` is read-only. The user-owned ontology is the semantic metadata separated from template shape: `.oms/template-policy.json` records note and field `intent` alongside naming/default policy, while `.oms/taxonomy.yaml` records folder/link `intent` and placement. `.oms/types.json` is generated after validation and is used as a write/search projection; it is never authority or hand-edited configuration.
+`.obsidian/types.json` is read-only. The user-owned ontology is the semantic metadata separated from template shape: `.oms/template-policy.json` records note and field `intent` alongside naming/default policy, while `.oms/taxonomy.json` records folder/link `intent` and placement. `.oms/types.json` is generated after validation and is used as a write/search projection; it is never authority or hand-edited configuration.
 
 Taxonomy controls placement without deciding a template's keys. Folder and wikilink relationships are global axes, so retrieval is not constrained to a single placement rule. Authored folder intents are exposed through the derived `folder-ontology` axis. Removing the legacy `concept` note identity and bundled ontology runtime defaults does not remove ontology: meaning remains active, vault-owned data.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -11,7 +11,7 @@ Each managed template has a stable `templateId`, independent of its file locatio
 | Vault Markdown template | Frontmatter key scaffolding/default literals and body shape. |
 | `.obsidian/types.json` | Read-only Obsidian type authority. OMS reads it but never writes it. |
 | `.oms/template-policy.json` | User-owned note/field ontology (`intent`) plus naming rules and defaults. |
-| `.oms/taxonomy.yaml` | User-owned folder/link ontology (`intent`) plus template placement. |
+| `.oms/taxonomy.json` | User-owned folder/link ontology (`intent`) plus template placement. |
 | `.oms/types.json` | Validated derived projection used by write and search operations; never hand-edit it. |
 
 These authorities coexist: templates decide what a note contains, ontology explains what those fields, folders, and relationships mean, taxonomy places notes, and Obsidian decides property types. The removed legacy surface is `concept` as note identity and bundled runtime defaults—not ontology itself.

--- a/docs/harness-architecture.md
+++ b/docs/harness-architecture.md
@@ -9,7 +9,7 @@ A vault composes four authorities:
 1. Actual Obsidian Markdown templates own frontmatter shape and body scaffolding.
 2. `.obsidian/types.json` is read-only property-type authority.
 3. `.oms/template-policy.json` owns requiredness, formats, allowed values, defaults, naming, stable IDs, and bindings.
-4. `.oms/taxonomy.yaml` owns physical placement and global folder/link axes.
+4. `.oms/taxonomy.json` owns physical placement and global folder/link axes.
 
 Every managed template inherits one vault-wide `BaseContract`. A stable `templateId` does not depend on source path or content digest. `.oms/types.json` is a derived, validated write/search projection and is never user-authored authority.
 

--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -140,7 +140,7 @@ function setupSmoke(packageRoot, vault, smokeHome) {
   if (!approval) fail("setup dry-run did not return an approval digest");
   const result = run(process.execPath, [cli, "setup", "--vault", vault, "--yes", "--approved-digest", approval, "--install-claude"], { cwd: packageRoot, env });
   const output = `${result.stdout}\n${result.stderr}`;
-  assertPath(path.join(vault, ".oms/taxonomy.yaml"), "vault taxonomy");
+  assertPath(path.join(vault, ".oms/taxonomy.json"), "vault taxonomy");
   assertPath(path.join(vault, ".oms/template-policy.json"), "vault template policy");
   assertPath(path.join(vault, ".oms/types.json"), "vault derived projection");
   if (existsSync(path.join(vault, ".oms/concepts"))) fail("setup recreated the retired concepts directory");

--- a/src/cli/doctor-lint.ts
+++ b/src/cli/doctor-lint.ts
@@ -46,6 +46,16 @@ export async function runDoctor(opts: {
   maxPerTemplate?: number;
 }): Promise<number> {
   try {
+    const legacyTaxonomy = path.join(opts.vault, ".oms", "taxonomy.yaml");
+    if (existsSync(legacyTaxonomy)) {
+      const taxonomy = path.join(opts.vault, ".oms", "taxonomy.json");
+      const message = existsSync(taxonomy)
+        ? "legacy .oms/taxonomy.yaml remains after conversion — remove it; .oms/taxonomy.json is authoritative"
+        : "legacy .oms/taxonomy.yaml is no longer read — run oms setup to convert to taxonomy.json";
+      if (opts.json) console.log(JSON.stringify({ vault: opts.vault, status: "needs-repair", diagnostics: [{ code: "LEGACY_TAXONOMY_YAML", path: ".oms/taxonomy.yaml", remediation: message }] }, null, 2));
+      else console.error(`[oms] ${message}`);
+      return 1;
+    }
     const diagnosis = await diagnoseTemplates({ vault: opts.vault, source: "explicit", maxPerTemplate: opts.maxPerTemplate });
     const hermesProvenance = await hermesProvenanceStatus();
     if (opts.json) {

--- a/src/cli/linkify.test.ts
+++ b/src/cli/linkify.test.ts
@@ -28,12 +28,12 @@ const digest = (value: string): `sha256:${string}` => `sha256:${createHash("sha2
 async function writeAuthority(vault: string): Promise<void> {
   for (const directory of [".oms", ".obsidian", "Templates/OMS"]) await mkdir(path.join(vault, directory), { recursive: true });
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { note: { intent: "note", fields: { template: { type: "text", required: true }, title: { type: "text", required: true } }, views: [] } }, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", contract: "note", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const obsidianTypes = JSON.stringify({ types: { template: "text", title: "text" } });
   const template = "---\ntemplate: note\ntitle: Untitled\n---\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [{ logicalId: "template-policy", signature: digest(policy) }, { logicalId: "taxonomy", signature: digest(taxonomy) }, { logicalId: "obsidian-types", signature: digest(obsidianTypes) }, { path: "Templates/OMS/note.md", signature: digest(template) }];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: {}, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", targetFolder: "Inbox", keyOrder: ["template", "title"], fields: { template: { type: "text", required: true }, title: { type: "text", required: true } }, views: [], naming: "{{slug}}.md", bodySignature: digest("<!-- oms:content -->\n") } } } });
-  await Promise.all([writeFile(path.join(vault, ".oms/template-policy.json"), policy), writeFile(path.join(vault, ".oms/taxonomy.yaml"), taxonomy), writeFile(path.join(vault, ".oms/types.json"), projection), writeFile(path.join(vault, ".obsidian/types.json"), obsidianTypes), writeFile(path.join(vault, "Templates/OMS/note.md"), template)]);
+  await Promise.all([writeFile(path.join(vault, ".oms/template-policy.json"), policy), writeFile(path.join(vault, ".oms/taxonomy.json"), taxonomy), writeFile(path.join(vault, ".oms/types.json"), projection), writeFile(path.join(vault, ".obsidian/types.json"), obsidianTypes), writeFile(path.join(vault, "Templates/OMS/note.md"), template)]);
 }
 
 /**

--- a/src/kernel/conventions/note-exclude.test.ts
+++ b/src/kernel/conventions/note-exclude.test.ts
@@ -52,9 +52,9 @@ describe("matchesAnyGlob", () => {
 });
 
 describe("excludedNoteMatcher", () => {
-  it("applies only the built-in defaults when taxonomy.yaml has no exclude key", async () => {
+  it("applies only the built-in defaults when taxonomy.json has no exclude key", async () => {
     const vault = await makeVault({
-      ".oms/taxonomy.yaml": "folders: {}\n",
+      ".oms/taxonomy.json": JSON.stringify({ folders: {} }),
     });
     const isExcluded = await excludedNoteMatcher(vault);
     expect(isExcluded(".obsidian/workspace.md")).toBe(true);
@@ -63,7 +63,7 @@ describe("excludedNoteMatcher", () => {
 
   it("merges vault-declared exclude globs with the built-in defaults", async () => {
     const vault = await makeVault({
-      ".oms/taxonomy.yaml": "folders: {}\nexclude:\n  - \"drafts/**\"\n",
+      ".oms/taxonomy.json": JSON.stringify({ folders: {}, exclude: ["drafts/**"] }),
     });
     const isExcluded = await excludedNoteMatcher(vault);
     expect(isExcluded("drafts/unfinished.md")).toBe(true);
@@ -71,7 +71,7 @@ describe("excludedNoteMatcher", () => {
     expect(isExcluded("notes/idea.md")).toBe(false);
   });
 
-  it("degrades to the built-in defaults when taxonomy.yaml is missing", async () => {
+  it("degrades to the built-in defaults when taxonomy.json is missing", async () => {
     const vault = await makeVault();
     const isExcluded = await excludedNoteMatcher(vault);
     expect(isExcluded(".obsidian/workspace.md")).toBe(true);
@@ -80,9 +80,9 @@ describe("excludedNoteMatcher", () => {
 
   it("retains malformed taxonomy evidence instead of silently allowing every note", async () => {
     const vault = await makeVault({
-      ".oms/taxonomy.yaml": "broken: [legacy\n",
+      ".oms/taxonomy.json": "broken: [legacy\n",
     });
-    await expect(excludedNoteMatcher(vault)).rejects.toThrow(/NOTE_EXCLUSION_RESOLUTION_FAILED.*taxonomy\.yaml/);
+    await expect(excludedNoteMatcher(vault)).rejects.toThrow(/NOTE_EXCLUSION_RESOLUTION_FAILED.*taxonomy\.json/);
   });
 });
 

--- a/src/kernel/conventions/note-exclude.ts
+++ b/src/kernel/conventions/note-exclude.ts
@@ -1,7 +1,7 @@
 /**
  * Vault-declared note exclusions for the scanning walkers.
  *
- * `taxonomy.yaml: exclude` names markdown files that are not notes - template
+ * `taxonomy.json: exclude` names markdown files that are not notes - template
  * sources whose pre-substitution frontmatter is intentionally not valid YAML
  * (Templater tags, agent {{var}} placeholders), build staging, skill files.
  * Every template-derived graph/index walker uses this declaration so excluded
@@ -13,7 +13,6 @@
  */
 import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
-import { parse as parseYaml } from "yaml";
 
 /**
  * Default audit exemptions - build artifacts, self-documenting templates, and
@@ -82,8 +81,8 @@ async function loadExcludeMatchers(vaultRoot: string): Promise<RegExp[]> {
     pending = (async () => {
       let declared: string[] = [];
       try {
-        const raw = await readFile(path.join(key, ".oms", "taxonomy.yaml"), "utf-8");
-        const parsed = parseYaml(raw) as unknown;
+        const raw = await readFile(path.join(key, ".oms", "taxonomy.json"), "utf-8");
+        const parsed = JSON.parse(raw) as unknown;
         const rawExclude =
           parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
             ? (parsed as Record<string, unknown>)["exclude"]
@@ -91,13 +90,13 @@ async function loadExcludeMatchers(vaultRoot: string): Promise<RegExp[]> {
         if (Array.isArray(rawExclude) && rawExclude.every((item) => typeof item === "string")) {
           declared = rawExclude;
         } else if (rawExclude !== undefined) {
-          failure("NOTE_EXCLUSION_RESOLUTION_FAILED", ".oms/taxonomy.yaml: exclude must be a list of strings");
+          failure("NOTE_EXCLUSION_RESOLUTION_FAILED", ".oms/taxonomy.json: exclude must be a list of strings");
         }
       } catch (error) {
         if (error instanceof Error && "code" in error && error.code === "ENOENT") {
           declared = [];
         } else {
-          failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `.oms/taxonomy.yaml: ${error instanceof Error ? error.message : String(error)}`);
+          failure("NOTE_EXCLUSION_RESOLUTION_FAILED", `.oms/taxonomy.json: ${error instanceof Error ? error.message : String(error)}`);
         }
       }
       const externalTemplatePaths = await loadExternalTemplatePaths(key);

--- a/src/kernel/doctor/service.test.ts
+++ b/src/kernel/doctor/service.test.ts
@@ -21,14 +21,14 @@ async function makeVault(): Promise<string> {
   ]);
   const digest = (value: string): `sha256:${string}` => `sha256:${createHash("sha256").update(value).digest("hex")}`;
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { note: { intent: "A note.", fields: { template: { type: "text", required: true }, title: { type: "text" } }, views: [] } }, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", contract: "note", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const obsidianTypes = JSON.stringify({ types: { template: "text", title: "text" } });
   const template = "---\ntemplate: note\ntitle: Untitled\n---\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [{ logicalId: "template-policy", signature: digest(policy) }, { logicalId: "taxonomy", signature: digest(taxonomy) }, { logicalId: "obsidian-types", signature: digest(obsidianTypes) }, { path: "Templates/OMS/note.md", signature: digest(template) }];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: {}, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", targetFolder: "Inbox", keyOrder: ["template", "title"], fields: { template: { type: "text", required: true }, title: { type: "text" } }, views: [], naming: "{{slug}}.md", bodySignature: digest("<!-- oms:content -->\n") } } } });
   await Promise.all([
     writeFile(path.join(vault, ".oms", "template-policy.json"), policy),
-    writeFile(path.join(vault, ".oms", "taxonomy.yaml"), taxonomy),
+    writeFile(path.join(vault, ".oms", "taxonomy.json"), taxonomy),
     writeFile(path.join(vault, ".oms", "types.json"), projection),
     writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes),
     writeFile(path.join(vault, "Templates", "OMS", "note.md"), template),

--- a/src/kernel/engine/README.md
+++ b/src/kernel/engine/README.md
@@ -50,7 +50,7 @@ exactly once with its assembly. Constructing an engine or serving lexical querie
 loads no model state at all.
 
 In 0.10.0, expansion and reranking receive folder context only from active
-`.oms/taxonomy.yaml` `intent` values. No legacy root file, bundled default, or
+`.oms/taxonomy.json` `intent` values. No legacy root file, bundled default, or
 parallel context database can enter a model prompt. Receipts and status expose
 the exact matched intents and deterministic warnings for unmatched indexed or
 taxonomy folders.

--- a/src/kernel/engine/assemble-graph-only.test.ts
+++ b/src/kernel/engine/assemble-graph-only.test.ts
@@ -16,13 +16,13 @@ function freshVault(): string {
   tempDirs.push(vault);
   for (const directory of [".oms", ".obsidian", "Templates/OMS", "notes"]) mkdirSync(path.join(vault, directory), { recursive: true });
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { note: { intent: "note", fields: { template: { type: "text", required: true }, status: { type: "text" } }, views: [] } }, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", contract: "note", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const obsidianTypes = JSON.stringify({ types: { template: "text", status: "text" } });
   const template = "---\ntemplate: note\nstatus: active\n---\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [{ logicalId: "template-policy", signature: digest(policy) }, { logicalId: "taxonomy", signature: digest(taxonomy) }, { logicalId: "obsidian-types", signature: digest(obsidianTypes) }, { path: "Templates/OMS/note.md", signature: digest(template) }];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: {}, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", targetFolder: "Inbox", keyOrder: ["template", "status"], fields: { template: { type: "text", required: true }, status: { type: "text" } }, views: [], naming: "{{slug}}.md", bodySignature: digest("<!-- oms:content -->\n") } } } });
   writeFileSync(path.join(vault, ".oms/template-policy.json"), policy);
-  writeFileSync(path.join(vault, ".oms/taxonomy.yaml"), taxonomy);
+  writeFileSync(path.join(vault, ".oms/taxonomy.json"), taxonomy);
   writeFileSync(path.join(vault, ".oms/types.json"), projection);
   writeFileSync(path.join(vault, ".obsidian/types.json"), obsidianTypes);
   writeFileSync(path.join(vault, "Templates/OMS/note.md"), template);

--- a/src/kernel/engine/mcp/facade.test.ts
+++ b/src/kernel/engine/mcp/facade.test.ts
@@ -92,10 +92,7 @@ function freshVault(intents: Readonly<Record<string, string>> = {}): string {
     },
   });
   const intentEntries = Object.entries(intents).sort(([left], [right]) => left.localeCompare(right));
-  const taxonomy = intentEntries.length === 0
-    ? "folders: {}\n"
-    : `folders:\n${intentEntries.map(([folder, intent]) =>
-      `  ${folder}:\n    intent: ${intent}\n`).join("")}`;
+  const taxonomy = JSON.stringify({ folders: Object.fromEntries(intentEntries.map(([folder, intent]) => [folder, { intent }])) });
   const types = JSON.stringify({ types: { status: "text", rating: "number", done: "boolean" } });
   const projectTemplate = "---\nstatus: active\nrating: 1\ndone: false\n---\nBody\n";
   const referenceTemplate = "---\nrating: 1\ndone: false\n---\nBody\n";
@@ -131,7 +128,7 @@ function freshVault(intents: Readonly<Record<string, string>> = {}): string {
     },
   });
   writeFileSync(path.join(dir, ".oms", "template-policy.json"), policy);
-  writeFileSync(path.join(dir, ".oms", "taxonomy.yaml"), taxonomy);
+  writeFileSync(path.join(dir, ".oms", "taxonomy.json"), taxonomy);
   writeFileSync(path.join(dir, ".obsidian", "types.json"), types);
   writeFileSync(path.join(dir, ".oms", "types.json"), projection);
   writeFileSync(path.join(dir, "Templates", "OMS", "project.md"), projectTemplate);
@@ -191,7 +188,7 @@ describe("McpEngineAdapter.semanticQuery", () => {
       unused: "No indexed documents",
     });
     // Parallel legacy context must never reach a model prompt.
-    writeFileSync(path.join(vault, "taxonomy.yaml"), `
+    writeFileSync(path.join(vault, "taxonomy.json"), `
 folders:
   notes:
     intent: Legacy context must not leak
@@ -239,12 +236,12 @@ folders:
         {
           folder: "notes",
           intent: "Permanent project notes",
-          source: ".oms/taxonomy.yaml",
+          source: ".oms/taxonomy.json",
         },
       ],
     });
     expect(result.receipt.warnings).toEqual([
-      'Indexed folder "inbox" has no intent in .oms/taxonomy.yaml.',
+      'Indexed folder "inbox" has no intent in .oms/taxonomy.json.',
       'Taxonomy folder "unused" has no indexed Markdown files.',
     ]);
   });
@@ -381,7 +378,7 @@ folders:
         {
           folder: "notes",
           intent: "Permanent project notes",
-          source: ".oms/taxonomy.yaml",
+          source: ".oms/taxonomy.json",
         },
       ],
     });
@@ -781,12 +778,12 @@ describe("McpEngineAdapter.semanticStatus", () => {
       available: true,
       taxonomyContext: {
         matched: [
-          { folder: "notes", intent: "Permanent notes", source: ".oms/taxonomy.yaml" },
+          { folder: "notes", intent: "Permanent notes", source: ".oms/taxonomy.json" },
         ],
         indexedWithoutIntent: ["inbox"],
         taxonomyWithoutIndexed: ["unused"],
         warnings: [
-          'Indexed folder "inbox" has no intent in .oms/taxonomy.yaml.',
+          'Indexed folder "inbox" has no intent in .oms/taxonomy.json.',
           'Taxonomy folder "unused" has no indexed Markdown files.',
         ],
       },
@@ -852,7 +849,7 @@ describe("McpEngineAdapter.listContexts", () => {
         collection: "notes",
         pathPrefix: "notes",
         context: "Permanent project notes",
-        source: ".oms/taxonomy.yaml",
+        source: ".oms/taxonomy.json",
       }],
     });
     if (!result.available) return;

--- a/src/kernel/engine/mcp/facade.ts
+++ b/src/kernel/engine/mcp/facade.ts
@@ -948,7 +948,7 @@ export class McpEngineAdapter {
       const indexedPaths = typeof store.listDocPaths === "function" ? store.listDocPaths() : [];
       const vault = opts.vault ?? this.vaultPath;
       const projection = await loadTaxonomyIntentProjection(vault, indexedPaths);
-      const taxonomyPath = path.join(vault, ".oms", "taxonomy.yaml");
+      const taxonomyPath = path.join(vault, ".oms", "taxonomy.json");
       const updatedAt = projection.matched.length === 0
         ? ""
         : statSync(taxonomyPath).mtime.toISOString();

--- a/src/kernel/engine/mcp/types.ts
+++ b/src/kernel/engine/mcp/types.ts
@@ -166,7 +166,7 @@ export interface McpSemanticReceipt {
   readonly taxonomyIntents: readonly {
     readonly folder: string;
     readonly intent: string;
-    readonly source: ".oms/taxonomy.yaml";
+    readonly source: ".oms/taxonomy.json";
   }[];
   readonly warnings: readonly string[];
 }
@@ -352,7 +352,7 @@ export interface McpSemanticStoredContext {
   readonly pathPrefix: string;
   readonly context: string;
   readonly updatedAt: string;
-  readonly source: ".oms/taxonomy.yaml";
+  readonly source: ".oms/taxonomy.json";
 }
 
 /** Output of oms_semantic_contexts (mirrors SemanticContextResult). */

--- a/src/kernel/engine/retrieval/taxonomy-context.test.ts
+++ b/src/kernel/engine/retrieval/taxonomy-context.test.ts
@@ -83,7 +83,7 @@ async function vaultWithContract(taxonomy: string): Promise<string> {
   });
   await Promise.all([
     writeFile(path.join(vault, ".oms", "template-policy.json"), policy),
-    writeFile(path.join(vault, ".oms", "taxonomy.yaml"), taxonomy),
+    writeFile(path.join(vault, ".oms", "taxonomy.json"), taxonomy),
     writeFile(path.join(vault, ".oms", "types.json"), projection),
     writeFile(path.join(vault, ".obsidian", "types.json"), types),
     writeFile(path.join(vault, "Templates", "OMS", "note.md"), template),
@@ -105,8 +105,8 @@ describe("projectTaxonomyIntents", () => {
     ]);
 
     expect(projection.matched).toEqual([
-      { folder: "alpha", intent: "Alpha knowledge", source: ".oms/taxonomy.yaml" },
-      { folder: "zeta", intent: "Zeta knowledge", source: ".oms/taxonomy.yaml" },
+      { folder: "alpha", intent: "Alpha knowledge", source: ".oms/taxonomy.json" },
+      { folder: "zeta", intent: "Zeta knowledge", source: ".oms/taxonomy.json" },
     ]);
     expect(projection.promptContext).toBe(
       "- alpha: Alpha knowledge\n- zeta: Zeta knowledge",
@@ -125,9 +125,9 @@ describe("projectTaxonomyIntents", () => {
     expect(projection.indexedWithoutIntent).toEqual(["alpha", "blank", "zulu"]);
     expect(projection.taxonomyWithoutIndexed).toEqual(["taxonomy-only"]);
     expect(projection.warnings).toEqual([
-      'Indexed folder "alpha" has no intent in .oms/taxonomy.yaml.',
-      'Indexed folder "blank" has no intent in .oms/taxonomy.yaml.',
-      'Indexed folder "zulu" has no intent in .oms/taxonomy.yaml.',
+      'Indexed folder "alpha" has no intent in .oms/taxonomy.json.',
+      'Indexed folder "blank" has no intent in .oms/taxonomy.json.',
+      'Indexed folder "zulu" has no intent in .oms/taxonomy.json.',
       'Taxonomy folder "taxonomy-only" has no indexed Markdown files.',
     ]);
   });
@@ -143,7 +143,7 @@ describe("projectTaxonomyIntents", () => {
     );
 
     expect(projection.matched).toEqual([
-      { folder: "notes", intent: "Permanent notes", source: ".oms/taxonomy.yaml" },
+      { folder: "notes", intent: "Permanent notes", source: ".oms/taxonomy.json" },
     ]);
     expect(projection.warnings).toEqual([]);
     expect(projection.promptContext).toBe("- notes: Permanent notes");
@@ -162,25 +162,23 @@ describe("projectTaxonomyIntents", () => {
 
 describe("loadTaxonomyIntentProjection", () => {
   it("uses resolved folder-ontology members and intents", async () => {
-    const vault = await vaultWithContract([
-      "folders:",
-      "  references:",
-      "    intent: Processed sources.",
-      "  notes:",
-      "    intent: Permanent notes.",
-      "",
-    ].join("\n"));
+    const vault = await vaultWithContract(JSON.stringify({
+      folders: {
+        references: { intent: "Processed sources." },
+        notes: { intent: "Permanent notes." },
+      },
+    }));
 
     const projection = await loadTaxonomyIntentProjection(vault, ["references/a.md", "notes/b.md"]);
 
     expect(projection.matched).toEqual([
-      { folder: "notes", intent: "Permanent notes.", source: ".oms/taxonomy.yaml" },
-      { folder: "references", intent: "Processed sources.", source: ".oms/taxonomy.yaml" },
+      { folder: "notes", intent: "Permanent notes.", source: ".oms/taxonomy.json" },
+      { folder: "references", intent: "Processed sources.", source: ".oms/taxonomy.json" },
     ]);
   });
 
   it("treats an absent folder-ontology axis as empty context", async () => {
-    const vault = await vaultWithContract("folders:\n  notes:\n    template: note\n");
+    const vault = await vaultWithContract(JSON.stringify({ folders: { notes: { template: "note" } } }));
 
     const projection = await loadTaxonomyIntentProjection(vault, ["notes/a.md"]);
 
@@ -214,7 +212,7 @@ describe("loadTaxonomyIntentProjection", () => {
       await writeFile(projectionPath, JSON.stringify(projection));
     }],
   ])("fails closed with repair guidance when the active contract is %s", async (state, change) => {
-    const vault = await vaultWithContract("folders:\n  notes:\n    intent: Permanent notes.\n");
+    const vault = await vaultWithContract(JSON.stringify({ folders: { notes: { intent: "Permanent notes." } } }));
     await change(vault);
 
     await expect(loadTaxonomyIntentProjection(vault, ["notes/a.md"])).rejects.toThrow(state);

--- a/src/kernel/engine/retrieval/taxonomy-context.ts
+++ b/src/kernel/engine/retrieval/taxonomy-context.ts
@@ -5,7 +5,7 @@ export interface TaxonomyIntentProvenance {
   readonly folder: string;
   readonly intent: string;
   /** The sole source allowed to contribute prompt text. */
-  readonly source: ".oms/taxonomy.yaml";
+  readonly source: ".oms/taxonomy.json";
 }
 
 export interface TaxonomyIntentProjection {
@@ -60,7 +60,7 @@ export function projectTaxonomyIntents(
       const intent = intents.get(folder)?.trim();
       return intent === undefined || intent === ""
         ? []
-        : [{ folder, intent, source: ".oms/taxonomy.yaml" }];
+        : [{ folder, intent, source: ".oms/taxonomy.json" }];
     })
     .sort((left, right) => compareText(left.folder, right.folder));
 
@@ -76,7 +76,7 @@ export function projectTaxonomyIntents(
 
   const warnings = [
     ...indexedWithoutIntent.map((folder) =>
-      `Indexed folder "${folder}" has no intent in .oms/taxonomy.yaml.`),
+      `Indexed folder "${folder}" has no intent in .oms/taxonomy.json.`),
     ...taxonomyWithoutIndexed.map((folder) =>
       `Taxonomy folder "${folder}" has no indexed Markdown files.`),
   ];

--- a/src/kernel/link/link.test.ts
+++ b/src/kernel/link/link.test.ts
@@ -109,9 +109,9 @@ describe("resolveEffectiveVault", () => {
     expect(resolved).toEqual({ vault: path.resolve(vault), scope: null, source: "vault" });
   });
 
-  it("treats a dir with .oms/taxonomy.yaml as the vault itself", async () => {
+  it("treats a dir with .oms/taxonomy.json as the vault itself", async () => {
     await mkdir(path.join(vault, ".oms"), { recursive: true });
-    await writeFile(path.join(vault, ".oms", "taxonomy.yaml"), "version: 1\nfolders: {}\n", "utf-8");
+    await writeFile(path.join(vault, ".oms", "taxonomy.json"), JSON.stringify({ version: 1, folders: {} }), "utf-8");
     const resolved = await resolveEffectiveVault(vault, {});
     expect(resolved.source).toBe("vault");
     expect(resolved.scope).toBeNull();

--- a/src/kernel/link/link.ts
+++ b/src/kernel/link/link.ts
@@ -9,7 +9,7 @@ import { parse as yamlParse, stringify as yamlStringify } from "yaml";
  * Two distinct `.oms/` profiles exist, distinguished by content:
  *
  *   - Vault `.oms/`  — template-first controls: `template-policy.json`,
- *                      `taxonomy.yaml`, and derived `types.json`.
+ *                      `taxonomy.json`, and derived `types.json`.
  *                      Written by `oms setup`. Owned by the user's Obsidian vault.
  *   - Bridge `.oms/` — a link into a vault from some *other* repo (e.g. a GitHub
  *                      project). Holds NO convention yaml; only `links.yaml`
@@ -167,7 +167,7 @@ export async function writeLinkRecord(omsDir: string, record: LinkRecord): Promi
  *
  * Precedence (content-based, so the two `.oms/` profiles never collide):
  *   1. Local template convention (`.oms/template-policy.json` or
- *      `.oms/taxonomy.yaml`)                                        → vault.
+ *      `.oms/taxonomy.json`)                                        → vault.
  *   2. Local bridge (`.oms/links.yaml`)                              → bridge.
  *   3. `OMS_VAULT` environment variable                             → env.
  *   4. Fallback to `startDir`                                       → cwd.
@@ -179,7 +179,7 @@ export async function resolveEffectiveVault(
   const omsDir = path.join(startDir, ".oms");
 
   const policyKind = await pathKind(path.join(omsDir, "template-policy.json"));
-  const taxonomyKind = await pathKind(path.join(omsDir, "taxonomy.yaml"));
+  const taxonomyKind = await pathKind(path.join(omsDir, "taxonomy.json"));
   if (policyKind === "file" || taxonomyKind === "file") {
     return { vault: path.resolve(startDir), scope: null, source: "vault" };
   }

--- a/src/kernel/search/morning-test-fixtures.ts
+++ b/src/kernel/search/morning-test-fixtures.ts
@@ -11,14 +11,14 @@ export async function writeMorningVaultFixture(): Promise<string> {
   const vault = await mkdtemp(path.join(tmpdir(), "oms-morning-"));
   for (const directory of [".oms", ".obsidian", "Templates/OMS", "references"]) await mkdir(path.join(vault, directory), { recursive: true });
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { reference: { intent: "reference", fields: { template: { type: "text", required: true }, title: { type: "text", required: true }, "source-url": { type: "text" }, tags: { type: "list" } }, views: [] } }, templates: { reference: { templateId: "reference", destinationClass: "managed-default", sourcePath: "Templates/OMS/reference.md", contract: "reference", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const obsidianTypes = JSON.stringify({ types: { template: "text", title: "text", "source-url": "text", tags: "list" } });
   const template = "---\ntemplate: reference\ntitle: Untitled\nsource-url:\ntags: []\n---\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [{ logicalId: "template-policy", signature: digest(policy) }, { logicalId: "taxonomy", signature: digest(taxonomy) }, { logicalId: "obsidian-types", signature: digest(obsidianTypes) }, { path: "Templates/OMS/reference.md", signature: digest(template) }];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: {}, templates: { reference: { templateId: "reference", destinationClass: "managed-default", sourcePath: "Templates/OMS/reference.md", targetFolder: "Inbox", keyOrder: ["template", "title", "source-url", "tags"], fields: { template: { type: "text", required: true }, title: { type: "text", required: true }, "source-url": { type: "text" }, tags: { type: "list" } }, views: [], naming: "{{slug}}.md", bodySignature: digest("<!-- oms:content -->\n") } } } });
   await Promise.all([
     writeFile(path.join(vault, ".oms/template-policy.json"), policy),
-    writeFile(path.join(vault, ".oms/taxonomy.yaml"), taxonomy),
+    writeFile(path.join(vault, ".oms/taxonomy.json"), taxonomy),
     writeFile(path.join(vault, ".oms/types.json"), projection),
     writeFile(path.join(vault, ".obsidian/types.json"), obsidianTypes),
     writeFile(path.join(vault, "Templates/OMS/reference.md"), template),

--- a/src/kernel/templates/doctor.test.ts
+++ b/src/kernel/templates/doctor.test.ts
@@ -14,14 +14,14 @@ async function vault(): Promise<string> {
   roots.push(root);
   await Promise.all([".oms", ".obsidian", "Templates", "notes"].map(dir => mkdir(path.join(root, dir), { recursive: true })));
   const policy = `${JSON.stringify({ version: 1, templateFolder: "Templates", base: { fields: {} }, contracts: { note: { intent: "note", fields: {}, views: [] } }, templates: { note: { templateId: "note", destinationClass: "registered-existing", sourcePath: "Templates/note.md", contract: "note", naming: "{{slug}}.md" } } })}\n`;
-  const taxonomy = "folders:\n  notes:\n    concept: note\n";
+  const taxonomy = JSON.stringify({ folders: { notes: { concept: "note" } } });
   const obsidian = "{\"title\":\"text\"}\n";
   const template = "---\ntitle: template\n---\nbody\n";
   const descriptors = [{ logicalId: "template-policy", signature: sha(policy) }, { logicalId: "taxonomy", signature: sha(taxonomy) }, { logicalId: "obsidian-types", signature: sha(obsidian) }, { path: "Templates/note.md", signature: sha(template) }];
   const projection = `${JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(descriptors), sources: descriptors }, managed: { base: { fields: {} }, globalAxes: {}, templates: { note: { templateId: "note", destinationClass: "registered-existing", sourcePath: "Templates/note.md", targetFolder: "Inbox", keyOrder: ["title"], fields: { title: { type: "text" } }, views: [], naming: "{{slug}}.md", bodySignature: sha("body\n") } } } }, null, 2)}\n`;
   await Promise.all([
     writeFile(path.join(root, ".oms", "template-policy.json"), policy, "utf8"),
-    writeFile(path.join(root, ".oms", "taxonomy.yaml"), taxonomy, "utf8"),
+    writeFile(path.join(root, ".oms", "taxonomy.json"), taxonomy, "utf8"),
     writeFile(path.join(root, ".oms", "types.json"), projection, "utf8"),
 
     writeFile(path.join(root, ".obsidian", "types.json"), obsidian, "utf8"),
@@ -125,7 +125,7 @@ describe("template doctor", () => {
     const root = await vault();
     await mkdir(path.join(root, "notes", "one"), { recursive: true });
     await writeFile(path.join(root, "notes", "one", "child.md"), "---\nconcept: note\n---\nbody\n", "utf8");
-    await writeFile(path.join(root, ".oms", "taxonomy.yaml"), "folders:\n  notes:\n    concept: note\n  notes/one:\n    concept: note\n", "utf8");
+    await writeFile(path.join(root, ".oms", "taxonomy.json"), JSON.stringify({ folders: { notes: { concept: "note" }, "notes/one": { concept: "note" } } }), "utf8");
     expect((await backfillDefaults({ target: { vault: root, source: "explicit" }, notePath: "notes/one/child.md", request: { dryRun: true } })).status).toBe("rejected");
   });
   it("rejects symlink and escaping note paths", async () => {

--- a/src/kernel/templates/doctor.ts
+++ b/src/kernel/templates/doctor.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import { parseDocument } from "yaml";
 
 import { admitWriteTarget } from "../capture/safe.js";
 import type { WriteTargetSource } from "../conventions/write-protocol.js";
@@ -89,7 +88,7 @@ export async function regenerateTypes(input: RegenerateTypesRequest): Promise<Te
   try { policy = parseTemplatePolicy(await readFile(join(root, ".oms/template-policy.json"), "utf8")); }
   catch { return rejected("TEMPLATE_POLICY_INVALID", "restore .oms/template-policy.json before regenerating types"); }
   try {
-    const controls = await Promise.all([state(root, ".oms/template-policy.json"), state(root, ".oms/taxonomy.yaml"), state(root, ".oms/types.json"), state(root, ".obsidian/types.json")]);
+    const controls = await Promise.all([state(root, ".oms/template-policy.json"), state(root, ".oms/taxonomy.json"), state(root, ".oms/types.json"), state(root, ".obsidian/types.json")]);
     if (controls[0]?.state === "absent" || controls[1]?.state === "absent" || controls[3]?.state === "absent") return rejected("TEMPLATE_CONTROL_MISSING", "restore template policy, taxonomy, and Obsidian types before regenerating types");
     const sources = await Promise.all(Object.values(policy.templates).map(async binding => {
       const current = await state(root, binding.sourcePath);
@@ -97,7 +96,7 @@ export async function regenerateTypes(input: RegenerateTypesRequest): Promise<Te
     }));
     const authority: AuthorityEntry[] = [
       { kind: "policy", logicalId: "template-policy", vaultRelativePath: ".oms/template-policy.json", contentDigest: (controls[0] as Extract<VerifiedFileState, { state: "present" }>).signature },
-      { kind: "taxonomy", logicalId: "taxonomy", vaultRelativePath: ".oms/taxonomy.yaml", contentDigest: (controls[1] as Extract<VerifiedFileState, { state: "present" }>).signature },
+      { kind: "taxonomy", logicalId: "taxonomy", vaultRelativePath: ".oms/taxonomy.json", contentDigest: (controls[1] as Extract<VerifiedFileState, { state: "present" }>).signature },
       { kind: "obsidian-types", logicalId: "obsidian-types", vaultRelativePath: ".obsidian/types.json", contentDigest: (controls[3] as Extract<VerifiedFileState, { state: "present" }>).signature },
     ];
     for (const source of sources) {
@@ -119,9 +118,10 @@ function legacyTemplateId(policy: TemplatePolicy, raw: string, taxonomyRaw: stri
   if (!parsed.hasFrontmatter || parsed.diagnostics.length > 0 || parsed.frontmatter["template"] !== undefined) return null;
   const concept = parsed.frontmatter["concept"];
   if (typeof concept !== "string") return null;
-  const taxonomy = parseDocument(taxonomyRaw, { prettyErrors: false });
-  const root = taxonomy.toJS();
-  if (taxonomy.errors.length > 0 || typeof root !== "object" || root === null || Array.isArray(root)) return null;
+  let root: unknown;
+  try { root = JSON.parse(taxonomyRaw) as unknown; }
+  catch { return null; }
+  if (typeof root !== "object" || root === null || Array.isArray(root)) return null;
   const folders = (root as Record<string, unknown>)["folders"];
   if (typeof folders !== "object" || folders === null || Array.isArray(folders)) return null;
   const candidates = Object.entries(folders).filter(([folder, binding]) => {
@@ -138,12 +138,12 @@ function legacyTemplateId(policy: TemplatePolicy, raw: string, taxonomyRaw: stri
   return line.test(parsed.frontmatterRaw) ? matches[0]!.templateId : null;
 }
 async function noteManifest(root: string, notePath: TemplateSourcePath, before: Extract<VerifiedFileState, { readonly state: "present" }>, after: Uint8Array, templateId: TemplateId): Promise<TemplateCompositionManifest> {
-  const controlPaths = [".oms/template-policy.json", ".oms/taxonomy.yaml", ".oms/types.json"] as const;
+  const controlPaths = [".oms/template-policy.json", ".oms/taxonomy.json", ".oms/types.json"] as const;
   const values = await Promise.all(controlPaths.map(path => state(root, path)));
   if (values.some(value => value.state === "absent")) throw new Error("TEMPLATE_CONTROL_MISSING");
   const controls = controlPaths.map((path, index) => {
     const value = values[index]! as Extract<VerifiedFileState, { readonly state: "present" }>;
-    return { kind: path === ".oms/template-policy.json" ? "policy" as const : path === ".oms/taxonomy.yaml" ? "taxonomy" as const : "projection" as const, path, expectedCurrent: expectation(value), current: value, proposed: value, action: "verify-only" as const };
+    return { kind: path === ".oms/template-policy.json" ? "policy" as const : path === ".oms/taxonomy.json" ? "taxonomy" as const : "projection" as const, path, expectedCurrent: expectation(value), current: value, proposed: value, action: "verify-only" as const };
   }) as unknown as TemplateCompositionManifest["controls"];
   const authority: InputV2 = { version: 2, authority: [{ kind: "template", logicalId: templateId, vaultRelativePath: notePath, contentDigest: digest(after) }], placement: [] };
   const transition = { templateId, path: notePath, expectedCurrent: expectation(before), current: before, proposed: { state: "present" as const, bytes: after, signature: digest(after) }, action: "write" as const };
@@ -165,7 +165,7 @@ export async function backfillDefaults(input: BackfillDefaultsRequest): Promise<
   try { path = normalizeTemplateSourcePath(input.notePath); await verifyTemplateSourcePath(root, path); }
   catch { return rejected("TEMPLATE_SOURCE_UNSAFE", "provide one existing regular markdown note path inside the verified vault"); }
   try {
-    const [before, policyRaw, taxonomyRaw] = await Promise.all([state(root, path), readFile(join(root, ".oms/template-policy.json"), "utf8"), readFile(join(root, ".oms/taxonomy.yaml"), "utf8")]);
+    const [before, policyRaw, taxonomyRaw] = await Promise.all([state(root, path), readFile(join(root, ".oms/template-policy.json"), "utf8"), readFile(join(root, ".oms/taxonomy.json"), "utf8")]);
     if (before.state === "absent") return rejected("TEMPLATE_SOURCE_INVALID", "provide one existing note path");
     const policy = parseTemplatePolicy(policyRaw);
     const raw = Buffer.from(before.bytes).toString("utf8");

--- a/src/kernel/templates/migration.test.ts
+++ b/src/kernel/templates/migration.test.ts
@@ -160,8 +160,7 @@ describe("template migration planner", () => {
     if (taxonomyControl?.proposed.state !== "present" || projectionControl?.proposed.state !== "present") throw new Error("expected migration controls");
     const taxonomy = new TextDecoder().decode(taxonomyControl.proposed.bytes);
     const projection = new TextDecoder().decode(projectionControl.proposed.bytes);
-    expect(taxonomy).toContain("user-extension:");
-    expect(taxonomy).toContain("template: literature");
+    expect(JSON.parse(taxonomy)).toMatchObject({ "user-extension": { preserved: "yes" }, folders: { references: { template: "literature" } } });
     expect(projection).toContain("projection-extension");
   });
 
@@ -202,7 +201,7 @@ describe("template migration planner", () => {
       members: ["inbox", "references"],
       extensions: { intents: { inbox: "Unprocessed captures.", references: "Processed external sources." } },
     });
-    expect(new TextDecoder().decode(manifest.controls.find(control => control.kind === "taxonomy")!.proposed.bytes)).toContain("templates:");
+    expect(JSON.parse(new TextDecoder().decode(manifest.controls.find(control => control.kind === "taxonomy")!.proposed.bytes))).toMatchObject({ folders: { references: { templates: ["literature", "term"] } } });
     expect((await applyTemplateMigration(root, proposal, manifest, { approvedDigest: manifest.approvalDigest })).status).toBe("applied");
     const resolved = await loadResolvedTemplates(root);
     expect(resolved.templates.literature?.targetFolder).toBe("references");
@@ -248,7 +247,7 @@ describe("template migration planner", () => {
     const policyText = new TextDecoder().decode(policy.proposed.bytes);
     expect(policyText).toContain('"contract": "literature"');
     expect(policyText).toContain('"migrationProvenance"');
-    expect(new TextDecoder().decode(taxonomy.proposed.bytes)).toContain("template: literature--books");
+    expect(JSON.parse(new TextDecoder().decode(taxonomy.proposed.bytes))).toMatchObject({ folders: { books: { template: "literature--books" } } });
     const projectionJson = JSON.parse(new TextDecoder().decode(projection.proposed.bytes)) as {
       managed: { templates: Record<string, { fields: Record<string, unknown> }> };
     };

--- a/src/kernel/templates/migration.ts
+++ b/src/kernel/templates/migration.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
 import type { Dirent } from "node:fs";
-import { lstat, readdir, readFile } from "node:fs/promises";
+import { lstat, readdir, readFile, rm } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
-import { parseDocument, stringify } from "yaml";
+import { parseDocument } from "yaml";
 import { parseNote } from "../conventions/frontmatter.js";
 import { excludedNoteMatcher } from "../conventions/note-exclude.js";
 
@@ -321,7 +321,11 @@ export async function applyTemplateMigration(vault: string, proposal: MigrationP
     || typeof manifest.approvalDigest !== "string"
     || typeof manifest.outputDigest !== "string"
   ) throw new Error("MIGRATION_APPROVAL_MISMATCH");
-  return executeTemplateTransaction(vault, manifest, request);
+  const receipt = await executeTemplateTransaction(vault, manifest, request);
+  if (request.dryRun !== true && (receipt.status === "applied" || receipt.status === "already-complete")) {
+    await rm(join(vault, ".oms", "taxonomy.yaml"), { force: true });
+  }
+  return receipt;
 }
 
 export function migrationProposalDigest(proposal: MigrationProposal): Digest {
@@ -528,11 +532,21 @@ function asJson(value: unknown): JsonValue {
   if (typeof value === "object") return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, member]) => [key, asJson(member)]));
   throw new Error("MIGRATION_TAXONOMY_INVALID: non-JSON taxonomy member");
 }
-function translatedTaxonomy(value: VerifiedFileState, proposal: MigrationProposal, inheritedAxes: GlobalAxes = {}): { readonly bytes: Uint8Array; readonly globalAxes: GlobalAxes; readonly targetFolders: ReadonlyMap<string, TemplateFolderPath> } {
-  if (value.state === "absent") return { bytes: bytes(stringify({ folders: {}, globalAxes: inheritedAxes })), globalAxes: inheritedAxes, targetFolders: new Map() };
-  const document = parseDocument(new TextDecoder().decode(value.bytes), { prettyErrors: false });
-  const source = document.toJS() as unknown;
-  if (document.errors.length > 0 || typeof source !== "object" || source === null || Array.isArray(source)) throw new Error("MIGRATION_TAXONOMY_INVALID: .oms/taxonomy.yaml");
+function translatedTaxonomy(value: VerifiedFileState, proposal: MigrationProposal, legacyYaml: boolean, inheritedAxes: GlobalAxes = {}): { readonly bytes: Uint8Array; readonly globalAxes: GlobalAxes; readonly targetFolders: ReadonlyMap<string, TemplateFolderPath> } {
+  if (value.state === "absent") return { bytes: bytes(`${JSON.stringify({ folders: {}, globalAxes: inheritedAxes }, null, 2)}\n`), globalAxes: inheritedAxes, targetFolders: new Map() };
+  let source: unknown;
+  try {
+    if (legacyYaml) {
+      const document = parseDocument(new TextDecoder().decode(value.bytes), { prettyErrors: false });
+      if (document.errors.length > 0) throw new Error("invalid YAML");
+      source = document.toJS() as unknown;
+    } else {
+      source = JSON.parse(new TextDecoder().decode(value.bytes)) as unknown;
+    }
+  } catch {
+    throw new Error(`MIGRATION_TAXONOMY_INVALID: ${legacyYaml ? ".oms/taxonomy.yaml" : ".oms/taxonomy.json"}`);
+  }
+  if (typeof source !== "object" || source === null || Array.isArray(source)) throw new Error(`MIGRATION_TAXONOMY_INVALID: ${legacyYaml ? ".oms/taxonomy.yaml" : ".oms/taxonomy.json"}`);
   const root = asJson(source) as unknown as Record<string, JsonValue>;
   const folders = root.folders;
   if (folders !== undefined && (typeof folders !== "object" || folders === null || Array.isArray(folders))) throw new Error("MIGRATION_TAXONOMY_INVALID: folders");
@@ -572,22 +586,22 @@ function translatedTaxonomy(value: VerifiedFileState, proposal: MigrationProposa
     }
   }
   const publishedAxes = { ...axes };
-  const folderOntology = deriveFolderOntologyAxis(folders, ".oms/taxonomy.yaml.folders");
+  const folderOntology = deriveFolderOntologyAxis(folders, ".oms/taxonomy.json.folders");
   if (folderOntology !== null) {
     if (Object.hasOwn(axes, "folder-ontology")) throw new Error("MIGRATION_TAXONOMY_INVALID: globalAxes.folder-ontology is reserved");
     axes["folder-ontology"] = folderOntology;
   }
   root.globalAxes = publishedAxes as unknown as JsonValue;
   delete root.axes;
-  return { bytes: bytes(stringify(root)), globalAxes: axes, targetFolders };
+  return { bytes: bytes(`${JSON.stringify(root, null, 2)}\n`), globalAxes: axes, targetFolders };
 }
 function inputFor(authority: readonly AuthorityEntry[], bindings: readonly TemplateBinding[], folder: TemplateFolderPath): InputV2 {
   return { version: 2, authority, placement: bindings.map(binding => ({ templateId: binding.templateId, destinationClass: binding.destinationClass, templateFolder: binding.destinationClass === "managed-default" ? folder : null, sourcePath: binding.sourcePath })) };
 }
-function authorityFor(policy: VerifiedFileState, taxonomy: VerifiedFileState, projection: VerifiedFileState, obsidian: VerifiedFileState, candidates: readonly TemplateCandidate[], includeLegacyProjection: boolean): AuthorityEntry[] {
+function authorityFor(policy: VerifiedFileState, taxonomy: VerifiedFileState, taxonomyPath: ".oms/taxonomy.yaml" | ".oms/taxonomy.json", projection: VerifiedFileState, obsidian: VerifiedFileState, candidates: readonly TemplateCandidate[], includeLegacyProjection: boolean): AuthorityEntry[] {
   const controls: AuthorityEntry[] = [];
   if (policy.state === "present") controls.push({ kind: "policy", logicalId: "template-policy", vaultRelativePath: ".oms/template-policy.json", contentDigest: policy.signature });
-  if (taxonomy.state === "present") controls.push({ kind: "taxonomy", logicalId: "taxonomy", vaultRelativePath: ".oms/taxonomy.yaml", contentDigest: taxonomy.signature });
+  if (taxonomy.state === "present") controls.push({ kind: "taxonomy", logicalId: "taxonomy", vaultRelativePath: taxonomyPath, contentDigest: taxonomy.signature });
   if (includeLegacyProjection && projection.state === "present") controls.push({ kind: "legacy-contract", logicalId: "legacy-types", vaultRelativePath: ".oms/types.json", contentDigest: projection.signature });
   controls.push({ kind: "obsidian-types", logicalId: "obsidian-types", vaultRelativePath: ".obsidian/types.json", contentDigest: present(obsidian, ".obsidian/types.json").signature });
   return [...controls, ...candidates.map(candidate => ({ kind: "template" as const, logicalId: candidate.templateId, vaultRelativePath: candidate.sourcePath, contentDigest: sha(candidate.bytes) }))];
@@ -597,16 +611,23 @@ function authorityFor(policy: VerifiedFileState, taxonomy: VerifiedFileState, pr
 export async function buildMigrationManifest(vault: string, proposal: MigrationProposal, input: MigrationCompositionInput): Promise<TemplateCompositionManifest> {
   if (proposal.unresolved.length > 0) throw new Error("MIGRATION_UNRESOLVED_MAPPING");
   const root = resolve(vault);
-  const [policyState, taxonomyState, projectionState, obsidianState] = await Promise.all([
-    fileState(root, ".oms/template-policy.json"), fileState(root, ".oms/taxonomy.yaml"), fileState(root, ".oms/types.json"), fileState(root, ".obsidian/types.json"),
+  const [policyState, taxonomyState, legacyTaxonomyState, projectionState, obsidianState] = await Promise.all([
+    fileState(root, ".oms/template-policy.json"), fileState(root, ".oms/taxonomy.json"), fileState(root, ".oms/taxonomy.yaml"), fileState(root, ".oms/types.json"), fileState(root, ".obsidian/types.json"),
   ]);
   present(obsidianState, ".obsidian/types.json");
   const authority = await loadObsidianTypes(root);
   if (authority === null) throw new Error("MIGRATION_AUTHORITY_MISSING: .obsidian/types.json");
   const currentPolicy = policyState.state === "present" ? parseTemplatePolicy(new TextDecoder().decode(policyState.bytes)) : undefined;
-  if (taxonomyState.state === "present") {
-    const document = parseDocument(new TextDecoder().decode(taxonomyState.bytes), { prettyErrors: false });
-    if (document.errors.length > 0 || mapping(document.toJS({ mapAsMap: true })) === null) throw new Error("MIGRATION_TAXONOMY_INVALID: .oms/taxonomy.yaml");
+  const taxonomyInput = legacyTaxonomyState.state === "present" ? legacyTaxonomyState : taxonomyState;
+  if (taxonomyInput.state === "present") {
+    try {
+      const source = legacyTaxonomyState.state === "present"
+        ? parseDocument(new TextDecoder().decode(taxonomyInput.bytes), { prettyErrors: false }).toJS({ mapAsMap: true })
+        : JSON.parse(new TextDecoder().decode(taxonomyInput.bytes)) as unknown;
+      if (mapping(source) === null) throw new Error("invalid taxonomy");
+    } catch {
+      throw new Error(`MIGRATION_TAXONOMY_INVALID: ${legacyTaxonomyState.state === "present" ? ".oms/taxonomy.yaml" : ".oms/taxonomy.json"}`);
+    }
   }
   // `.oms/types.json` is legacy input during migration. It is intentionally not
   // accepted through the template-first projection parser.
@@ -631,7 +652,7 @@ export async function buildMigrationManifest(vault: string, proposal: MigrationP
     );
   });
   const policyBytes = bytes(serializeTemplatePolicy(proposedPolicy));
-  const translated = translatedTaxonomy(taxonomyState, proposal, legacyContract.axes);
+  const translated = translatedTaxonomy(taxonomyInput, proposal, legacyTaxonomyState.state === "present", legacyContract.axes);
   const taxonomyBytes = translated.bytes;
   const sourceDescriptors = [
     { logicalId: "template-policy", signature: sha(policyBytes) },
@@ -663,13 +684,13 @@ export async function buildMigrationManifest(vault: string, proposal: MigrationP
     };
   }))).sort((a, b) => a.templateId.localeCompare(b.templateId));
   const currentBindings = currentPolicy === undefined ? [] : Object.values(currentPolicy.templates).sort((a, b) => a.templateId.localeCompare(b.templateId));
-  const currentInput = inputFor(authorityFor(policyState, taxonomyState, projectionState, obsidianState, currentBindings.map(binding => candidateById.get(binding.templateId)!).filter((candidate): candidate is TemplateCandidate => candidate !== undefined), currentPolicy === undefined), currentBindings, currentPolicy?.templateFolder ?? proposal.templateFolder);
-  const proposedInput = inputFor(authorityFor({ state: "present", bytes: policyBytes, signature: sha(policyBytes) }, { state: "present", bytes: taxonomyBytes, signature: sha(taxonomyBytes) }, projectionState, obsidianState, proposal.candidates, currentPolicy === undefined), proposedBindings, proposedPolicy.templateFolder);
+  const currentInput = inputFor(authorityFor(policyState, taxonomyInput, legacyTaxonomyState.state === "present" ? ".oms/taxonomy.yaml" : ".oms/taxonomy.json", projectionState, obsidianState, currentBindings.map(binding => candidateById.get(binding.templateId)!).filter((candidate): candidate is TemplateCandidate => candidate !== undefined), currentPolicy === undefined), currentBindings, currentPolicy?.templateFolder ?? proposal.templateFolder);
+  const proposedInput = inputFor(authorityFor({ state: "present", bytes: policyBytes, signature: sha(policyBytes) }, { state: "present", bytes: taxonomyBytes, signature: sha(taxonomyBytes) }, ".oms/taxonomy.json", projectionState, obsidianState, proposal.candidates, currentPolicy === undefined), proposedBindings, proposedPolicy.templateFolder);
   const current = { input: currentInput, inputDigest: inputDigest(currentInput), bindings: currentBindings, resolvedTemplates: currentBindings.map(binding => { const candidate = candidateById.get(binding.templateId)!; return { templateId: binding.templateId, sourcePath: binding.sourcePath, inputSignature: inputDigest(currentInput), templateSignature: sha(candidate.bytes) }; }) };
   const proposed = { input: proposedInput, inputDigest: inputDigest(proposedInput), bindings: proposedBindings, resolvedTemplates: extracted.map((template, index) => ({ templateId: proposedBindings[index]!.templateId, sourcePath: template.sourcePath, inputSignature: derived.generatedFrom.inputSignature, templateSignature: template.sourceDigest })) };
   const controls: TemplateCompositionManifest["controls"] = [
     { kind: "policy", path: ".oms/template-policy.json", expectedCurrent: expectation(policyState), current: policyState, proposed: { state: "present", bytes: policyBytes, signature: sha(policyBytes) }, action: policyState.state === "present" && same(policyState.bytes, policyBytes) ? "verify-only" : "write" },
-    { kind: "taxonomy", path: ".oms/taxonomy.yaml", expectedCurrent: expectation(taxonomyState), current: taxonomyState, proposed: { state: "present", bytes: taxonomyBytes, signature: sha(taxonomyBytes) }, action: taxonomyState.state === "present" && same(taxonomyState.bytes, taxonomyBytes) ? "verify-only" : "write" },
+    { kind: "taxonomy", path: ".oms/taxonomy.json", expectedCurrent: expectation(taxonomyState), current: taxonomyState, proposed: { state: "present", bytes: taxonomyBytes, signature: sha(taxonomyBytes) }, action: taxonomyState.state === "present" && same(taxonomyState.bytes, taxonomyBytes) ? "verify-only" : "write" },
     { kind: "projection", path: ".oms/types.json", expectedCurrent: expectation(projectionState), current: projectionState, proposed: { state: "present", bytes: projectionBytes, signature: sha(projectionBytes) }, action: projectionState.state === "present" && same(projectionState.bytes, projectionBytes) ? "verify-only" : "write" },
   ];
   const mode: "create" | "update" = currentPolicy === undefined ? "create" : "update";

--- a/src/kernel/templates/paths.ts
+++ b/src/kernel/templates/paths.ts
@@ -3,7 +3,7 @@ import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { DestinationClass, TemplateFolderPath, TemplateId, TemplateSourcePath } from "./types.js";
 const ID = /^[a-z0-9]+(?:-{1,2}[a-z0-9]+)*$/;
 const INTERNAL = new Set([".oms", ".gjc", ".git", ".obsidian", ".template-transactions"]);
-const CONTROLS = new Set([".oms/template-policy.json", ".oms/types.json", ".oms/taxonomy.yaml", ".oms/template-migration.json", ".oms/template-transaction.json"]);
+const CONTROLS = new Set([".oms/template-policy.json", ".oms/types.json", ".oms/taxonomy.json", ".oms/template-migration.json", ".oms/template-transaction.json"]);
 export type TemplateControlPath = string & { readonly __kind: "TemplateControlPath" };
 export interface VerifiedVaultPath<T extends TemplateFolderPath | TemplateSourcePath | TemplateControlPath> { readonly vaultRoot: string; readonly vaultRelativePath: T; readonly absolutePath: string; readonly targetRealPath: string | null; }
 export interface VaultPathVerificationOptions { readonly expected: "existing-file" | "absent" | "either"; }

--- a/src/kernel/templates/resolver.test.ts
+++ b/src/kernel/templates/resolver.test.ts
@@ -31,7 +31,7 @@ async function fixture(): Promise<string> {
       },
     },
   });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const types = JSON.stringify({ types: { title: "text" } });
   const template = "---\ntitle: literal\n---\nBody\n";
   const sources: SourceDescriptor[] = [
@@ -63,7 +63,7 @@ async function fixture(): Promise<string> {
   });
   await Promise.all([
     writeFile(join(root, ".oms", "template-policy.json"), policy),
-    writeFile(join(root, ".oms", "taxonomy.yaml"), taxonomy),
+    writeFile(join(root, ".oms", "taxonomy.json"), taxonomy),
     writeFile(join(root, ".obsidian", "types.json"), types),
     writeFile(join(root, "Templates", "OMS", "note.md"), template),
     writeFile(join(root, ".oms", "types.json"), projection),
@@ -84,7 +84,7 @@ describe("loadResolvedTemplates", () => {
     [".oms/template-migration.json", "MIGRATION_INCOMPLETE"],
     [".oms/template-policy.json", "TEMPLATE_SOURCE_INVALID"],
     [".oms/types.json", "TEMPLATE_SOURCE_INVALID"],
-    [".oms/taxonomy.yaml", "TEMPLATE_SOURCE_INVALID"],
+    [".oms/taxonomy.json", "TEMPLATE_SOURCE_INVALID"],
   ])("rejects a vault with only %s", async (control, code) => {
     const root = await mkdtemp(join(tmpdir(), "oms-template-resolver-partial-"));
     roots.push(root);
@@ -95,9 +95,9 @@ describe("loadResolvedTemplates", () => {
   });
 
   it.each([
-    [".oms/template-policy.json", ".oms/taxonomy.yaml"],
+    [".oms/template-policy.json", ".oms/taxonomy.json"],
     [".oms/template-policy.json", ".oms/types.json"],
-    [".oms/types.json", ".oms/taxonomy.yaml"],
+    [".oms/types.json", ".oms/taxonomy.json"],
   ])("rejects representative partial control sets: %s and %s", async (first, second) => {
     const root = await mkdtemp(join(tmpdir(), "oms-template-resolver-partial-"));
     roots.push(root);
@@ -143,7 +143,7 @@ describe("loadResolvedTemplates", () => {
 
   it("resolves a signed actual template without writing the vault", async () => {
     const root = await fixture();
-    const before = await Promise.all([".oms/template-policy.json", ".oms/types.json", ".oms/taxonomy.yaml", ".obsidian/types.json", "Templates/OMS/note.md"].map(async file => [file, await readFile(join(root, file), "utf8")] as const));
+    const before = await Promise.all([".oms/template-policy.json", ".oms/types.json", ".oms/taxonomy.json", ".obsidian/types.json", "Templates/OMS/note.md"].map(async file => [file, await readFile(join(root, file), "utf8")] as const));
     const resolved = await loadResolvedTemplates(root);
     expect(Object.keys(resolved.templates)).toEqual(["note"]);
     expect(resolved.templates.note?.body).toBe("Body\n");
@@ -165,18 +165,10 @@ describe("loadResolvedTemplates", () => {
 
   it("rejects an authored axis that collides with the derived folder ontology", async () => {
     const root = await fixture();
-    await writeFile(join(root, ".oms", "taxonomy.yaml"), [
-      "folders:",
-      "  notes:",
-      "    intent: Working notes.",
-      "globalAxes:",
-      "  folder-ontology:",
-      "    kind: folder",
-      "    key: folder",
-      "    type: text",
-      "    members: [notes]",
-      "",
-    ].join("\n"));
+    await writeFile(join(root, ".oms", "taxonomy.json"), JSON.stringify({
+      folders: { notes: { intent: "Working notes." } },
+      globalAxes: { "folder-ontology": { kind: "folder", key: "folder", type: "text", members: ["notes"] } },
+    }));
     await expect(loadResolvedTemplates(root)).rejects.toThrow(/globalAxes\.folder-ontology is reserved/);
   });
 });

--- a/src/kernel/templates/resolver.ts
+++ b/src/kernel/templates/resolver.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import { readFile, stat } from "node:fs/promises";
 import { relative, resolve } from "node:path";
-import { isMap, parseDocument } from "yaml";
 import { loadObsidianTypes } from "../contracts/index.js";
 import { extractTemplate, parseTemplate } from "./extract.js";
 import { approvalDigest, canonicalJson, inputDigest, outputDigest } from "./canonical.js";
@@ -23,7 +22,7 @@ const TEMPLATE_CONTROL_PATHS = [
   ".oms/template-migration.json",
   ".oms/template-policy.json",
   ".oms/types.json",
-  ".oms/taxonomy.yaml",
+  ".oms/taxonomy.json",
 ] as const;
 
 function sha256(value: Uint8Array | string): Digest {
@@ -156,13 +155,17 @@ function managed(projection: DerivedProjection["managed"], templates: Readonly<R
   };
 }
 function validateTaxonomy(path: string, bytes: Uint8Array): void {
-  const document = parseDocument(Buffer.from(bytes).toString("utf8"), { prettyErrors: false });
-  if (document.errors.length > 0 || document.contents === null || !isMap(document.contents)) fail("TEMPLATE_SOURCE_INVALID", `taxonomy (${path}) must be a YAML mapping`);
+  const root = jsonRecord(bytes, path);
+  if (root === null) fail("TEMPLATE_SOURCE_INVALID", `taxonomy (${path}) must be a JSON object`);
 }
 function yamlRecord(value: unknown): Readonly<Record<string, unknown>> | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as Readonly<Record<string, unknown>>
     : null;
+}
+function jsonRecord(bytes: Uint8Array, path: string): Readonly<Record<string, unknown>> | null {
+  try { return yamlRecord(JSON.parse(Buffer.from(bytes).toString("utf8")) as unknown); }
+  catch { fail("TEMPLATE_SOURCE_INVALID", `taxonomy (${path}) must be valid JSON`); }
 }
 
 export function deriveFolderOntologyAxis(rawFolders: unknown, where = "taxonomy.folders"): GlobalAxis | null {
@@ -187,9 +190,8 @@ export function deriveFolderOntologyAxis(rawFolders: unknown, where = "taxonomy.
 }
 
 function taxonomyRouting(path: string, bytes: Uint8Array): { readonly targetFolders: ReadonlyMap<string, TemplateFolderPath>; readonly globalAxes: GlobalAxes } {
-  const document = parseDocument(Buffer.from(bytes).toString("utf8"), { prettyErrors: false });
-  const root = yamlRecord(document.toJS());
-  if (root === null) fail("TEMPLATE_SOURCE_INVALID", `taxonomy (${path}) must be a YAML mapping`);
+  const root = jsonRecord(bytes, path);
+  if (root === null) fail("TEMPLATE_SOURCE_INVALID", `taxonomy (${path}) must be a JSON object`);
   const targetFolders = new Map<string, TemplateFolderPath>();
   const templates = yamlRecord(root.templates);
   for (const [templateId, raw] of Object.entries(templates ?? {})) {
@@ -238,7 +240,7 @@ export async function loadResolvedTemplates(vault: string, options: LoadResolved
   if (await templateMigrationAdmission(root) !== "clear") fail("MIGRATION_INCOMPLETE", "template migration marker is in progress or invalid");
   const policyFile = options.policyPath ?? ".oms/template-policy.json";
   const projectionFile = options.projectionPath ?? ".oms/types.json";
-  const taxonomyFile = options.taxonomyPath ?? ".oms/taxonomy.yaml";
+  const taxonomyFile = options.taxonomyPath ?? ".oms/taxonomy.json";
   const [policyRaw, projectionRaw, taxonomyRaw] = await Promise.all([
     required(root, policyFile, "template policy"), required(root, projectionFile, "derived projection"), required(root, taxonomyFile, "taxonomy"),
   ]);
@@ -359,7 +361,7 @@ export async function buildTemplateCompositionManifest(vault: string, change: Te
     await loadResolvedTemplates(vault);
   }
   const policyPath = ".oms/template-policy.json";
-  const taxonomyPath = ".oms/taxonomy.yaml";
+  const taxonomyPath = ".oms/taxonomy.json";
   const projectionPath = ".oms/types.json";
   const obsidianPath = ".obsidian/types.json";
   const [policyState, taxonomyState, projectionState, obsidianState] = await Promise.all([
@@ -372,8 +374,7 @@ export async function buildTemplateCompositionManifest(vault: string, change: Te
   const taxonomyFile = requiredControl(taxonomyPath, taxonomyState);
   const obsidianFile = requiredControl(obsidianPath, obsidianState);
   if (!matchExpectation(policyFile, options.expected.controls.policy) || !matchExpectation(taxonomyFile, options.taxonomy.expectedCurrent) || !matchExpectation(projectionState, options.expected.controls.projection)) fail("TEMPLATE_TRANSACTION_MANIFEST_INVALID", "control CAS does not match");
-  const taxonomy = parseDocument(new TextDecoder().decode(options.taxonomy.proposedBytes), { prettyErrors: false });
-  if (taxonomy.errors.length || taxonomy.contents === null || !isMap(taxonomy.contents) || (options.taxonomy.action === "verify-only" && !sameManifestBytes(taxonomyFile.bytes, options.taxonomy.proposedBytes))) fail("TEMPLATE_TRANSACTION_MANIFEST_INVALID", "taxonomy proposal is invalid");
+  if (jsonRecord(options.taxonomy.proposedBytes, taxonomyPath) === null || (options.taxonomy.action === "verify-only" && !sameManifestBytes(taxonomyFile.bytes, options.taxonomy.proposedBytes))) fail("TEMPLATE_TRANSACTION_MANIFEST_INVALID", "taxonomy proposal is invalid");
   const currentPolicy = parseTemplatePolicy(new TextDecoder().decode(policyFile.bytes));
   const proposedPolicy = applyTemplatePolicyChange(currentPolicy, change);
   const proposedTaxonomy = taxonomyRouting(taxonomyPath, options.taxonomy.proposedBytes);
@@ -444,7 +445,7 @@ export async function buildTemplateCompositionManifest(vault: string, change: Te
     transitions.push({ templateId: binding.templateId, path: binding.sourcePath, expectedCurrent: current.state === "present" ? { state: "present", signature: current.signature } : { state: "absent" }, current, proposed, action: proposal === undefined || proposal.publication === "verify-existing" ? "verify-only" : "write" });
   }
   const makeSnapshot = (policy: import("./types.js").TemplatePolicy, policyDigest: Digest, taxonomyDigest: Digest, obsidianDigest: Digest, bindings: readonly import("./types.js").TemplateBinding[], sourceState: (binding: import("./types.js").TemplateBinding) => VerifiedFileState, resolvedInputSignature: Digest): TemplateSemanticSnapshot => {
-    const authority = [{ kind: "policy" as const, logicalId: "template-policy", vaultRelativePath: ".oms/template-policy.json", contentDigest: policyDigest }, { kind: "taxonomy" as const, logicalId: "taxonomy", vaultRelativePath: ".oms/taxonomy.yaml", contentDigest: taxonomyDigest }, { kind: "obsidian-types" as const, logicalId: "obsidian-types", vaultRelativePath: obsidianPath, contentDigest: obsidianDigest }, ...bindings.map(binding => { const state = sourceState(binding); return { kind: "template" as const, logicalId: binding.templateId, vaultRelativePath: binding.sourcePath, contentDigest: state.state === "present" ? state.signature : fail("TEMPLATE_TRANSACTION_MANIFEST_INVALID", "source absent") }; })].sort((a,b) => a.kind.localeCompare(b.kind) || a.logicalId.localeCompare(b.logicalId));
+    const authority = [{ kind: "policy" as const, logicalId: "template-policy", vaultRelativePath: ".oms/template-policy.json", contentDigest: policyDigest }, { kind: "taxonomy" as const, logicalId: "taxonomy", vaultRelativePath: ".oms/taxonomy.json", contentDigest: taxonomyDigest }, { kind: "obsidian-types" as const, logicalId: "obsidian-types", vaultRelativePath: obsidianPath, contentDigest: obsidianDigest }, ...bindings.map(binding => { const state = sourceState(binding); return { kind: "template" as const, logicalId: binding.templateId, vaultRelativePath: binding.sourcePath, contentDigest: state.state === "present" ? state.signature : fail("TEMPLATE_TRANSACTION_MANIFEST_INVALID", "source absent") }; })].sort((a,b) => a.kind.localeCompare(b.kind) || a.logicalId.localeCompare(b.logicalId));
     const input: InputV2 = { version: 2, authority, placement: bindings.map(binding => ({ templateId: binding.templateId, destinationClass: binding.destinationClass, templateFolder: binding.destinationClass === "managed-default" ? policy.templateFolder : null, sourcePath: binding.sourcePath })) };
     return { input, inputDigest: inputDigest(input), bindings, resolvedTemplates: bindings.map(binding => { const source = sourceState(binding); return { templateId: binding.templateId, sourcePath: binding.sourcePath, inputSignature: resolvedInputSignature, templateSignature: source.state === "present" ? source.signature : fail("TEMPLATE_TRANSACTION_MANIFEST_INVALID", "source absent") }; }) };
   };

--- a/src/kernel/templates/transaction.test.ts
+++ b/src/kernel/templates/transaction.test.ts
@@ -75,7 +75,7 @@ import type {
 const encoder = new TextEncoder();
 const TEMPLATE = "---\ntitle: literal\n---\nBody\n";
 const UPDATED = "---\ntitle: changed\n---\nChanged\n";
-const TAXONOMY = "folders: {}\n";
+const TAXONOMY = JSON.stringify({ folders: {} });
 const OBSIDIAN = `${JSON.stringify({ types: { title: "text" } }, null, 2)}\n`;
 
 beforeEach(() => {
@@ -150,7 +150,7 @@ async function fixture(bindings: readonly TemplateBinding[] = [], sourceBytes: R
   const projectionBytes = projection(bindings, policyBytes, sourceBytes);
   await Promise.all([
     writeFile(path.join(vault, ".oms", "template-policy.json"), policyBytes),
-    writeFile(path.join(vault, ".oms", "taxonomy.yaml"), TAXONOMY),
+    writeFile(path.join(vault, ".oms", "taxonomy.json"), TAXONOMY),
     writeFile(path.join(vault, ".oms", "types.json"), projectionBytes),
     writeFile(path.join(vault, ".obsidian", "types.json"), OBSIDIAN),
   ]);
@@ -163,7 +163,7 @@ async function fixture(bindings: readonly TemplateBinding[] = [], sourceBytes: R
     version: 2,
     authority: [
       { kind: "policy", logicalId: "template-policy", vaultRelativePath: ".oms/template-policy.json", contentDigest: digest(policyBytes) },
-      { kind: "taxonomy", logicalId: "taxonomy", vaultRelativePath: ".oms/taxonomy.yaml", contentDigest: digest(TAXONOMY) },
+      { kind: "taxonomy", logicalId: "taxonomy", vaultRelativePath: ".oms/taxonomy.json", contentDigest: digest(TAXONOMY) },
       { kind: "obsidian-types", logicalId: "obsidian-types", vaultRelativePath: ".obsidian/types.json", contentDigest: digest(OBSIDIAN) },
       ...bindings.map(item => ({ kind: "template" as const, logicalId: item.templateId, vaultRelativePath: item.sourcePath, contentDigest: digest(sourceBytes[item.templateId] ?? TEMPLATE) })),
     ],

--- a/src/kernel/templates/transaction.ts
+++ b/src/kernel/templates/transaction.ts
@@ -33,7 +33,7 @@ function matches(actual: VerifiedFileState, expected: FileExpectation): boolean 
 async function verifyPath(vault: string, path: TransactionPath, expectation: FileExpectation): Promise<boolean> { if (path.startsWith(".oms/")) await verifyTemplateControlPath(vault, normalizeTemplateControlPath(path), { expected: "either" }); else await verifyTemplateSourcePath(vault, normalizeTemplateSourcePath(path), { expected: "either" }); return matches(await state(vault, path), expectation); }
 function manifestValid(manifest: TemplateCompositionManifest): boolean {
   if (manifest.version !== 1 || manifest.controls.length !== 3) return false;
-  const paths: readonly ControlPath[] = [".oms/template-policy.json", ".oms/taxonomy.yaml", ".oms/types.json"];
+  const paths: readonly ControlPath[] = [".oms/template-policy.json", ".oms/taxonomy.json", ".oms/types.json"];
   if (!manifest.controls.every((control, index) => control.path === paths[index] && control.proposed.signature === sha(control.proposed.bytes))) return false;
   if (manifest.current.inputDigest !== inputDigest(manifest.current.input) || manifest.proposed.inputDigest !== inputDigest(manifest.proposed.input)) return false;
   if (manifest.approvalDigest !== approvalDigest(manifest.proposed.inputDigest, manifest.operations, manifest.diagnostics)) return false;

--- a/src/kernel/templates/types.ts
+++ b/src/kernel/templates/types.ts
@@ -33,7 +33,7 @@ export interface Diagnostic { readonly code: DiagnosticCode; readonly templateId
 export type TemplateMutationMode = "create" | "update" | "reclassify" | "relocate-folder";
 export type LogicalOperationKind = TemplateMutationMode;
 export type ControlKind = "policy" | "taxonomy" | "projection";
-export type ControlPath = ".oms/template-policy.json" | ".oms/taxonomy.yaml" | ".oms/types.json";
+export type ControlPath = ".oms/template-policy.json" | ".oms/taxonomy.json" | ".oms/types.json";
 export type TransactionPath = TemplateSourcePath | ControlPath;
 export type TemplateTransactionMarkerPath = ".oms/template-migration.json" | ".oms/template-transaction.json" | ".oms/template-backfill.json" | ".oms/template-regenerate.json";
 export type FileExpectation = { readonly state: "absent" } | { readonly state: "present"; readonly signature: Digest };
@@ -45,7 +45,7 @@ export interface SourceTransition { readonly templateId: TemplateId; readonly pa
 export interface TemplateMove { readonly templateId: TemplateId; readonly strategy: "oms-managed-rename" | "register-already-moved" | "no-op"; readonly oldPath: TemplateSourcePath; readonly newPath: TemplateSourcePath; readonly sourceSignature: Digest; }
 export interface LogicalOperation { readonly kind: LogicalOperationKind; readonly templateId: TemplateId; readonly destinationClass: DestinationClass; readonly payloadDigest: Digest; readonly stableRelativeSuffix: null; }
 export interface PlannedPhysicalOutput { readonly finalVaultRelativePath: TransactionPath; readonly payloadDigest: Digest; }
-export interface TemplateCompositionManifest { readonly version: 1; readonly mode: TemplateMutationMode; readonly current: TemplateSemanticSnapshot; readonly proposed: TemplateSemanticSnapshot; readonly controls: readonly [ControlTransition<"policy", ".oms/template-policy.json">, ControlTransition<"taxonomy", ".oms/taxonomy.yaml">, ControlTransition<"projection", ".oms/types.json">]; readonly sources: readonly SourceTransition[]; readonly operations: readonly LogicalOperation[]; readonly diagnostics: readonly Diagnostic[]; readonly moves: readonly TemplateMove[]; readonly outputs: readonly PlannedPhysicalOutput[]; readonly approvalDigest: Digest; readonly outputDigest: Digest; }
+export interface TemplateCompositionManifest { readonly version: 1; readonly mode: TemplateMutationMode; readonly current: TemplateSemanticSnapshot; readonly proposed: TemplateSemanticSnapshot; readonly controls: readonly [ControlTransition<"policy", ".oms/template-policy.json">, ControlTransition<"taxonomy", ".oms/taxonomy.json">, ControlTransition<"projection", ".oms/types.json">]; readonly sources: readonly SourceTransition[]; readonly operations: readonly LogicalOperation[]; readonly diagnostics: readonly Diagnostic[]; readonly moves: readonly TemplateMove[]; readonly outputs: readonly PlannedPhysicalOutput[]; readonly approvalDigest: Digest; readonly outputDigest: Digest; }
 export interface SourceCasExpectation { readonly templateId: TemplateId; readonly path: TemplateSourcePath; readonly expected: FileExpectation; }
 export interface TemplateCasExpectation { readonly input: Digest; readonly controls: Readonly<{ policy: FileExpectation; taxonomy: FileExpectation; projection: FileExpectation; }>; readonly sources: readonly SourceCasExpectation[]; }
 export interface TemplateDryRunRequest { readonly dryRun: true; readonly approvedDigest?: never; }

--- a/src/mcp/demotion-reachability.test.ts
+++ b/src/mcp/demotion-reachability.test.ts
@@ -21,7 +21,7 @@ function digest(value: string): `sha256:${string}` {
 
 async function createTemplateAuthority(vault: string): Promise<void> {
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { note: { intent: "A note.", fields: { template: { type: "text", required: true }, title: { type: "text", required: true }, status: { type: "select", required: true, allowedValues: ["open", "closed"] } }, views: [] } }, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", contract: "note", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const obsidianTypes = JSON.stringify({ types: { template: "text", title: "text", status: "select" } });
   const template = "---\ntemplate: note\ntitle: Untitled\nstatus: open\n---\n# Note\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [
@@ -32,7 +32,7 @@ async function createTemplateAuthority(vault: string): Promise<void> {
   ];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: {}, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", targetFolder: "Inbox", keyOrder: ["template", "title", "status"], fields: { template: { type: "text", required: true }, title: { type: "text", required: true }, status: { type: "select", required: true, allowedValues: ["open", "closed"] } }, views: [], naming: "{{slug}}.md", bodySignature: digest("# Note\n<!-- oms:content -->\n") } } } });
   await Promise.all([mkdir(path.join(vault, ".oms"), { recursive: true }), mkdir(path.join(vault, ".obsidian"), { recursive: true }), mkdir(path.join(vault, "Templates", "OMS"), { recursive: true })]);
-  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.yaml"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "note.md"), template)]);
+  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.json"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "note.md"), template)]);
   const targetPath = path.join(vault, "references", "clean-architecture.md");
   const target = await readFile(targetPath, "utf-8");
   await writeFile(targetPath, target.replace(/^---\n/u, "---\ntemplate: note\n"), "utf-8");

--- a/src/mcp/search-read-only.test.ts
+++ b/src/mcp/search-read-only.test.ts
@@ -145,12 +145,12 @@ async function makeTemplateVault(): Promise<string> {
     mkdir(path.join(vault, "Templates", "OMS"), { recursive: true }),
   ]);
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { note: { intent: "A note.", fields: { template: { type: "text", required: true, intent: "Stable note identity." } }, views: [] } }, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", contract: "note", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders:\n  notes:\n    intent: Working notes.\n    template: note\n";
+  const taxonomy = JSON.stringify({ folders: { notes: { intent: "Working notes.", template: "note" } } });
   const obsidianTypes = JSON.stringify({ types: { template: "text" } });
   const template = "---\ntemplate: note\n---\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [{ logicalId: "template-policy", signature: digest(policy) }, { logicalId: "taxonomy", signature: digest(taxonomy) }, { logicalId: "obsidian-types", signature: digest(obsidianTypes) }, { path: "Templates/OMS/note.md", signature: digest(template) }];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: { "folder-ontology": { kind: "folder", key: "folder", type: "text", intent: "Semantic meanings of vault folders.", members: ["notes"], extensions: { intents: { notes: "Working notes." } } } }, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", targetFolder: "notes", keyOrder: ["template"], fields: { template: { type: "text", required: true, intent: "Stable note identity." } }, views: [], naming: "{{slug}}.md", bodySignature: digest("<!-- oms:content -->\n") } } } });
-  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.yaml"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "note.md"), template)]);
+  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.json"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "note.md"), template)]);
   return vault;
 }
 

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -21,24 +21,24 @@ function templateDigest(value: string): `sha256:${string}` {
 
 async function createMcpTemplateAuthority(vault: string): Promise<void> {
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { literature: { intent: "A source.", fields: { template: { type: "text", required: true }, title: { type: "text", required: true }, "source-url": { type: "text", required: true } }, views: [] } }, templates: { literature: { templateId: "literature", destinationClass: "managed-default", sourcePath: "Templates/OMS/literature.md", contract: "literature", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const obsidianTypes = JSON.stringify({ types: { template: "text", title: "text", "source-url": "text" } });
   const template = "---\ntemplate: literature\ntitle: Untitled\nsource-url:\n---\n# Literature\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [{ logicalId: "template-policy", signature: templateDigest(policy) }, { logicalId: "taxonomy", signature: templateDigest(taxonomy) }, { logicalId: "obsidian-types", signature: templateDigest(obsidianTypes) }, { path: "Templates/OMS/literature.md", signature: templateDigest(template) }];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: {}, templates: { literature: { templateId: "literature", destinationClass: "managed-default", sourcePath: "Templates/OMS/literature.md", targetFolder: "Inbox", keyOrder: ["template", "title", "source-url"], fields: { template: { type: "text", required: true }, title: { type: "text", required: true }, "source-url": { type: "text", required: true } }, views: [], naming: "{{slug}}.md", bodySignature: templateDigest("# Literature\n<!-- oms:content -->\n") } } } });
   await Promise.all([mkdir(path.join(vault, ".oms"), { recursive: true }), mkdir(path.join(vault, ".obsidian"), { recursive: true }), mkdir(path.join(vault, "Templates", "OMS"), { recursive: true })]);
-  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.yaml"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "literature.md"), template)]);
+  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.json"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "literature.md"), template)]);
 }
 
 async function createLinkTemplateAuthority(vault: string): Promise<void> {
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { note: { intent: "A note.", fields: { template: { type: "text", required: true }, title: { type: "text", required: true } }, views: [] } }, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", contract: "note", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const obsidianTypes = JSON.stringify({ types: { template: "text", title: "text", aliases: "aliases" } });
   const template = "---\ntemplate: note\ntitle: Untitled\n---\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [{ logicalId: "template-policy", signature: templateDigest(policy) }, { logicalId: "taxonomy", signature: templateDigest(taxonomy) }, { logicalId: "obsidian-types", signature: templateDigest(obsidianTypes) }, { path: "Templates/OMS/note.md", signature: templateDigest(template) }];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: {}, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/OMS/note.md", targetFolder: "Inbox", keyOrder: ["template", "title"], fields: { template: { type: "text", required: true }, title: { type: "text", required: true } }, views: [], naming: "{{slug}}.md", bodySignature: templateDigest("<!-- oms:content -->\n") } } } });
   await Promise.all([mkdir(path.join(vault, ".oms"), { recursive: true }), mkdir(path.join(vault, ".obsidian"), { recursive: true }), mkdir(path.join(vault, "Templates", "OMS"), { recursive: true })]);
-  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.yaml"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "note.md"), template)]);
+  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.json"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "note.md"), template)]);
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -1186,7 +1186,7 @@ Valid frontmatter remains available to retrieve.
   it("returns a server-verified semantic sync receipt for a verified target", async () => {
     const tmpVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-mcp-doctor-sync-")));
     await mkdir(path.join(tmpVault, ".oms", "concepts"), { recursive: true });
-    await writeFile(path.join(tmpVault, ".oms", "taxonomy.yaml"), "version: 1\nfolders: {}\n", "utf-8");
+    await writeFile(path.join(tmpVault, ".oms", "taxonomy.json"), JSON.stringify({ version: 1, folders: {} }), "utf-8");
     await writeFile(path.join(tmpVault, "note.md"), "# Indexed note\n", "utf-8");
     const transport = new StdioClientTransport({
       command: process.execPath,
@@ -1233,7 +1233,7 @@ Valid frontmatter remains available to retrieve.
   it("returns a server-verified semantic cleanup receipt for a verified target", async () => {
     const tmpVault = await realpath(await mkdtemp(path.join(tmpdir(), "oms-mcp-doctor-cleanup-")));
     await mkdir(path.join(tmpVault, ".oms", "concepts"), { recursive: true });
-    await writeFile(path.join(tmpVault, ".oms", "taxonomy.yaml"), "version: 1\nfolders: {}\n", "utf-8");
+    await writeFile(path.join(tmpVault, ".oms", "taxonomy.json"), JSON.stringify({ version: 1, folders: {} }), "utf-8");
     await writeFile(path.join(tmpVault, "removed.md"), "# Removed note\n", "utf-8");
     const transport = new StdioClientTransport({
       command: process.execPath,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -496,7 +496,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
         return jsonText({
           vault,
           projectionSource: ".oms/types.json",
-          sourceOfTruth: ["markdown notes", "actual Obsidian templates", ".obsidian/types.json", ".oms/template-policy.json", ".oms/taxonomy.yaml"],
+          sourceOfTruth: ["markdown notes", "actual Obsidian templates", ".obsidian/types.json", ".oms/template-policy.json", ".oms/taxonomy.json"],
           counts: {
             templates: Object.keys(convention.templates).length,
             globalAxes: Object.keys(convention.globalAxes).length,
@@ -909,7 +909,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       };
       const [policy, taxonomy, projection] = await Promise.all([
         readState(".oms/template-policy.json"),
-        readState(".oms/taxonomy.yaml"),
+        readState(".oms/taxonomy.json"),
         readState(".oms/types.json"),
       ]);
       if (
@@ -949,7 +949,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
         sources,
       };
       const currentTaxonomy = new Uint8Array(
-        await readFile(path.join(vault, ".oms/taxonomy.yaml")),
+        await readFile(path.join(vault, ".oms/taxonomy.json")),
       );
       const mode = stringArg(args, "mode");
       let change: TemplateSemanticChange;

--- a/src/mcp/verified-target.test.ts
+++ b/src/mcp/verified-target.test.ts
@@ -21,7 +21,7 @@ function digest(value: string): `sha256:${string}` {
 
 async function createTemplateAuthority(vault: string): Promise<void> {
   const policy = JSON.stringify({ version: 1, templateFolder: "Templates/OMS", base: { fields: {} }, contracts: { literature: { intent: "A source.", fields: { template: { type: "text", required: true }, title: { type: "text", required: true }, "source-url": { type: "text", required: true } }, views: [] } }, templates: { literature: { templateId: "literature", destinationClass: "managed-default", sourcePath: "Templates/OMS/literature.md", contract: "literature", naming: "{{slug}}.md" } } });
-  const taxonomy = "folders: {}\n";
+  const taxonomy = JSON.stringify({ folders: {} });
   const obsidianTypes = JSON.stringify({ types: { template: "text", title: "text", "source-url": "text" } });
   const template = "---\ntemplate: literature\ntitle: Untitled\nsource-url:\n---\n# Literature\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [
@@ -32,7 +32,7 @@ async function createTemplateAuthority(vault: string): Promise<void> {
   ];
   const projection = JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(sources), sources }, managed: { base: { fields: {} }, globalAxes: {}, templates: { literature: { templateId: "literature", destinationClass: "managed-default", sourcePath: "Templates/OMS/literature.md", targetFolder: "Inbox", keyOrder: ["template", "title", "source-url"], fields: { template: { type: "text", required: true }, title: { type: "text", required: true }, "source-url": { type: "text", required: true } }, views: [], naming: "{{slug}}.md", bodySignature: digest("# Literature\n<!-- oms:content -->\n") } } } });
   await Promise.all([mkdir(path.join(vault, ".oms"), { recursive: true }), mkdir(path.join(vault, ".obsidian"), { recursive: true }), mkdir(path.join(vault, "Templates", "OMS"), { recursive: true })]);
-  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.yaml"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "literature.md"), template)]);
+  await Promise.all([writeFile(path.join(vault, ".oms", "template-policy.json"), policy), writeFile(path.join(vault, ".oms", "taxonomy.json"), taxonomy), writeFile(path.join(vault, ".oms", "types.json"), projection), writeFile(path.join(vault, ".obsidian", "types.json"), obsidianTypes), writeFile(path.join(vault, "Templates", "OMS", "literature.md"), template)]);
 }
 
 function textPayload(result: Awaited<ReturnType<Client["callTool"]>>): Record<string, unknown> {

--- a/src/vendors/claude/hook/post-tool-use.test.ts
+++ b/src/vendors/claude/hook/post-tool-use.test.ts
@@ -15,14 +15,14 @@ async function vault(notes: Record<string, string> = {}): Promise<string> {
   roots.push(root);
   await Promise.all([".oms", ".obsidian", "Templates", "notes"].map(dir => mkdir(path.join(root, dir), { recursive: true })));
   const policy = `${JSON.stringify({ version: 1, templateFolder: "Templates", base: { fields: {} }, contracts: { note: { intent: "note", fields: { title: { required: true, type: "text" } }, views: [] } }, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/note.md", contract: "note", naming: "{{slug}}.md" } } })}\n`;
-  const taxonomy = "folders:\n  notes:\n    template: note\n";
+  const taxonomy = JSON.stringify({ folders: { notes: { template: "note" } } });
   const obsidian = "{\"title\":\"text\"}\n";
   const template = "---\ntitle: template\n---\nbody\n";
   const descriptors = [{ logicalId: "template-policy", signature: sha(policy) }, { logicalId: "taxonomy", signature: sha(taxonomy) }, { logicalId: "obsidian-types", signature: sha(obsidian) }, { path: "Templates/note.md", signature: sha(template) }];
   const projection = `${JSON.stringify({ version: "oms.types.v1", generatedFrom: { algorithm: "sha256-lp-v1", inputSignature: sourceSignature(descriptors), sources: descriptors }, managed: { base: { fields: {} }, globalAxes: {}, templates: { note: { templateId: "note", destinationClass: "managed-default", sourcePath: "Templates/note.md", targetFolder: "notes", keyOrder: ["title"], fields: { title: { required: true, type: "text" } }, views: [], naming: "{{slug}}.md", bodySignature: sha("body\n") } } } }, null, 2)}\n`;
   await Promise.all([
     writeFile(path.join(root, ".oms", "template-policy.json"), policy, "utf8"),
-    writeFile(path.join(root, ".oms", "taxonomy.yaml"), taxonomy, "utf8"),
+    writeFile(path.join(root, ".oms", "taxonomy.json"), taxonomy, "utf8"),
     writeFile(path.join(root, ".oms", "types.json"), projection, "utf8"),
     writeFile(path.join(root, ".obsidian", "types.json"), obsidian, "utf8"),
     writeFile(path.join(root, "Templates", "note.md"), template, "utf8"),

--- a/src/vendors/claude/hook/pre-tool-use.test.ts
+++ b/src/vendors/claude/hook/pre-tool-use.test.ts
@@ -62,9 +62,9 @@ async function makeTempVault(
 }
 
 describe("loadRegisteredFolders", () => {
-  it("returns registered folder keys from a valid taxonomy.yaml", async () => {
+  it("returns registered folder keys from a valid taxonomy.json", async () => {
     const { vaultPath, cleanup } = await makeTempVault({
-      ".oms/taxonomy.yaml": `version: 1\nfolders:\n  "00. Inbox":\n    intent: inbox\n    concept: null\n  "10. Time":\n    intent: time\n    concept: null\n`,
+      ".oms/taxonomy.json": JSON.stringify({ version: 1, folders: { "00. Inbox": { intent: "inbox", concept: null }, "10. Time": { intent: "time", concept: null } } }),
     });
     try {
       const folders = await loadRegisteredFolders(vaultPath);
@@ -75,7 +75,7 @@ describe("loadRegisteredFolders", () => {
     }
   });
 
-  it("returns null when taxonomy.yaml is missing (fail-open)", async () => {
+  it("returns null when taxonomy.json is missing (fail-open)", async () => {
     const { vaultPath, cleanup } = await makeTempVault({});
     try {
       const folders = await loadRegisteredFolders(vaultPath);
@@ -85,9 +85,9 @@ describe("loadRegisteredFolders", () => {
     }
   });
 
-  it("returns null when taxonomy.yaml contains invalid YAML (fail-open)", async () => {
+  it("returns null when taxonomy.json contains invalid YAML (fail-open)", async () => {
     const { vaultPath, cleanup } = await makeTempVault({
-      ".oms/taxonomy.yaml": "{ this is: [ not valid yaml",
+      ".oms/taxonomy.json": "{ this is: [ not valid yaml",
     });
     try {
       const folders = await loadRegisteredFolders(vaultPath);

--- a/src/vendors/claude/hook/pre-tool-use.ts
+++ b/src/vendors/claude/hook/pre-tool-use.ts
@@ -1,6 +1,5 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { parse as parseYaml } from "yaml";
 import { readStdinTimeout } from "./stdin.js";
 
 interface PreToolUsePayload {
@@ -36,13 +35,13 @@ export function isPathAllowed(relPath: string, registeredFolders: readonly strin
 }
 
 /**
- * Load registered folder keys from <vault>/.oms/taxonomy.yaml.
+ * Load registered folder keys from <vault>/.oms/taxonomy.json.
  * Returns null on any I/O or parse error (caller must fail-open).
  */
 export async function loadRegisteredFolders(vault: string): Promise<string[] | null> {
   try {
-    const raw = await readFile(path.join(vault, ".oms", "taxonomy.yaml"), "utf-8");
-    const parsed = parseYaml(raw) as Record<string, unknown>;
+    const raw = await readFile(path.join(vault, ".oms", "taxonomy.json"), "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
     const folders = parsed["folders"];
     if (!folders || typeof folders !== "object" || Array.isArray(folders)) return null;
     return Object.keys(folders as Record<string, unknown>);
@@ -108,7 +107,7 @@ export async function runPreToolUse(opts: { vault: string }): Promise<void> {
   // Load taxonomy — fail-open if unreadable or corrupt.
   const registeredFolders = await loadRegisteredFolders(vault);
   if (registeredFolders === null) {
-    process.stderr.write(`[oms-guard] taxonomy.yaml unreadable at ${vault} — fail-open\n`);
+    process.stderr.write(`[oms-guard] taxonomy.json unreadable at ${vault} — fail-open\n`);
     writeResponse({ continue: true, suppressOutput: true });
     return;
   }
@@ -126,7 +125,7 @@ export async function runPreToolUse(opts: { vault: string }): Promise<void> {
 
   const topFolder = relPath.split("/")[0] ?? relPath;
   const reason =
-    `[oms-guard] Blocked: "${topFolder}" is not registered in .oms/taxonomy.yaml.\n` +
+    `[oms-guard] Blocked: "${topFolder}" is not registered in .oms/taxonomy.json.\n` +
     `Vault: ${vault}\n` +
     `To register this folder run: oms setup --vault ${vault}\n` +
     `To bypass temporarily set: OMS_GUARD=off`;

--- a/test/template-first.e2e.test.ts
+++ b/test/template-first.e2e.test.ts
@@ -65,7 +65,7 @@ async function fixture(): Promise<string> {
       },
     },
   });
-  const taxonomy = "folders:\n  notes:\n    template: note\n";
+  const taxonomy = JSON.stringify({ folders: { notes: { template: "note" } } });
   const obsidianTypes = JSON.stringify({ types: { template: "text", title: "text", status: "select" } });
   const template = "---\ntemplate: note\ntitle: Untitled\nstatus: open\n---\n# Note\n<!-- oms:content -->\n";
   const sources: SourceDescriptor[] = [
@@ -102,7 +102,7 @@ async function fixture(): Promise<string> {
 
   await Promise.all([
     writeFile(join(root, ".oms", "template-policy.json"), policy),
-    writeFile(join(root, ".oms", "taxonomy.yaml"), taxonomy),
+    writeFile(join(root, ".oms", "taxonomy.json"), taxonomy),
     writeFile(join(root, ".oms", "types.json"), projection),
     writeFile(join(root, ".obsidian", "types.json"), obsidianTypes),
     writeFile(join(root, "Templates", "OMS", "note.md"), template),


### PR DESCRIPTION
Third release of the approved consensus plan (T2, user-confirmed): the OMS-owned ontology surface drops YAML entirely. Setup converts approved legacy YAML to JSON and removes it; doctor guides YAML-only vaults; approval digests are intentionally invalidated by the signed path change (re-approval documented in the changelog). Derived folder-ontology behavior unchanged (SSOT tests green). Historical ADRs deliberately untouched. Verification: npm run lint, npm test (1419 passed), npm run check:docs, npx vitest run test/architecture all green.