### PR TITLE
Fix #104: re-ingest generated taxonomy and add templates

### DIFF
--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -4,6 +4,8 @@ Domain logic changes belong here.
 
 ## [Unreleased]
 
+- **Setup preserves generated taxonomy template bindings and incrementally registers newly discovered templates.** (#104)
+
 ## [0.12.1] - 2026-09-01
 
 ## [0.12.0] - 2026-09-01

--- a/src/kernel/templates/migration.test.ts
+++ b/src/kernel/templates/migration.test.ts
@@ -336,6 +336,43 @@ describe("template migration planner", () => {
     expect(migration.controls.map(control => control.expectedCurrent.state)).toEqual(["present", "present", "present"]);
   });
 
+  it("re-ingests normalized taxonomy and adds newly discovered template bindings", async () => {
+    const root = await fresh();
+    await mkdir(path.join(root, ".oms"), { recursive: true });
+    await mkdir(path.join(root, ".obsidian"), { recursive: true });
+    await writeFile(path.join(root, ".obsidian", "types.json"), JSON.stringify({ types: { template: "string" } }));
+    await writeFile(path.join(root, ".oms", "template-policy.json"), JSON.stringify({
+      version: 1,
+      templateFolder: "Templates",
+      base: { fields: {} },
+      contracts: { base: { intent: "Template convention", fields: {}, views: [] } },
+      templates: {},
+    }));
+    await writeFile(path.join(root, ".oms", "taxonomy.json"), JSON.stringify({
+      folders: {
+        Notes: { intent: "Notes", templates: [], templateFolder: "Notes" },
+        Raw: { intent: "Raw", template: "note", templateFolder: "Raw" },
+      },
+    }));
+    await template(root, "Templates/note.md");
+
+    const proposal = await planTemplateMigration(root);
+    const manifest = await buildMigrationManifest(root, proposal, { base: { fields: {} } });
+    const taxonomy = manifest.controls.find(control => control.kind === "taxonomy")!;
+    const policy = manifest.controls.find(control => control.kind === "policy")!;
+    if (taxonomy.proposed.state !== "present" || policy.proposed.state !== "present") throw new Error("expected proposed controls");
+    expect(JSON.parse(new TextDecoder().decode(taxonomy.proposed.bytes))).toMatchObject({
+      folders: { Raw: { template: "note", templateFolder: "Raw" } },
+    });
+    expect(JSON.parse(new TextDecoder().decode(policy.proposed.bytes))).toMatchObject({
+      templates: { note: { templateId: "note", sourcePath: "Templates/note.md" } },
+    });
+
+    await applyTemplateMigration(root, proposal, manifest, { approvedDigest: manifest.approvalDigest });
+    const rerun = await buildMigrationManifest(root, await planTemplateMigration(root), { base: { fields: {} } });
+    expect(rerun.controls.map(control => control.action)).toEqual(["verify-only", "verify-only", "verify-only"]);
+  });
+
   it("binds legacy taxonomy deletion to the observed YAML pre-image", async () => {
     const root = await fresh();
     await template(root, "Templates/note.md");

--- a/src/kernel/templates/migration.ts
+++ b/src/kernel/templates/migration.ts
@@ -569,21 +569,39 @@ function translatedTaxonomy(value: VerifiedFileState, proposal: MigrationProposa
       if (typeof raw !== "object" || raw === null || Array.isArray(raw)) throw new Error(`MIGRATION_TAXONOMY_INVALID: folders.${folder}`);
       const binding = raw as Record<string, JsonValue>;
       const concept = binding.concept;
-      if (concept !== null && typeof concept !== "string" && (!Array.isArray(concept) || concept.some(item => typeof item !== "string"))) throw new Error(`MIGRATION_TAXONOMY_INVALID: folders.${folder}.concept`);
+      if (concept !== undefined && concept !== null && typeof concept !== "string" && (!Array.isArray(concept) || concept.some(item => typeof item !== "string"))) throw new Error(`MIGRATION_TAXONOMY_INVALID: folders.${folder}.concept`);
       const concepts = typeof concept === "string" ? [concept] : Array.isArray(concept) ? concept as readonly string[] : [];
-      const templateIds = concepts.map(name => {
+      const conceptTemplateIds = concepts.map(name => {
         const clone = proposal.bindingClones.find(item => item.legacyConcept === name && item.folder === folder);
-        const templateId = clone?.templateId ?? candidates.get(validateTemplateId(name));
+        let templateId: TemplateId | undefined;
+        if (clone !== undefined) templateId = clone.templateId;
+        else {
+          try { templateId = candidates.get(validateTemplateId(name)); }
+          catch { templateId = undefined; }
+        }
         if (templateId === undefined) throw new Error(`MIGRATION_UNRESOLVED_MAPPING: folders.${folder}`);
-        targetFolders.set(templateId, normalizeTemplateFolderPath(folder));
+        targetFolders.set(templateId, normalizeTemplateFolderPath(typeof binding.templateFolder === "string" ? binding.templateFolder : folder));
         return templateId;
       });
-      const { concept: _concept, ...rest } = binding;
-      (folders as Record<string, JsonValue>)[folder] = {
-        ...rest,
-        ...(templateIds.length === 1 ? { template: templateIds[0]! } : { templates: templateIds }),
-        templateFolder: folder,
-      };
+      const rawTemplateIds = binding.templates ?? binding.template;
+      let existingTemplateIds: TemplateId[] = [];
+      if (rawTemplateIds !== undefined) {
+        const values = Array.isArray(rawTemplateIds) ? rawTemplateIds : [rawTemplateIds];
+        if (values.some(item => typeof item !== "string")) throw new Error(`MIGRATION_TAXONOMY_INVALID: folders.${folder}.template(s)`);
+        existingTemplateIds = values.map(item => {
+          try {
+            const id = validateTemplateId(item as string);
+            if (!candidates.has(id)) throw new Error();
+            return id;
+          } catch { throw new Error(`MIGRATION_UNRESOLVED_MAPPING: folders.${folder}`); }
+        });
+        for (const id of existingTemplateIds) targetFolders.set(id, normalizeTemplateFolderPath(typeof binding.templateFolder === "string" ? binding.templateFolder : folder));
+      }
+      const templateIds = concepts.length > 0 ? conceptTemplateIds : existingTemplateIds;
+      const { concept: _concept, template: _template, templates: _templates, ...rest } = binding;
+      (folders as Record<string, JsonValue>)[folder] = templateIds.length === 0
+        ? { ...rest }
+        : { ...rest, ...(templateIds.length === 1 ? { template: templateIds[0]! } : { templates: templateIds }), ...(typeof binding.templateFolder === "string" ? { templateFolder: binding.templateFolder } : {}) };
     }
   }
   const rawAxes = root.globalAxes ?? root.axes;
@@ -646,7 +664,17 @@ export async function buildMigrationManifest(vault: string, proposal: MigrationP
   // accepted through the template-first projection parser.
   const legacyContract = legacyProjectionContract(projectionState);
   const migratedBase: BaseContract = { ...input.base, fields: { ...legacyContract.fields, ...input.base.fields } };
-  const proposedPolicy = currentPolicy ?? policyFor(proposal, migratedBase);
+  const proposedPolicy = currentPolicy === undefined
+    ? policyFor(proposal, migratedBase)
+    : {
+      ...currentPolicy,
+      templates: {
+        ...currentPolicy.templates,
+        ...Object.fromEntries(proposal.bindings
+          .filter(binding => !(binding.templateId in currentPolicy.templates))
+          .map(binding => [binding.templateId, binding])),
+      },
+    };
   const proposedBindings = Object.values(proposedPolicy.templates).sort((a, b) => a.templateId.localeCompare(b.templateId));
   const candidateById = new Map(proposal.candidates.map(candidate => [candidate.templateId, candidate]));
   if (candidateById.size !== proposal.candidates.length) throw new Error("TEMPLATE_ID_DUPLICATE");


### PR DESCRIPTION
Fixes setup rejecting its own normalized taxonomy.json and permits a later-discovered template to be incrementally registered without removing existing policy bindings. Adds a regression test for normalized folder bindings, policy merge, apply, and idempotent rerun.\n\nVerified: npm run lint; npm run build; npm test (1435 tests).