### PR TITLE
feat(cli): report install asset and hook executability in doctor

### DIFF
--- a/CHANGELOG-cli.md
+++ b/CHANGELOG-cli.md
@@ -4,6 +4,8 @@ Changes to the `oms` command surface belong here.
 
 ## [Unreleased]
 
+- **`oms doctor` now reports structured and text install-asset health, naming dangling Claude hook symlinks with the reinstall command instead of allowing a silent command-not-found failure at tool time.**
+
 ## [0.12.2] - 2026-09-01
 
 ## [0.12.1] - 2026-09-01

--- a/CHANGELOG-kernel.md
+++ b/CHANGELOG-kernel.md
@@ -5,6 +5,7 @@ Domain logic changes belong here.
 ## [Unreleased]
 
 - **Axis-narrowed search now ranks with a continuous coverage score, using title, declared-axis, and term-specificity signals to resolve equal coverage instead of integer token-count ties and alphabetical paths.** Zero-score padding is refused, and `minScore` filters hits and facets identically. Scores are now fractional: a previously meaningful `minScore: 1` ("at least one token") effectively requires perfect coverage, so callers must re-tune thresholds.
+- **Install asset health inspection now classifies missing, non-executable, and dangling hook symlinks explicitly, including Hermes skill-tree provenance drift, so failed hook commands are no longer silent.**
 
 ## [0.12.2] - 2026-09-01
 

--- a/src/cli/doctor-lint.test.ts
+++ b/src/cli/doctor-lint.test.ts
@@ -3,7 +3,17 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { inspectInstalledAssets } from "../kernel/install/asset-health.js";
 import { computeTreeDigest } from "../kernel/install/provenance.js";
