### PR TITLE
R3 public acceptance fixtures

### DIFF
--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -141,6 +141,7 @@ function setupSmoke(packageRoot, vault, smokeHome) {
   const result = run(process.execPath, [cli, "setup", "--vault", vault, "--yes", "--approved-digest", approval, "--install-claude"], { cwd: packageRoot, env });
   const output = `${result.stdout}\n${result.stderr}`;
   assertPath(path.join(vault, ".oms/taxonomy.json"), "vault taxonomy");
+  if (existsSync(path.join(vault, ".oms/taxonomy.yaml"))) fail("setup retained retired vault taxonomy YAML");
   assertPath(path.join(vault, ".oms/template-policy.json"), "vault template policy");
   assertPath(path.join(vault, ".oms/types.json"), "vault derived projection");
   if (existsSync(path.join(vault, ".oms/concepts"))) fail("setup recreated the retired concepts directory");

--- a/src/cli/oms-dispatch.test.ts
+++ b/src/cli/oms-dispatch.test.ts
@@ -259,6 +259,64 @@ describe("oms CLI dispatch", () => {
     );
   });
 
+  it("guides a YAML-only vault through one approved setup conversion without doctor parsing YAML", async () => {
+    const vault = await makeVault();
+    await mkdir(path.join(vault, ".oms"), { recursive: true });
+    await writeFile(path.join(vault, ".oms", "taxonomy.yaml"), "this: [is not valid YAML\n");
+
+    const doctor = runCli(["doctor", "--vault", vault, "--json"]);
+    expect(doctor.status).toBe(1);
+    expect(doctor.stderr).toBe("");
+    expect(jsonObject(doctor.stdout)).toEqual({
+      vault,
+      status: "needs-repair",
+      diagnostics: [{
+        code: "LEGACY_TAXONOMY_YAML",
+        path: ".oms/taxonomy.yaml",
+        remediation: "legacy .oms/taxonomy.yaml is no longer read — run oms setup to convert to taxonomy.json",
+      }],
+    });
+
+    await writeFile(path.join(vault, ".oms", "taxonomy.yaml"), "folders: {}\n");
+    await mkdir(path.join(vault, ".obsidian"), { recursive: true });
+    await writeFile(path.join(vault, ".obsidian", "types.json"), JSON.stringify({ types: { template: "text" } }));
+    const dryRun = runCli(["setup", "--vault", vault, "--dry-run"]);
+    expect(dryRun.status).toBe(0);
+    const approval = /"approvalDigest":\s*"(sha256:[0-9a-f]{64})"/u.exec(dryRun.stdout)?.[1];
+    expect(approval).toBeDefined();
+
+    const applied = runCli(["setup", "--vault", vault, "--yes", "--approved-digest", approval!]);
+    expect(applied.status).toBe(0);
+    expect(existsSync(path.join(vault, ".oms", "taxonomy.json"))).toBe(true);
+    expect(existsSync(path.join(vault, ".oms", "taxonomy.yaml"))).toBe(false);
+  });
+
+  it("fails closed when both legacy YAML and authoritative JSON taxonomy files exist", async () => {
+    const vault = await makeVault();
+    await mkdir(path.join(vault, ".oms"), { recursive: true });
+    await writeFile(path.join(vault, ".oms", "taxonomy.yaml"), "folders: {}\n");
+    await writeFile(path.join(vault, ".oms", "taxonomy.json"), "{\"folders\":{}}\n");
+
+    const doctor = runCli(["doctor", "--vault", vault, "--json"]);
+    expect(doctor.status).toBe(1);
+    expect(jsonObject(doctor.stdout)).toEqual({
+      vault,
+      status: "needs-repair",
+      diagnostics: [{
+        code: "LEGACY_TAXONOMY_YAML",
+        path: ".oms/taxonomy.yaml",
+        remediation: "legacy .oms/taxonomy.yaml remains after conversion — remove it; .oms/taxonomy.json is authoritative",
+      }],
+    });
+
+    const setup = runCli(["setup", "--vault", vault, "--dry-run"]);
+    expect(setup.status).toBe(1);
+    expect(`${setup.stdout}\n${setup.stderr}`).toContain("MIGRATION_TAXONOMY_INVALID");
+    expect(`${setup.stdout}\n${setup.stderr}`).toContain(".oms/taxonomy.json is authoritative; manually remove .oms/taxonomy.yaml before setup");
+    expect(existsSync(path.join(vault, ".oms", "taxonomy.json"))).toBe(true);
+    expect(existsSync(path.join(vault, ".oms", "taxonomy.yaml"))).toBe(true);
+  });
+
   it("emits audit JSON and exits 0 for a clean template fixture folder", async () => {
     const vault = await makeVault();
     await mkdir(path.join(vault, "Templates"), { recursive: true });

--- a/src/cli/setup-command.ts
+++ b/src/cli/setup-command.ts
@@ -66,8 +66,9 @@ export async function runSetup(opts: {
   if (state.proposal.unresolved.length > 0) {
     console.log(JSON.stringify({
       status: "blocked",
-      diagnostics: state.proposal.unresolved.map(({ code, path }) => ({
+      diagnostics: state.proposal.unresolved.map(({ code, message, path }) => ({
         code,
+        remediation: message,
         ...(path === undefined ? {} : { path }),
       })),
     }, null, 2));

--- a/src/kernel/templates/transaction.test.ts
+++ b/src/kernel/templates/transaction.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -54,6 +55,7 @@ vi.mock("node:fs/promises", async importOriginal => {
 });
 
 import { inputDigest } from "./canonical.js";
+import { buildMigrationManifest, planTemplateMigration } from "./migration.js";
 import { normalizeTemplateSourcePath } from "./paths.js";
 import { serializeDerivedProjection, serializeTemplatePolicy } from "./policy.js";
 import { buildTemplateCompositionManifest, sourceSignature } from "./resolver.js";
@@ -521,6 +523,34 @@ describe("guarded template transactions", () => {
       }
       expect(await readFile(path.join(item.vault, "Moved/beta.md"), "utf8")).toBe(TEMPLATE);
     } finally { await cleanup(item); }
+  });
+
+  it("resumes a failed legacy taxonomy YAML cleanup and receipts the converged final state", async () => {
+    const vault = await mkdtemp(path.join(tmpdir(), "oms-transaction-legacy-cleanup-"));
+    try {
+      await mkdir(path.join(vault, ".oms"), { recursive: true });
+      await mkdir(path.join(vault, ".obsidian"), { recursive: true });
+      await writeFile(path.join(vault, ".oms", "taxonomy.yaml"), "folders: {}\n");
+      await writeFile(path.join(vault, ".obsidian", "types.json"), JSON.stringify({ types: { template: "text" } }));
+      const proposal = await planTemplateMigration(vault);
+      const manifest = await buildMigrationManifest(vault, proposal, { base: { fields: {} } });
+      expect(manifest.legacyCleanup).toMatchObject({ path: ".oms/taxonomy.yaml", action: "delete" });
+      const transactionId = createHash("sha256").update(`${manifest.approvalDigest}\0${manifest.outputDigest}`).digest("hex").slice(0, 32);
+
+      inject("remove", ".oms/taxonomy.yaml");
+      injectSecondary("remove", ".oms/template-migration.json");
+      expect((await executeTemplateTransaction(vault, manifest, { approvedDigest: manifest.approvalDigest })).status).toBe("inconsistent");
+      expect(existsSync(path.join(vault, ".oms", "taxonomy.yaml"))).toBe(true);
+
+      const receipt = await resumeTemplateTransaction(vault, transactionId, manifest.approvalDigest);
+      expect(receipt.status).toBe("applied");
+      if (receipt.status === "applied") {
+        expect(receipt.deletedPaths).toContain(".oms/taxonomy.yaml");
+        expect(receipt.verified).toContainEqual({ path: ".oms/taxonomy.yaml", state: "absent" });
+        expect(receipt.markerState).toBe("complete");
+      }
+      expect(existsSync(path.join(vault, ".oms", "taxonomy.yaml"))).toBe(false);
+    } finally { await rm(vault, { recursive: true, force: true }); }
   });
 
   it("keeps completed migration, routine mutation, and regenerate marker families independent", async () => {


### PR DESCRIPTION
Closes the R3 generation-2 WATCH item: artifact-smoke asserts taxonomy.yaml absence after setup, real-CLI fixtures pin YAML-only conversion and dual-authority fail-closed guidance, and a cleanup fault/resume test pins receipt convergence.