### PR TITLE
fix(kernel): rank axis-narrowed search on continuous coverage score

### DIFF
--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -4,6 +4,8 @@ Domain logic changes belong here.
 
 ## [Unreleased]
 
+- **Axis-narrowed search now ranks with a continuous coverage score, using title, declared-axis, and term-specificity signals to resolve equal coverage instead of integer token-count ties and alphabetical paths.** Zero-score padding is refused, and `minScore` filters hits and facets identically. Scores are now fractional: a previously meaningful `minScore: 1` ("at least one token") effectively requires perfect coverage, so callers must re-tune thresholds.
+
 ## [0.12.2] - 2026-09-01
 
 - **Setup preserves generated taxonomy template bindings and incrementally registers newly discovered templates.** (#104)

--- a/src/kernel/engine/graph/node.test.ts
+++ b/src/kernel/engine/graph/node.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { filterNodesByAxis, filterNodesByQueryAxes, queryFacets } from "./node.js";
+import { filterNodesByAxis, filterNodesByQueryAxes, queryFacets, searchScore } from "./node.js";
 import type { EngineGraphNode } from "./node.js";
 
 const nodes: EngineGraphNode[] = [
@@ -28,5 +28,29 @@ describe("template graph node axes", () => {
 
   it("fails loudly for an unknown public axis", () => {
     expect(() => filterNodesByQueryAxes(nodes, { invalid: "value" } as never)).toThrow(/Unknown query axis/);
+  });
+
+  it("ranks greater query coverage above lower coverage regardless of path order", () => {
+    const higherCoverage: EngineGraphNode = { path: "notes/zulu.md", template: "note", folder: "notes", axes: {}, wikilinks: [], bodyPreview: "", searchTerms: new Set(["alpha", "beta"]) };
+    const lowerCoverage: EngineGraphNode = { path: "notes/alpha.md", template: "note", folder: "notes", axes: {}, wikilinks: [], bodyPreview: "", searchTerms: new Set(["alpha"]) };
+
+    expect(searchScore(higherCoverage, "alpha beta")).toBeGreaterThan(searchScore(lowerCoverage, "alpha beta"));
+  });
+
+  it("uses title coverage to break equal-coverage ties before path order", () => {
+    const titleMatch: EngineGraphNode = { path: "notes/alpha.md", template: "note", folder: "notes", axes: {}, wikilinks: [], bodyPreview: "", searchTerms: new Set(["alpha"]) };
+    const pathFirst: EngineGraphNode = { path: "notes/aaa.md", template: "note", folder: "notes", axes: {}, wikilinks: [], bodyPreview: "", searchTerms: new Set(["alpha"]) };
+
+    const ranked = [pathFirst, titleMatch].sort((left, right) =>
+      searchScore(right, "alpha") - searchScore(left, "alpha") || left.path.localeCompare(right.path),
+    );
+
+    expect(ranked.map(node => node.path)).toEqual(["notes/alpha.md", "notes/aaa.md"]);
+  });
+
+  it("scores nodes with no matching query terms as zero", () => {
+    const node: EngineGraphNode = { path: "notes/alpha.md", template: "note", folder: "notes", axes: {}, wikilinks: [], bodyPreview: "", searchTerms: new Set(["alpha"]) };
+
+    expect(searchScore(node, "beta")).toBe(0);
   });
 });

--- a/src/kernel/engine/graph/node.ts
+++ b/src/kernel/engine/graph/node.ts
@@ -188,7 +188,15 @@ export function filterNodesByAxis(nodes: readonly EngineGraphNode[], filters: No
 
 export function searchScore(node: EngineGraphNode, query: string): number {
   const terms = new Set(tokenize(query));
-  let score = 0;
-  for (const term of terms) if (node.searchTerms.has(term)) score++;
-  return score;
+  if (terms.size === 0) return 0;
+  const matchedTerms = new Set([...terms].filter(term => node.searchTerms.has(term)));
+  if (matchedTerms.size === 0) return 0;
+  const titleTerms = new Set(tokenize(node.path.replace(/^.*\//u, "").replace(/\.md$/u, "")));
+  const axisTerms = new Set(Object.values(node.axes).flatMap(values => values.flatMap(value => tokenize(String(value)))));
+  const coverage = matchedTerms.size / terms.size;
+  const titleCoverage = [...matchedTerms].filter(term => titleTerms.has(term)).length / terms.size;
+  const axisCoverage = [...matchedTerms].filter(term => axisTerms.has(term)).length / terms.size;
+  const specificity = Math.min(1, matchedTerms.size / node.searchTerms.size);
+  // Scale secondary signals by query size so one additional matched term always outranks them.
+  return coverage + (titleCoverage * 0.1 + axisCoverage * 0.05 + specificity * 0.01) / terms.size;
 }

--- a/src/kernel/engine/mcp/facade.test.ts
+++ b/src/kernel/engine/mcp/facade.test.ts
@@ -648,6 +648,27 @@ folders:
     ]);
   });
 
+  it("applies lexical score thresholds consistently to axis hits and facets", async () => {
+    const v = freshVault();
+    writeFileSync(path.join(v, "notes", "matching.md"), "---\ntemplate: project\nstatus: active\n---\n# Needle\nneedle\n");
+    writeFileSync(path.join(v, "notes", "nonmatching.md"), "---\ntemplate: project\nstatus: archived\n---\n# Other\nunrelated text\n");
+    const adapter = new McpEngineAdapter(makeDeps(), v, undefined, undefined, false, false);
+
+    const result = await adapter.semanticQuery({
+      query: "needle",
+      axes: { folder: "notes" },
+      minScore: 0,
+      limit: 10,
+    });
+
+    expect(result).toMatchObject({ available: true, totalCount: 1 });
+    if (!result.available) return;
+    expect(result.hits.map((hit) => hit.path)).toEqual(["notes/matching.md"]);
+    expect(result.facets).toEqual(expect.not.arrayContaining([
+      expect.objectContaining({ axis: "field", key: "status", value: "archived" }),
+    ]));
+  });
+
   it("does not report lexical or vector evidence for an axis-only query", async () => {
     const v = freshVault();
     const adapter = new McpEngineAdapter(makeDeps(), v, undefined, undefined, false, false);

--- a/src/kernel/engine/mcp/facade.ts
+++ b/src/kernel/engine/mcp/facade.ts
@@ -492,24 +492,21 @@ export class McpEngineAdapter {
       : axisFiltered.filter((node) => node.path === collection || node.path.startsWith(`${collection}/`));
     const query = subQueries.find((subQuery) => subQuery.type === "lex")?.query
       ?? (subQueries.length === 0 ? opts.query ?? "" : "");
-    const scored = filtered
-      .map((node) => {
-        const score = searchScore(node, query);
-        return {
-          docPath: node.path,
-          score,
-          ...(query.trim().length > 0 ? { perTypeScores: { lex: score } } : {}),
-        };
-      })
-      // An axis constraint narrows the corpus; it is not lexical evidence.
-      // Once a lexical query is supplied, do not return axis-only zero-score
-      // documents as query hits.
-      .filter((result) => query.trim().length === 0 || result.score > 0)
+    const hasLexicalQuery = query.trim().length > 0;
+    const scoredNodes = filtered.map((node) => ({ node, score: searchScore(node, query) }));
+    // An axis constraint narrows the corpus; it is not lexical evidence.
+    // Apply the lexical threshold once so hits and facets represent the same nodes.
+    const qualifyingNodes = scoredNodes.filter(({ score }) =>
+      (!hasLexicalQuery || score > 0) && (opts.minScore === undefined || score >= opts.minScore),
+    );
+    const scored = qualifyingNodes
+      .map(({ node, score }) => ({
+        docPath: node.path,
+        score,
+        ...(hasLexicalQuery ? { perTypeScores: { lex: score } } : {}),
+      }))
       .sort((left, right) => right.score - left.score || left.docPath.localeCompare(right.docPath));
-    const facetNodes = opts.minScore === undefined
-      ? filtered
-      : filtered.filter((node) => searchScore(node, query) >= opts.minScore!);
-    const facets: McpSemanticFacet[] = queryFacets(facetNodes).map((facet) => ({
+    const facets: McpSemanticFacet[] = queryFacets(qualifyingNodes.map(({ node }) => node)).map((facet) => ({
       ...facet,
       intent: facetIntent(facet, opts.intent),
     }));


### PR DESCRIPTION
Closes #94

## What changed
The model-free axis/template/field-narrowed path scored notes with an integer count of matched query tokens (`searchScore`). That produced large tie groups, and the only tiebreak was `docPath.localeCompare` — alphabetical path order, which is not a relevance signal, so the best note did not stably rank first (#30 P1a).

`searchScore` now returns a continuous score:

- `coverage` = matched distinct query terms / total query terms (primary, weight 1.0)
- title coverage (basename stem), axis-value coverage, and term specificity as secondary signals, all divided by the query term count so that **one additional matched term always outranks every secondary signal combined**. `docPath` remains only as the final deterministic key.

Threshold policy (#30 P1b) is applied once in `queryNodeAxes`: `score > 0` is mandatory when a lexical query is supplied, and an explicit `minScore` now filters hits **and** facets from the same qualifying set. Previously facets recomputed the score separately, so a hit and its facet could disagree about the same node.

## Ranking-default gate
The shipped RRF + provenance-boost default (`boost-additive`) is untouched, so release principle 7 needs no new measurement manifest. No file under `docs/measurements/` or `docs/preregistration/` changed.

## Caller-visible consequence
Scores are fractional now. A previously meaningful `minScore: 1` ("at least one token") effectively demands perfect coverage — documented in `CHANGELOG-kernel.md`.

## Verification
- `tsc --noEmit` clean
- Full `vitest run`: 116 files passed, 1428 tests passed, 1 skipped
- New cases assert higher coverage always outranks lower coverage regardless of path order, equal-coverage ordering falls to the secondary signal rather than the alphabet, and a zero-match node scores exactly 0