+
+vi.mock("../kernel/install/asset-health.js", () => ({
+  inspectInstalledAssets: vi.fn(async () => ({
+    status: "ok",
+    assets: [
+      { id: "hook:oms-guard", kind: "hook", declaredPath: "/bin/oms-guard", realPath: "/bin/oms-guard", state: "ok", remediation: "" },
+    ],
+  })),
+}));
 
 vi.mock("../kernel/templates/index.js", () => ({
   diagnoseTemplates: vi.fn(async () => ({
@@ -49,7 +59,11 @@ describe("doctor Hermes provenance", () => {
 
       const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
       expect(await runDoctor({ vault: "/vault", json: true })).toBe(0);
-      const json = JSON.parse(String(log.mock.calls[0]?.[0])) as { hermesProvenance: unknown };
+      const json = JSON.parse(String(log.mock.calls[0]?.[0])) as { hermesProvenance: unknown; installAssets: unknown };
+      expect(json.installAssets).toEqual({
+        status: "ok",
+        assets: [{ id: "hook:oms-guard", kind: "hook", declaredPath: "/bin/oms-guard", realPath: "/bin/oms-guard", state: "ok", remediation: "" }],
+      });
       expect(json.hermesProvenance).toEqual(
         state === "not-installed"
           ? { state, packageVersion, recordedVersion: null, digestMatch: null }
@@ -66,5 +80,24 @@ describe("doctor Hermes provenance", () => {
       if (originalOverride === undefined) delete process.env.OMS_HERMES_HOME;
       else process.env.OMS_HERMES_HOME = originalOverride;
     }
+  });
+
+  it("includes degraded install assets in text doctor output", async () => {
+    vi.mocked(inspectInstalledAssets).mockResolvedValueOnce({
+      status: "degraded",
+      assets: [{
+        id: "binary:oms-guard",
+        kind: "binary",
+        declaredPath: "/bin/oms-guard",
+        realPath: null,
+        state: "dangling-symlink",
+        remediation: "oms install --host claude",
+      }],
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(await runDoctor({ vault: "/vault" })).toBe(0);
+    expect(log.mock.calls.map(call => call[0])).toContain("Install assets: degraded (1 of 1 unusable).");
+    expect(log.mock.calls.map(call => call[0])).toContain("  [DANGLING_SYMLINK] /bin/oms-guard — oms install --host claude");
   });
 });

--- a/src/cli/doctor-lint.ts
+++ b/src/cli/doctor-lint.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { detectLinkIssues } from "../kernel/conventions/lint.js";
 import { formatLintReport } from "../kernel/conventions/report.js";
+import { inspectInstalledAssets } from "../kernel/install/asset-health.js";
 import { hostHome } from "../kernel/install/common.js";
 import { computeTreeDigest, parseProvenance } from "../kernel/install/provenance.js";
 import { diagnoseTemplates } from "../kernel/templates/index.js";
@@ -39,6 +40,13 @@ function formatHermesProvenanceStatus(status: HermesProvenanceStatus): string {
   return `Hermes provenance: ${status.state} (package ${status.packageVersion ?? "unknown"}, recorded ${status.recordedVersion ?? "none"}).`;
 }
 
+function formatInstallAssets(status: Awaited<ReturnType<typeof inspectInstalledAssets>>): string {
+  const unusable = status.assets.filter(asset => asset.state !== "ok").length;
+  return unusable === 0
+    ? `Install assets: ok (${status.assets.length} checked).`
+    : `Install assets: degraded (${unusable} of ${status.assets.length} unusable).`;
+}
+
 export async function runDoctor(opts: {
   vault: string;
   verbose?: boolean;
@@ -58,18 +66,20 @@ export async function runDoctor(opts: {
     }
     const diagnosis = await diagnoseTemplates({ vault: opts.vault, source: "explicit", maxPerTemplate: opts.maxPerTemplate });
     const hermesProvenance = await hermesProvenanceStatus();
+    const installAssets = await inspectInstalledAssets();
     if (opts.json) {
-      console.log(JSON.stringify({ vault: opts.vault, ...diagnosis, hermesProvenance }, null, 2));
+      console.log(JSON.stringify({ vault: opts.vault, ...diagnosis, hermesProvenance, installAssets }, null, 2));
       return 0;
     }
     console.log(`\nOh My Second Brain doctor: ${diagnosis.status}.`);
     console.log(`Migration marker: ${diagnosis.migrationMarker}.`);
     console.log(`Managed template sources excluded: ${diagnosis.managedSourceExclusions.length}.`);
     console.log(formatHermesProvenanceStatus(hermesProvenance));
+    console.log(formatInstallAssets(installAssets));
     if (diagnosis.unresolvedLegacyNotes.length > 0) {
       console.log(`Unresolved legacy notes: ${diagnosis.unresolvedLegacyNotes.length}.`);
     }
-    for (const item of diagnosis.diagnostics) {
+    for (const item of [...diagnosis.diagnostics, ...installAssets.assets.filter(asset => asset.state !== "ok").map(asset => ({ code: asset.state.toUpperCase().replace(/-/g, "_"), path: asset.declaredPath, remediation: asset.remediation }))]) {
       console.log(`  [${item.code}]${item.path === undefined ? "" : ` ${item.path}`} — ${item.remediation}`);
     }
     console.log("");

--- a/src/kernel/install/asset-health.test.ts
+++ b/src/kernel/install/asset-health.test.ts
@@ -1,0 +1,107 @@
+import { chmod, mkdir, mkdtemp, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { inspectInstalledAssets } from "./asset-health.js";
+
+const roots: string[] = [];
+
+async function inspect(declaredPath: string) {
+  return inspectInstalledAssets({
+    assets: [{ id: "test", kind: "hook", declaredPath }],
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+
+});
+
+describe("inspectInstalledAssets", () => {
+  it("reports executable assets as ok", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-asset-health-"));
+    roots.push(root);
+    const guard = path.join(root, "oms-guard");
+    const postGuard = path.join(root, "oms-post-guard");
+    await Promise.all([guard, postGuard].map(asset => writeFile(asset, "#!/usr/bin/env node\n")));
+    await Promise.all([guard, postGuard].map(asset => chmod(asset, 0o755)));
+
+    await expect(inspectInstalledAssets({
+      assets: [
+        { id: "guard", kind: "hook", declaredPath: guard },
+        { id: "post-guard", kind: "binary", declaredPath: postGuard },
+      ],
+    })).resolves.toMatchObject({
+      status: "ok",
+      assets: [
+        { state: "ok", realPath: expect.any(String) },
+        { state: "ok", realPath: expect.any(String) },
+      ],
+    });
+  });
+
+  it("names a dangling symlink instead of treating it as absent", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-asset-health-"));
+    roots.push(root);
+    const target = path.join(root, "deleted-target");
+    const asset = path.join(root, "oms-guard");
+    await writeFile(target, "#!/usr/bin/env node\n");
+    await symlink(target, asset);
+    await unlink(target);
+
+    const result = await inspect(asset);
+    expect(result.assets[0]).toMatchObject({ state: "dangling-symlink", realPath: null });
+    expect(result.assets[0]?.remediation.length).toBeGreaterThan(0);
+  });
+
+  it("reports a present non-executable file", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-asset-health-"));
+    roots.push(root);
+    const asset = path.join(root, "oms-guard");
+    await writeFile(asset, "#!/usr/bin/env node\n");
+    await chmod(asset, 0o644);
+
+    const result = await inspect(asset);
+    expect(result.assets[0]).toMatchObject({ state: "not-executable", realPath: expect.any(String) });
+    expect(result.assets[0]?.remediation.length).toBeGreaterThan(0);
+  });
+
+  it("reports an absent declared path", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-asset-health-"));
+    roots.push(root);
+
+    const result = await inspect(path.join(root, "missing"));
+    expect(result.assets[0]).toMatchObject({ state: "missing", realPath: null });
+    expect(result.assets[0]?.remediation.length).toBeGreaterThan(0);
+  });
+
+  it("reports a non-file hook path", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-asset-health-"));
+    roots.push(root);
+
+    const result = await inspect(root);
+    expect(result.assets[0]).toMatchObject({ state: "not-a-file", realPath: expect.any(String) });
+    expect(result.assets[0]?.remediation.length).toBeGreaterThan(0);
+  });
+
+  it("reports a skill tree whose provenance does not match", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "oms-asset-health-"));
+    roots.push(root);
+    const skillTree = path.join(root, "skills");
+    await writeFile(path.join(root, "provenance.json"), JSON.stringify({
+      schemaVersion: 1,
+      source: "npm",
+      version: "0.12.2",
+      skillTreeDigest: "wrong",
+      installedAt: "2026-01-01T00:00:00.000Z",
+    }));
+    await mkdir(skillTree);
+
+    const result = await inspectInstalledAssets({
+      assets: [{ id: "skills", kind: "skill-tree", declaredPath: skillTree, provenancePath: path.join(root, "provenance.json") }],
+    });
+    expect(result.assets[0]).toMatchObject({ state: "provenance-mismatch", realPath: expect.any(String) });
+    expect(result.assets[0]?.remediation.length).toBeGreaterThan(0);
+  });
+
+});

--- a/src/kernel/install/asset-health.ts
+++ b/src/kernel/install/asset-health.ts
@@ -1,0 +1,135 @@
+import { lstat, readFile, realpath, stat } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { harnessSurfaceRegistry } from "../harness/surface-registry.js";
+import { hostHome } from "./common.js";
+import { computeTreeDigest, parseProvenance } from "./provenance.js";
+
+export type InstalledAssetKind = "hook" | "binary" | "skill-tree";
+export type InstalledAssetState = "ok" | "missing" | "dangling-symlink" | "not-executable" | "not-a-file" | "provenance-mismatch";
+
+export interface InstalledAssetDeclaration {
+  readonly id: string;
+  readonly kind: InstalledAssetKind;
+  readonly declaredPath: string;
+  readonly provenancePath?: string;
+  readonly remediation?: string;
+}
+
+export interface InstalledAssetHealth {
+  readonly id: string;
+  readonly kind: InstalledAssetKind;
+  readonly declaredPath: string;
+  readonly realPath: string | null;
+  readonly state: InstalledAssetState;
+  readonly remediation: string;
+}
+
+export interface InstalledAssetInspectionOptions {
+  readonly assets?: readonly InstalledAssetDeclaration[];
+  readonly hostHomes?: Readonly<Partial<Record<"claude" | "codex" | "hermes", string>>>;
+  readonly registry?: typeof harnessSurfaceRegistry;
+  readonly packageRoot?: string;
+  readonly binaryDirectories?: readonly string[];
+}
+
+export interface InstalledAssetInspection {
+  readonly status: "ok" | "degraded";
+  readonly assets: readonly InstalledAssetHealth[];
+}
+
+function packageRoot(): string {
+  return path.dirname(fileURLToPath(new URL("../../../package.json", import.meta.url)));
+}
+
+function remediation(asset: InstalledAssetDeclaration): string {
+  if (asset.remediation !== undefined) return asset.remediation;
+  return asset.kind === "skill-tree" ? "oms install --host hermes" : "oms install --host claude";
+}
+
+async function binaryPath(binaryDirectories: readonly string[], binary: string, fallback: string): Promise<string> {
+  for (const directory of binaryDirectories) {
+    const candidate = path.join(directory, binary);
+    try {
+      await lstat(candidate);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return path.join(binaryDirectories[0] ?? fallback, binary);
+}
+
+async function defaultAssets(options: InstalledAssetInspectionOptions): Promise<readonly InstalledAssetDeclaration[]> {
+  const registry = options.registry ?? harnessSurfaceRegistry;
+  const root = options.packageRoot ?? packageRoot();
+  const binaryDirectories = options.binaryDirectories ?? (process.env.PATH?.split(path.delimiter) ?? []);
+  const hermesHome = options.hostHomes?.hermes ?? hostHome(undefined, ".hermes", "OMS_HERMES_HOME");
+  const hooks = await Promise.all(registry.hooks.map(async hook => [
+    { id: `hook:${hook.bin}`, kind: "hook" as const, declaredPath: path.join(root, hook.path) },
+    { id: `binary:${hook.bin}`, kind: "binary" as const, declaredPath: await binaryPath(binaryDirectories, hook.bin, root) },
+  ]));
+  return [
+    ...hooks.flat(),
+    {
+      id: "skill-tree:hermes",
+      kind: "skill-tree",
+      declaredPath: path.join(hermesHome, "skills", "knowledge-management", "oms"),
+      provenancePath: path.join(hermesHome, "adapters", "oms", "oms-provenance.json"),
+    },
+  ];
+}
+
+function missingHealth(asset: InstalledAssetDeclaration, state: "missing" | "dangling-symlink"): InstalledAssetHealth {
+  return { id: asset.id, kind: asset.kind, declaredPath: asset.declaredPath, realPath: null, state, remediation: remediation(asset) };
+}
+
+async function inspectAsset(asset: InstalledAssetDeclaration): Promise<InstalledAssetHealth> {
+  let entry;
+  try {
+    entry = await lstat(asset.declaredPath);
+  } catch {
+    return missingHealth(asset, "missing");
+  }
+  let resolved: string;
+  try {
+    resolved = await realpath(asset.declaredPath);
+  } catch {
+    return missingHealth(asset, entry.isSymbolicLink() ? "dangling-symlink" : "missing");
+  }
+  let target;
+  try {
+    target = await stat(asset.declaredPath);
+  } catch {
+    return missingHealth(asset, entry.isSymbolicLink() ? "dangling-symlink" : "missing");
+  }
+  if (asset.kind === "skill-tree") {
+    if (!target.isDirectory()) {
+      return { id: asset.id, kind: asset.kind, declaredPath: asset.declaredPath, realPath: resolved, state: "not-a-file", remediation: remediation(asset) };
+    }
+    if (asset.provenancePath !== undefined) {
+      try {
+        const provenance = parseProvenance(await readFile(asset.provenancePath, "utf8"));
+        if (provenance === null || provenance.skillTreeDigest !== await computeTreeDigest(resolved)) {
+          return { id: asset.id, kind: asset.kind, declaredPath: asset.declaredPath, realPath: resolved, state: "provenance-mismatch", remediation: remediation(asset) };
+        }
+      } catch {
+        return { id: asset.id, kind: asset.kind, declaredPath: asset.declaredPath, realPath: resolved, state: "provenance-mismatch", remediation: remediation(asset) };
+      }
+    }
+    return { id: asset.id, kind: asset.kind, declaredPath: asset.declaredPath, realPath: resolved, state: "ok", remediation: "" };
+  }
+  if (!target.isFile()) {
+    return { id: asset.id, kind: asset.kind, declaredPath: asset.declaredPath, realPath: resolved, state: "not-a-file", remediation: remediation(asset) };
+  }
+  if ((target.mode & 0o111) === 0) {
+    return { id: asset.id, kind: asset.kind, declaredPath: asset.declaredPath, realPath: resolved, state: "not-executable", remediation: remediation(asset) };
+  }
+  return { id: asset.id, kind: asset.kind, declaredPath: asset.declaredPath, realPath: resolved, state: "ok", remediation: "" };
+}
+
+export async function inspectInstalledAssets(options: InstalledAssetInspectionOptions = {}): Promise<InstalledAssetInspection> {
+  const declarations = options.assets ?? await defaultAssets(options);
+  const assets = await Promise.all(declarations.map(inspectAsset));
+  return { status: assets.every(asset => asset.state === "ok") ? "ok" : "degraded", assets };
+}


### PR DESCRIPTION
Closes #95

## What changed
#48 measured a real failure: a stale install layout left dangling symlinks, so the Claude `PreToolUse`/`PostToolUse` guards (`oms-guard`, `oms-post-guard`) failed with command-not-found **silently**. Nothing in the product could observe it, so the ghost install could recur.

New kernel module `src/kernel/install/asset-health.ts` (`inspectInstalledAssets`) resolves every asset declared by `harnessSurfaceRegistry` — the packaged hook files, the hook binaries on `PATH`, and the Hermes skill tree — through `realpath` and classifies each one:

| state | meaning |
|---|---|
| `ok` | resolves, is the right kind, and carries the execute bit |
| `missing` | declared path does not exist |
| `dangling-symlink` | symlink exists, target does not — the #48 failure, no longer conflated with `missing` |
| `not-executable` | file present without `mode & 0o111` |
| `not-a-file` | wrong kind at the declared path |
| `provenance-mismatch` | skill tree digest disagrees with the recorded install provenance |

Every non-`ok` state carries an actionable remediation command. `oms doctor` surfaces the structured result under `installAssets` in JSON mode and prints a summary line plus one diagnostic line per unusable asset in text mode.

Host homes, the registry, the package root, and the binary directories are injected parameters, so the tests drive real temp directories instead of the developer's `~`.

Exit-code semantics are unchanged: degraded assets are reported, not fatal.

## Verification
- `tsc --noEmit` clean
- Full `vitest run`: 117 files passed, 1431 tests passed, 1 skipped
- New tests build real fixtures with `mkdtemp` for each state, including a symlink whose target is deleted and a file at mode `0o644`
- Run against this machine, the real inspection resolves `/opt/homebrew/bin/oms-post-guard` through to the global package's hook file and reports `ok` for all assets