### PR TITLE
fix(mcp): render the oms namespace once instead of oms_oms_*

### DIFF
--- a/CHANGELOG-mcp.md
+++ b/CHANGELOG-mcp.md
@@ -4,6 +4,10 @@ MCP server tools and resources belong here.
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP local tool names are now capability-only.** The `oms` server advertises `write`, `search`, `link`, `status`, and `doctor`, so qualifying hosts display `oms_write`, `oms_search`, `oms_link`, `oms_status`, and `oms_doctor` rather than `oms_oms_*`. Raw MCP callers must migrate `oms_write` → `write`, `oms_search` → `search`, `oms_link` → `link`, `oms_status` → `status`, and `oms_doctor` → `doctor`.
+
 ## [0.12.2] - 2026-09-01
 
 ## [0.12.1] - 2026-09-01

--- a/CHANGELOG-vendors.md
+++ b/CHANGELOG-vendors.md
@@ -4,6 +4,10 @@ Per-host adapter and installer changes belong here.
 
 ## [Unreleased]
 
+### Changed
+
+- **Supported host guidance now names the single-qualified OMS tools.** Hermes, Claude, and Codex users see `oms_write`, `oms_search`, `oms_link`, `oms_status`, and `oms_doctor`, never `oms_oms_*`; raw MCP integrations must replace local calls `oms_write`/`oms_search`/`oms_link`/`oms_status`/`oms_doctor` with `write`/`search`/`link`/`status`/`doctor`.
+
 ## [0.12.2] - 2026-09-01
 
 ## [0.12.1] - 2026-09-01

--- a/README.ko.md
+++ b/README.ko.md
@@ -73,7 +73,7 @@ Setup에서는 로컬 검증 acquisition 정책 하나를 선택한다:
 
 `oms mcp`는 정확히 다섯 개의 공개 도구를 노출한다:
 
-`oms_write` · `oms_search` · `oms_link` · `oms_status` · `oms_doctor`
+`write` · `search` · `link` · `status` · `doctor`
 
 일곱 스킬(`write`, `search`, `link`, `distill`, `status`, `doctor`, `template`)은 워크플로 안내이며 MCP 도구와 같은 집합이 아니다. 세부 기능은 다섯 도구의 `op` 값으로 제공한다.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ During setup, choose one local verified acquisition policy:
 
 `oms mcp` exposes exactly five public tools:
 
-`oms_write` · `oms_search` · `oms_link` · `oms_status` · `oms_doctor`
+`write` · `search` · `link` · `status` · `doctor`
 
 The seven skills (`write`, `search`, `link`, `distill`, `status`, `doctor`, `template`) are workflow guidance, not a tool-equality list. Detail capabilities remain `op` values under the five tools.
 

--- a/assets/skills/doctor/SKILL.md
+++ b/assets/skills/doctor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: doctor
 description: Diagnose template authority and index problems, then run explicit repairs.
-mcp_tool: oms_doctor
+mcp_tool: doctor
 mcp_args:
   op: "validate"
 ---

--- a/assets/skills/link/SKILL.md
+++ b/assets/skills/link/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: link
 description: Suggest or apply safe wikilinks between vault notes.
-mcp_tool: oms_link
+mcp_tool: link
 mcp_args:
   op: "suggest"
   notePath: "$1"

--- a/assets/skills/search/SKILL.md
+++ b/assets/skills/search/SKILL.md
@@ -2,7 +2,7 @@
 name: search
 description: Retrieve vault knowledge through resolved template axes.
 aliases: [retrieve]
-mcp_tool: oms_search
+mcp_tool: search
 mcp_args:
   op: "query"
   query: "$1"
@@ -19,9 +19,9 @@ Retrieve vault knowledge without changing the vault.
 ```
 
 Plain `query` is projection-independent lexical retrieval and remains available when no embedding provider is configured. Template-managed source files are never returned as notes.
-Expansion is explicit only for `oms_search` `op: "query"` through the closed strategy object and never changes a plain lexical query.
+Expansion is explicit only for `search` `op: "query"` through the closed strategy object and never changes a plain lexical query.
 
-Use `oms_search { op: "templates" }` to discover stable template IDs and declared axes. Typed queries use the same derived projection as writes:
+Use `search { op: "templates" }` to discover stable template IDs and declared axes. Typed queries use the same derived projection as writes:
 
 - `axes.template` selects one stable template identity.
 - `axes.field.<key>` filters a field declared by that template; values may be scalars, scalar lists, or supported predicate objects.

--- a/assets/skills/status/SKILL.md
+++ b/assets/skills/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: status
 description: Report read-only template, graph, and semantic-index health.
-mcp_tool: oms_status
+mcp_tool: status
 mcp_args: {}
 ---
 

--- a/assets/skills/template/SKILL.md
+++ b/assets/skills/template/SKILL.md
@@ -19,9 +19,9 @@ Use an existing stable `templateId` when updating or moving a template. A path o
 
 ## Workflow
 
-1. Read `oms_search { op: "templates" }` and the user's requested shape. Do not guess existing IDs or fields.
+1. Read `search { op: "templates" }` and the user's requested shape. Do not guess existing IDs or fields.
 2. Draft the exact Markdown and policy/taxonomy intent. Preserve unknown frontmatter, policy extensions, body bytes, and Obsidian property types.
-3. Call `oms_write { op: "template", ..., dryRun: true }` for create, update, reclassify, or relocate-folder.
+3. Call `write { op: "template", ..., dryRun: true }` for create, update, reclassify, or relocate-folder.
 4. Show the proposal, paths, diagnostics, and `approvalDigest` to the user.
 5. Apply only after the caller explicitly approves that exact digest. Submit the same request with `dryRun: false` and `approvedDigest`.
 6. Report the server-verified receipt and postconditions.

--- a/assets/skills/write/SKILL.md
+++ b/assets/skills/write/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write
 description: Write vault notes and manage Obsidian templates through the guarded template contract.
-mcp_tool: oms_write
+mcp_tool: write
 mcp_args:
   op: "note"
   mode: "create"
@@ -11,11 +11,11 @@ mcp_args:
 
 # write
 
-Use MCP `oms_write` for every vault-note or managed-template mutation. Do not use host Write/Edit for vault Markdown.
+Use MCP `write` for every vault-note or managed-template mutation. Do not use host Write/Edit for vault Markdown.
 
 ## Notes
 
-Translate the user's natural-language note kind into a stable ID returned by `oms_search { op: "templates" }`; never guess an ID.
+Translate the user's natural-language note kind into a stable ID returned by `search { op: "templates" }`; never guess an ID.
 
 ```text
 /write <template-id> [body]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,16 @@ Search is lexical and works without `.oms/types.json`. It supports narrowing by 
 
 The CLI works independently of host integrations. Installable assets are under [`assets/`](../assets/): seven public skills (`write`, `search`, `link`, `distill`, `status`, `doctor`, and tool-less `template`) and host guidance. `assets/claude/`, `assets/codex/`, and `assets/hermes/` contain host-specific files.
 
-MCP is a separate API surface. `oms mcp` serves exactly five public tools: `oms_write`, `oms_search`, `oms_link`, `oms_status`, and `oms_doctor`. Skills are host-facing workflows; MCP tools are callable operations. Neither replaces the independent CLI.
+MCP is a separate API surface. `oms mcp` serves exactly five public capabilities: write, search, link, status, and doctor. Skills are host-facing workflows; MCP tools are callable operations. Neither replaces the independent CLI.
+
+### MCP namespace boundary
+
+The MCP server id is `oms`, while its local tool names are capability-only:
+`write`, `search`, `link`, `status`, and `doctor`. Qualifying supported hosts
+therefore display `oms_write`, `oms_search`, `oms_link`, `oms_status`, and
+`oms_doctor` exactly once; no supported host may render `oms_oms_*`. Raw MCP
+clients call the local names, so callers using the former `oms_write`,
+`oms_search`, `oms_link`, `oms_status`, or `oms_doctor` names must migrate to
+`write`, `search`, `link`, `status`, or `doctor`.
 
 See [conventions](./conventions.md) for vault data and [verified targets](./verified-target.md) for target resolution and mutation admission.

--- a/docs/harness-architecture.md
+++ b/docs/harness-architecture.md
@@ -50,7 +50,11 @@ Plain lexical retrieval is projection-independent and read-only. Typed axes fail
 The public sets are intentionally different:
 
 - seven skills: write, search, link, distill, status, doctor, template;
-- five MCP tools: `oms_write`, `oms_search`, `oms_link`, `oms_status`, `oms_doctor`;
+- five capability-only local MCP tools: `write`, `search`, `link`, `status`, `doctor`;
 - an independent CLI command allowlist.
 
 Detail capabilities remain `op` values under the five tools. Host adapters differ natively, but all register the same MCP runtime and stamp the selected vault into their managed `oms mcp --vault` entry. That stamp never changes runtime resolution precedence: explicit target, local vault controls, bridge, `OMS_VAULT`, then read-only cwd fallback.
+
+The runtime server id is `oms`; qualifying hosts render those local names as
+`oms_write`, `oms_search`, `oms_link`, `oms_status`, and `oms_doctor`, never
+`oms_oms_*`. Raw MCP callers use the local names.

--- a/scripts/release-artifact-smoke.mjs
+++ b/scripts/release-artifact-smoke.mjs
@@ -287,7 +287,7 @@ async function mcpSmoke(packageRoot, vault, smokeHome) {
     // without a model, so retrieve_context's semantic leg simply degrades to the
     // graph leg here; with a model present the engine handles the sync just as well.
     await client.callTool({
-      name: "oms_search",
+      name: "search",
       arguments: {
         op: "context",
         property: "tags",
@@ -322,18 +322,18 @@ async function mcpSmoke(packageRoot, vault, smokeHome) {
     // surface cutover; they are routed by `op`, not deleted. Calling them
     // through the public surface is what proves the demotion kept behaviour.
     const syncCall = {
-      name: "oms_doctor",
+      name: "doctor",
       arguments: { op: "sync-embeddings", collection: "vault" },
     };
     const queryCall = {
-      name: "oms_search",
+      name: "search",
       arguments: { op: "query", query: "agent retr", collection: "vault", limit: 1 },
     };
     // R4's public envelope keeps axis narrowing under the renamed `query` op;
     // this is deliberately a model-free lexical call so every release runner
     // exercises axes, paging, candidates, rerank selection, and receipt DTOs.
     const axisQuery = await client.callTool({
-      name: "oms_search",
+      name: "search",
       arguments: {
         op: "query",
         query: "agent retrieval",
@@ -403,7 +403,7 @@ async function mcpSmoke(packageRoot, vault, smokeHome) {
 
     // The public surface must be exactly the five tools.
     const publicTools = result.tools.map((tool) => tool.name).sort();
-    const expectedTools = ["oms_doctor", "oms_link", "oms_search", "oms_status", "oms_write"];
+    const expectedTools = ["doctor", "link", "search", "status", "write"];
     if (JSON.stringify(publicTools) !== JSON.stringify(expectedTools)) {
       fail(
         `MCP public tool surface drifted: expected ${expectedTools.join(", ")}, got ${publicTools.join(", ")}`,

--- a/src/kernel/harness/surface-registry.ts
+++ b/src/kernel/harness/surface-registry.ts
@@ -92,11 +92,11 @@ export const harnessSurfaceRegistry: HarnessSurfaceRegistry = {
     { name: "serve", owner: "semantic-engine", stability: "experimental" },
   ],
   mcpTools: [
-    { name: "oms_write", owner: "capture", posture: "write", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
-    { name: "oms_search", owner: "retrieval", posture: "read", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
-    { name: "oms_link", owner: "capture", posture: "write", destructive: true, idempotent: false, openWorld: false, stability: "stable" },
-    { name: "oms_status", owner: "mcp", posture: "read", destructive: false, idempotent: true, openWorld: false, stability: "stable" },
-    { name: "oms_doctor", owner: "mcp", posture: "write", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
+    { name: "write", owner: "capture", posture: "write", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
+    { name: "search", owner: "retrieval", posture: "read", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
+    { name: "link", owner: "capture", posture: "write", destructive: true, idempotent: false, openWorld: false, stability: "stable" },
+    { name: "status", owner: "mcp", posture: "read", destructive: false, idempotent: true, openWorld: false, stability: "stable" },
+    { name: "doctor", owner: "mcp", posture: "write", destructive: false, idempotent: false, openWorld: false, stability: "stable" },
   ],
   hosts: [
     {

--- a/src/mcp/demotion-reachability.test.ts
+++ b/src/mcp/demotion-reachability.test.ts
@@ -84,29 +84,29 @@ describe("MCP detail-tool demotion", () => {
       };
       const demoted = ["oms_retrieve_by_axis", "oms_retrieve_context", "oms_lazy_load_note", "oms_semantic_query", "oms_semantic_collections", "oms_semantic_contexts", "oms_semantic_status", "oms_get_document", "oms_multi_get_documents", "oms_link_suggest", "oms_link_apply", "oms_graph_status", "oms_vault_audit", "oms_graph_build", "oms_semantic_cleanup", "oms_sync_embeddings", "query", "get", "multi_get", "status"];
       expect(names).not.toEqual(expect.arrayContaining(demoted));
-      expect(payload(await call("oms_status", {})).derivedState).toBeDefined();
-      expect(payload(await call("oms_doctor", { op: "audit", folder: "references" })).scannedNotes).toBeTypeOf("number");
-      expect(payload(await call("oms_doctor", { op: "validate" })).status).toBeTypeOf("string");
-      expect(payload(await call("oms_doctor", { op: "build-graph" })).notes).toBeTypeOf("number");
-      expect(payload(await call("oms_search", { op: "templates" })).templates).toBeInstanceOf(Array);
-      expect(payload(await call("oms_doctor", { op: "regenerate-types", dryRun: true })).status).toMatch(/planned|unchanged/);
-      expect(payload(await call("oms_search", { op: "context", folder: "references", useCache: false })).hits).toBeInstanceOf(Array);
-      expect(payload(await call("oms_search", { op: "lazy-load", notePath: "references/clean-architecture.md" })).body).toBeTypeOf("string");
-      expect(payload(await call("oms_search", { op: "get-document", target: "references/clean-architecture.md" })).documents).toBeInstanceOf(Array);
-      expect(payload(await call("oms_search", { op: "multi-get-documents", targets: ["references/clean-architecture.md"] })).documents).toBeInstanceOf(Array);
-      const suggested = payload(await call("oms_link", { op: "suggest", notePath: "references/clean-architecture.md" }));
+      expect(payload(await call("status", {})).derivedState).toBeDefined();
+      expect(payload(await call("doctor", { op: "audit", folder: "references" })).scannedNotes).toBeTypeOf("number");
+      expect(payload(await call("doctor", { op: "validate" })).status).toBeTypeOf("string");
+      expect(payload(await call("doctor", { op: "build-graph" })).notes).toBeTypeOf("number");
+      expect(payload(await call("search", { op: "templates" })).templates).toBeInstanceOf(Array);
+      expect(payload(await call("doctor", { op: "regenerate-types", dryRun: true })).status).toMatch(/planned|unchanged/);
+      expect(payload(await call("search", { op: "context", folder: "references", useCache: false })).hits).toBeInstanceOf(Array);
+      expect(payload(await call("search", { op: "lazy-load", notePath: "references/clean-architecture.md" })).body).toBeTypeOf("string");
+      expect(payload(await call("search", { op: "get-document", target: "references/clean-architecture.md" })).documents).toBeInstanceOf(Array);
+      expect(payload(await call("search", { op: "multi-get-documents", targets: ["references/clean-architecture.md"] })).documents).toBeInstanceOf(Array);
+      const suggested = payload(await call("link", { op: "suggest", notePath: "references/clean-architecture.md" }));
       expect(suggested.baseContentHash).toBeTypeOf("string");
-      const apply = await call("oms_link", { op: "apply", notePath: "references/clean-architecture.md", baseContentHash: "0".repeat(64), candidateIds: [] });
+      const apply = await call("link", { op: "apply", notePath: "references/clean-architecture.md", baseContentHash: "0".repeat(64), candidateIds: [] });
       expect(apply.content[0]?.type).toBe("text");
       for (const op of ["query", "collections", "contexts", "status"]) {
-        const result = await call("oms_search", { op, ...(op === "query" ? { query: "architecture" } : {}) });
+        const result = await call("search", { op, ...(op === "query" ? { query: "architecture" } : {}) });
         expect(result.content[0]?.type).toBe("text");
         expect(result.content[0]?.type === "text" ? result.content[0].text : "").toMatch(
           /OMS_EMBEDDING_PROVIDER|available|collections|contexts/,
         );
       }
       for (const op of ["cleanup", "sync-embeddings"]) {
-        const result = await call("oms_doctor", { op });
+        const result = await call("doctor", { op });
         expect(result.content[0]?.type).toBe("text");
         expect(result.content[0]?.type === "text" ? result.content[0].text : "").toMatch(
           /OMS_EMBEDDING_PROVIDER|available/,

--- a/src/mcp/search-read-only.test.ts
+++ b/src/mcp/search-read-only.test.ts
@@ -1,10 +1,10 @@
 /**
- * `oms_search` must not write.
+ * `search` must not write.
  *
  * The tool is annotated `readOnlyHint: true`, which is a promise to every MCP
  * host that calling it is safe on an untouched vault. This suite verifies the
  * promise the only way that actually proves it: by snapshotting the whole vault
- * tree, calling every advertised `oms_search` operation, and requiring the tree
+ * tree, calling every advertised `search` operation, and requiring the tree
  * to come back byte-identical.
  *
  * It deliberately does NOT enumerate the specific writes we know about
@@ -46,12 +46,12 @@ const repoRoot = path.resolve(__dirname, "../../");
 const distCli = path.join(repoRoot, "dist", "cli", "oms.js");
 
 /**
- * Every operation the `oms_search` schema advertises, with arguments valid for
+ * Every operation the `search` schema advertises, with arguments valid for
  * each, including the template identity listing. Derived from the live tool schema rather than hand-listed, so an
  * operation added later cannot quietly escape the read-only guarantee.
  */
 function advertisedSearchOperations(): { op: string; args: Record<string, unknown> }[] {
-  const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+  const search = omsMcpTools.find((tool) => tool.name === "search");
   const schema = search?.inputSchema as {
     readonly oneOf?: readonly {
       readonly properties?: Record<string, { readonly const?: string }>;
@@ -165,7 +165,7 @@ async function makeTemplateVault(): Promise<string> {
  * `OMS_VAULT` makes the vault a verified write target. That is deliberate: it
  * means the search path is permitted to write and still must not. A cwd-inferred
  * target would have writes rejected by the admission layer anyway, so a clean
- * tree would prove nothing about `oms_search`'s own behaviour.
+ * tree would prove nothing about `search`'s own behaviour.
  */
 async function withClient<T>(vault: string, run: (client: Client) => Promise<T>): Promise<T> {
   const emptyHome = await mkdtemp(path.join(tmpdir(), "oms-readonly-home-"));
@@ -189,14 +189,14 @@ async function withClient<T>(vault: string, run: (client: Client) => Promise<T>)
 const vaults: string[] = [];
 const homes: string[] = [];
 
-describe("oms_search read-only guarantee", () => {
+describe("search read-only guarantee", () => {
   beforeAll(() => () =>
     Promise.all(
       [...vaults, ...homes].map((dir) => rm(dir, { recursive: true, force: true })),
     ));
 
   it("declares itself read-only", () => {
-    const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+    const search = omsMcpTools.find((tool) => tool.name === "search");
     expect(search?.annotations?.readOnlyHint).toBe(true);
   });
 
@@ -205,7 +205,7 @@ describe("oms_search read-only guarantee", () => {
     vaults.push(vault);
     const before = await snapshotTree(vault);
     const result = await withClient(vault, (client) =>
-      client.callTool({ name: "oms_search", arguments: { op: "templates" } }),
+      client.callTool({ name: "search", arguments: { op: "templates" } }),
     );
     const payload = textPayload(result);
     expect(payload["templates"]).toMatchObject([{ fields: { template: { intent: "Stable note identity." } } }]);
@@ -230,7 +230,7 @@ describe("oms_search read-only guarantee", () => {
    * test rather than quietly invalidate the annotation above.
    */
   it("advertises no parameter that would let a caller trigger a write", () => {
-    const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+    const search = omsMcpTools.find((tool) => tool.name === "search");
     const schema = JSON.stringify(search?.inputSchema ?? {});
 
     for (const knob of [
@@ -239,7 +239,7 @@ describe("oms_search read-only guarantee", () => {
       "embeddingSyncEmbed",
       "syncBeforeSearch",
     ]) {
-      expect(schema, `oms_search must not advertise ${knob}`).not.toContain(knob);
+      expect(schema, `search must not advertise ${knob}`).not.toContain(knob);
     }
 
     // Guard against a vacuous pass: the schema must still be the real one.
@@ -249,7 +249,7 @@ describe("oms_search read-only guarantee", () => {
     expect(schema).toContain("get-document");
 
     // The capability moved rather than vanished, so doctor must still offer it.
-    const doctor = omsMcpTools.find((tool) => tool.name === "oms_doctor");
+    const doctor = omsMcpTools.find((tool) => tool.name === "doctor");
     expect(JSON.stringify(doctor?.inputSchema ?? {})).toContain("sync-embeddings");
     expect(doctor?.annotations?.readOnlyHint).toBe(false);
   });
@@ -269,7 +269,7 @@ describe("oms_search read-only guarantee", () => {
     await withClient(vault, async (client) => {
       for (const { op, args } of operations) {
         try {
-          await client.callTool({ name: "oms_search", arguments: args });
+          await client.callTool({ name: "search", arguments: args });
         } catch (error) {
           // A missing index must degrade to a structured unavailable result,
           // not a transport-level throw.
@@ -302,7 +302,7 @@ describe("oms_search read-only guarantee", () => {
     const payload = await withClient(vault, async (client) =>
       textPayload(
         await client.callTool({
-          name: "oms_search",
+          name: "search",
           arguments: { op: "query", query: "retrieval", limit: 1 },
         }),
       ),
@@ -347,12 +347,12 @@ describe("oms_search read-only guarantee", () => {
     // and memoised its engine, not what it returned: the defect being guarded
     // is a read-only engine landing in a slot the repair then reuses.
     const served = await withClient(vault, (client) =>
-      client.callTool({ name: "oms_search", arguments: { op: "query", query: "alpha" } }),
+      client.callTool({ name: "search", arguments: { op: "query", query: "alpha" } }),
     );
     expect(textPayload(served)["available"]).toBe(true);
 
     const repaired = await withClient(vault, (client) =>
-      client.callTool({ name: "oms_doctor", arguments: { op: "sync-embeddings", embed: false } }),
+      client.callTool({ name: "doctor", arguments: { op: "sync-embeddings", embed: false } }),
     );
     // Surface the server's own message on failure. Parsing first would throw on
     // the error path, which reports a JSON syntax error instead of the reason
@@ -364,7 +364,7 @@ describe("oms_search read-only guarantee", () => {
     expect([...tree.keys()].some((rel) => rel.includes("engine-store.sqlite"))).toBe(true);
 
     const hits = await withClient(vault, (client) =>
-      client.callTool({ name: "oms_search", arguments: { op: "query", query: "alpha" } }),
+      client.callTool({ name: "search", arguments: { op: "query", query: "alpha" } }),
     );
     const hitPayload = textPayload(hits);
     expect(hitPayload["available"]).toBe(true);
@@ -378,7 +378,7 @@ describe("oms_search read-only guarantee", () => {
     // Build the index through the write surface that is allowed to create it.
     await withClient(vault, async (client) => {
       await client.callTool({
-        name: "oms_doctor",
+        name: "doctor",
         arguments: { op: "sync-embeddings", embed: false },
       });
     });
@@ -390,11 +390,11 @@ describe("oms_search read-only guarantee", () => {
 
     const hits = await withClient(vault, async (client) => {
       for (const { args } of advertisedSearchOperations()) {
-        await client.callTool({ name: "oms_search", arguments: args });
+        await client.callTool({ name: "search", arguments: args });
       }
       return textPayload(
         await client.callTool({
-          name: "oms_search",
+          name: "search",
           arguments: { op: "query", query: "alpha" },
         }),
       );

--- a/src/mcp/semantic-server.test.ts
+++ b/src/mcp/semantic-server.test.ts
@@ -55,12 +55,12 @@ describe("Oh My Second Brain MCP semantic stdio server", () => {
     try {
       await client.connect(transport);
       await client.callTool({
-        name: "oms_doctor",
+        name: "doctor",
         arguments: { op: "sync-embeddings", embed: false },
       });
       const retrieve = textPayload(
         await client.callTool({
-          name: "oms_search",
+          name: "search",
           arguments: { op: "context",
             property: "tags",
             value: "agent-graph",
@@ -88,11 +88,11 @@ describe("Oh My Second Brain MCP semantic stdio server", () => {
       const docid = "references/Agent Retrieval.md";
 
       const syncRaw = await client.callTool({
-        name: "oms_doctor",
+        name: "doctor",
         arguments: { op: "sync-embeddings", collection: "obsidian", ensureCollection: true, force: true, index: "brain" },
       });
       const queryCall = {
-        name: "oms_search",
+        name: "search",
         arguments: { op: "query", query: "intent: qmd compatible MCP search\nlex: agent retr", collection: "obsidian", limit: 1 },
       };
       if (hasModel) {
@@ -134,7 +134,7 @@ describe("Oh My Second Brain MCP semantic stdio server", () => {
         // default for callers who did not choose a strategy, never a substitute
         // for one that was asked for and cannot run.
         const explicitVec = await client.callTool({
-          name: "oms_search",
+          name: "search",
           arguments: {
             op: "query",
             searches: [{ type: "vec", query: "agent retrieval" }],
@@ -153,7 +153,7 @@ describe("Oh My Second Brain MCP semantic stdio server", () => {
 
         const lexOnlyQuery = textPayload(
           await client.callTool({
-            name: "oms_search",
+            name: "search",
             arguments: { op: "query", query: "", lex: "agent retrieval", collection: "obsidian", limit: 1 },
           }),
         );
@@ -166,13 +166,13 @@ describe("Oh My Second Brain MCP semantic stdio server", () => {
 
       const single = textPayload(
         await client.callTool({
-          name: "oms_search",
+          name: "search",
           arguments: { op: "get-document", target: `${docid}:1:20`, collection: "obsidian", fullPath: true },
         }),
       );
       const batch = textPayload(
         await client.callTool({
-          name: "oms_search",
+          name: "search",
           arguments: { op: "multi-get-documents", targets: ["references/*.md", docid], lineLimit: 40, maxBytes: 2048 },
         }),
       );

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -124,7 +124,7 @@ function textPayload(result: Awaited<ReturnType<Client["callTool"]>>): Record<st
 
 describe("Oh My Second Brain MCP stdio server", () => {
   it("advertises query defaults that match the SearchBackend contract", () => {
-    const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+    const search = omsMcpTools.find((tool) => tool.name === "search");
     const schema = search?.inputSchema as {
       readonly oneOf?: readonly {
         readonly properties?: Record<string, { readonly const?: string; readonly default?: unknown }>;
@@ -148,7 +148,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
 
   it("keeps query budget schemas aligned with the runtime contract", () => {
     const validator = new AjvJsonSchemaValidator();
-    const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+    const search = omsMcpTools.find((tool) => tool.name === "search");
     const validate = validator.getValidator(search!.inputSchema);
 
     expect(validate({ op: "query", query: "architecture", limit: 0, candidateLimit: 1 }).valid).toBe(true);
@@ -194,7 +194,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
     try {
       await client.connect(transport);
       for (const op of ["semantic-query", "axis"]) {
-        const result = await client.callTool({ name: "oms_search", arguments: { op, query: "architecture" } });
+        const result = await client.callTool({ name: "search", arguments: { op, query: "architecture" } });
         expect(result.isError, op).toBe(true);
         const message = result.content[0]?.type === "text" ? result.content[0].text : "";
         expect(message).toContain(`Unknown operation "${op}"`);
@@ -215,7 +215,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
     const client = new Client({ name: "oms-index-guidance-test", version: "0.0.0" });
     try {
       await client.connect(transport);
-      const result = await client.callTool({ name: "oms_search", arguments: { op: "collections" } });
+      const result = await client.callTool({ name: "search", arguments: { op: "collections" } });
       const payload = textPayload(result);
       expect(payload.available).toBe(false);
       const message = typeof payload.reason === "string" ? payload.reason : "";
@@ -265,7 +265,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
 
   it("advertises containsAll and between field predicates with strict tuple shapes", () => {
     const validator = new AjvJsonSchemaValidator();
-    const search = omsMcpTools.find((tool) => tool.name === "oms_search");
+    const search = omsMcpTools.find((tool) => tool.name === "search");
     const schema = search?.inputSchema;
     const validate = validator.getValidator(schema!);
 
@@ -299,8 +299,8 @@ describe("Oh My Second Brain MCP stdio server", () => {
   it("advertises the complete write payload and zero-argument status contract", () => {
     const validator = new AjvJsonSchemaValidator();
     const toolByName = new Map(omsMcpTools.map((tool) => [tool.name, tool]));
-    const write = validator.getValidator(toolByName.get("oms_write")!.inputSchema);
-    const status = validator.getValidator(toolByName.get("oms_status")!.inputSchema);
+    const write = validator.getValidator(toolByName.get("write")!.inputSchema);
+    const status = validator.getValidator(toolByName.get("status")!.inputSchema);
 
     expect(write({
       op: "note",
@@ -322,16 +322,16 @@ describe("Oh My Second Brain MCP stdio server", () => {
     expect(write({ op: "note", mode: "update", notePath: "notes/x.md" }).valid).toBe(false);
     expect(write({ op: "note", mode: "update", notePath: "notes/x.md", frontmatter: { title: "x" } }).valid).toBe(true);
     expect(write({ op: "note", templateId: "literature", mode: "create", folder: "references" }).valid).toBe(false);
-    expect(JSON.stringify(toolByName.get("oms_search")!.inputSchema)).not.toContain("concept");
+    expect(JSON.stringify(toolByName.get("search")!.inputSchema)).not.toContain("concept");
   });
 
   it("requires an op for routed tools", () => {
     const normalOperations = [
-      ["oms_write", "note", "write-note"],
-      ["oms_search", "query", "oms_semantic_query"],
-      ["oms_link", "suggest", "oms_link_suggest"],
-      ["oms_status", undefined, "oms_graph_status"],
-      ["oms_doctor", "audit", "oms_vault_audit"],
+      ["write", "note", "write-note"],
+      ["search", "query", "oms_semantic_query"],
+      ["link", "suggest", "oms_link_suggest"],
+      ["status", undefined, "oms_graph_status"],
+      ["doctor", "audit", "oms_vault_audit"],
     ] as const;
     const schemas = new Map(omsMcpTools.map((tool) => [tool.name, tool.inputSchema as {
       readonly required?: readonly string[];
@@ -339,7 +339,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
     }]));
 
     for (const [tool, op] of normalOperations) {
-      if (tool === "oms_status") {
+      if (tool === "status") {
         expect(schemas.get(tool)?.required).not.toContain("op");
       } else {
         expect(op).toBeDefined();
@@ -350,11 +350,11 @@ describe("Oh My Second Brain MCP stdio server", () => {
 
   it("registers only the five public tools and retires detail aliases", () => {
     expect(omsMcpTools.map((tool) => tool.name)).toEqual([
-      "oms_write",
-      "oms_search",
-      "oms_link",
-      "oms_status",
-      "oms_doctor",
+      "write",
+      "search",
+      "link",
+      "status",
+      "doctor",
     ]);
     expect(omsMcpTools.map((tool) => tool.name)).not.toEqual(
       expect.arrayContaining([
@@ -386,7 +386,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
     const client = new Client({ name: "oms-test-client", version: "0.0.0" });
     try {
       await client.connect(transport);
-      const result = await client.callTool({ name: "oms_search", arguments: arguments_ });
+      const result = await client.callTool({ name: "search", arguments: arguments_ });
       expect(result.isError).toBe(true);
       const message = result.content[0]?.type === "text" ? result.content[0].text : "";
       expect(message).toContain("OMS_EMBEDDING_PROVIDER");
@@ -408,7 +408,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
     try {
       await client.connect(transport);
       const result = await client.callTool({
-        name: "oms_search",
+        name: "search",
         arguments: {
           op: "query",
           searches: [{ type: "lex", query: "architecture" }],
@@ -473,6 +473,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
 
       const tools = await client.listTools();
       const names = tools.tools.map((tool) => tool.name);
+      expect(names).toEqual(["write", "search", "link", "status", "doctor"]);
       expect(names).toEqual(harnessSurfaceRegistry.mcpTools.map((tool) => tool.name));
       for (const registryTool of harnessSurfaceRegistry.mcpTools) {
         const tool = tools.tools.find((candidate) => candidate.name === registryTool.name);
@@ -482,7 +483,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
         expect(tool?.annotations?.idempotentHint).toBe(registryTool.idempotent);
         expect(tool?.annotations?.openWorldHint).toBe(registryTool.openWorld);
       }
-      const retrieveTool = tools.tools.find((tool) => tool.name === "oms_search");
+      const retrieveTool = tools.tools.find((tool) => tool.name === "search");
       expect(JSON.stringify(retrieveTool?.inputSchema)).toContain("semanticMinScore");
       // storage/modelPath knobs were removed from the schemas (engine uses explicit env config).
       expect(JSON.stringify(retrieveTool?.inputSchema)).not.toContain("semanticStorage");
@@ -493,14 +494,14 @@ describe("Oh My Second Brain MCP stdio server", () => {
       expect(JSON.stringify(retrieveTool?.inputSchema)).toContain("get-document");
       expect(JSON.stringify(retrieveTool?.inputSchema)).not.toContain("modelPath");
       expect(JSON.stringify(retrieveTool?.inputSchema)).not.toContain("concept");
-      const doctorTool = tools.tools.find((tool) => tool.name === "oms_doctor");
+      const doctorTool = tools.tools.find((tool) => tool.name === "doctor");
       expect(doctorTool?.annotations?.readOnlyHint).toBe(false);
       expect(JSON.stringify(doctorTool?.inputSchema)).toContain("audit");
 
-      const status = await client.callTool({ name: "oms_status", arguments: {} });
+      const status = await client.callTool({ name: "status", arguments: {} });
       const parsedStatus = textPayload(status);
-      expect(parsedStatus.writeTools).toBe("oms_write-disabled-invalid-template-projection");
-      const writeTool = tools.tools.find((tool) => tool.name === "oms_write");
+      expect(parsedStatus.writeTools).toBe("write-disabled-invalid-template-projection");
+      const writeTool = tools.tools.find((tool) => tool.name === "write");
       expect(writeTool?.annotations?.readOnlyHint).toBe(false);
       expect(JSON.stringify(writeTool?.inputSchema)).toContain("update");
       expect(parsedStatus.counts).toBeNull();
@@ -509,19 +510,19 @@ describe("Oh My Second Brain MCP stdio server", () => {
       expect(derivedState.status).toBe("invalid");
 
       const templateDiagnosis = textPayload(await client.callTool({
-        name: "oms_doctor",
+        name: "doctor",
         arguments: { op: "validate" },
       }));
       expect(templateDiagnosis.status).toBe("needs-repair");
       const audit = await client.callTool({
-        name: "oms_doctor",
+        name: "doctor",
         arguments: { op: "audit", folder: "references" },
       });
       const parsedAudit = textPayload(audit);
       expect(parsedAudit.clean).toBe(false);
       expect(parsedAudit.scannedNotes).toBe(0);
       const nonStringFolderAudit = await client.callTool({
-        name: "oms_doctor",
+        name: "doctor",
         arguments: { op: "audit", folder: 123 },
       });
       expect(nonStringFolderAudit.isError).toBe(true);
@@ -530,7 +531,7 @@ describe("Oh My Second Brain MCP stdio server", () => {
       );
 
       const missingVaultFolderAudit = textPayload(await client.callTool({
-        name: "oms_doctor",
+        name: "doctor",
         arguments: { op: "audit", folder: "inbox" },
       }));
       expect(missingVaultFolderAudit).toMatchObject({ clean: false, scannedNotes: 0 });
@@ -591,7 +592,7 @@ Valid frontmatter remains available to retrieve.
 
       const result = textPayload(
         await client.callTool({
-          name: "oms_search",
+          name: "search",
           arguments: { op: "context",
             template: "literature",
             query: "agent retrieval graph",
@@ -633,12 +634,12 @@ Valid frontmatter remains available to retrieve.
     try {
       await client.connect(transport);
 
-      const status = textPayload(await client.callTool({ name: "oms_status", arguments: {} }));
+      const status = textPayload(await client.callTool({ name: "status", arguments: {} }));
       expect(status.projectionSource).toBe("vault-invalid");
-      expect(status.writeTools).toBe("oms_write-disabled-invalid-template-projection");
+      expect(status.writeTools).toBe("write-disabled-invalid-template-projection");
 
       const write = await client.callTool({
-        name: "oms_write",
+        name: "write",
         arguments: {
           notePath: "references/unsafe.md",
           frontmatter: {
@@ -674,11 +675,11 @@ Valid frontmatter remains available to retrieve.
 
     try {
       await client.connect(transport);
-      expect(textPayload(await client.callTool({ name: "oms_status", arguments: {} })).projectionSource).toBe("vault-invalid");
+      expect(textPayload(await client.callTool({ name: "status", arguments: {} })).projectionSource).toBe("vault-invalid");
 
-      await client.callTool({ name: "oms_doctor", arguments: { op: "build-graph",} });
+      await client.callTool({ name: "doctor", arguments: { op: "build-graph",} });
 
-      expect(textPayload(await client.callTool({ name: "oms_status", arguments: {} })).projectionSource).toBe("vault-invalid");
+      expect(textPayload(await client.callTool({ name: "status", arguments: {} })).projectionSource).toBe("vault-invalid");
     } finally {
       await client.close();
       await rm(tmpVault, { recursive: true, force: true });
@@ -701,12 +702,12 @@ Valid frontmatter remains available to retrieve.
     try {
       await client.connect(transport);
 
-      const status = textPayload(await client.callTool({ name: "oms_status", arguments: {} }));
+      const status = textPayload(await client.callTool({ name: "status", arguments: {} }));
       expect(status.projectionSource).toBe("vault-invalid");
-      expect(status.writeTools).toBe("oms_write-disabled-invalid-template-projection");
+      expect(status.writeTools).toBe("write-disabled-invalid-template-projection");
 
       const write = await client.callTool({
-        name: "oms_write",
+        name: "write",
         arguments: {
           notePath: "references/unsafe.md",
           frontmatter: {
@@ -745,7 +746,7 @@ Valid frontmatter remains available to retrieve.
       // concept implied by one form and the folder implied by the other, which
       // reads as corruption rather than as the input error it is.
       const raw = await client.callTool({
-        name: "oms_write",
+        name: "write",
         arguments: {
           op: "note",
           mode: "create",
@@ -783,7 +784,7 @@ Valid frontmatter remains available to retrieve.
 
       const asked = textPayload(
         await client.callTool({
-          name: "oms_write",
+          name: "write",
           arguments: {
             op: "note",
             mode: "create",
@@ -798,7 +799,7 @@ Valid frontmatter remains available to retrieve.
 
       const created = textPayload(
         await client.callTool({
-          name: "oms_write",
+          name: "write",
           arguments: {
             op: "note",
             mode: "create",
@@ -828,7 +829,7 @@ Valid frontmatter remains available to retrieve.
 
       const broken = textPayload(
         await client.callTool({
-          name: "oms_write",
+          name: "write",
           arguments: {
             op: "note",
             mode: "update",
@@ -884,7 +885,7 @@ Valid frontmatter remains available to retrieve.
 
       // When: link suggestions are requested for the mentioning note
       const suggested = textPayload(
-        await client.callTool({ name: "oms_link", arguments: { op: "suggest", notePath } }),
+        await client.callTool({ name: "link", arguments: { op: "suggest", notePath } }),
       );
 
       // Then: both term notes are proposed, first-occurrence only, with a hash
@@ -906,7 +907,7 @@ Valid frontmatter remains available to retrieve.
       const beforeApply = await readFile(noteFile, "utf-8");
       const stale = textPayload(
         await client.callTool({
-          name: "oms_link",
+          name: "link",
           arguments: { op: "apply",
             notePath,
             baseContentHash: "0".repeat(64),
@@ -923,7 +924,7 @@ Valid frontmatter remains available to retrieve.
       // When: apply runs with the hash the suggestions were computed against
       const applied = textPayload(
         await client.callTool({
-          name: "oms_link",
+          name: "link",
           arguments: { op: "apply",
             notePath,
             baseContentHash: suggested.baseContentHash,
@@ -944,7 +945,7 @@ Valid frontmatter remains available to retrieve.
       // When: the same (now stale) hash is replayed
       const replayed = textPayload(
         await client.callTool({
-          name: "oms_link",
+          name: "link",
           arguments: { op: "apply",
             notePath,
             baseContentHash: suggested.baseContentHash,
@@ -982,14 +983,14 @@ Valid frontmatter remains available to retrieve.
       await client.connect(transport);
 
       // When: notePath is omitted
-      const missing = await client.callTool({ name: "oms_link", arguments: { op: "suggest",} });
+      const missing = await client.callTool({ name: "link", arguments: { op: "suggest",} });
       // Then: the tool reports a typed argument error
       expect(missing.isError).toBe(true);
       expect(missing.content[0]?.type === "text" ? missing.content[0].text : "").toContain("notePath");
 
       // When: the note does not exist
       const absent = await client.callTool({
-        name: "oms_link",
+        name: "link",
         arguments: { op: "suggest", notePath: "notes/does-not-exist.md" },
       });
       // Then: the tool errors instead of inventing an empty suggestion set
@@ -997,7 +998,7 @@ Valid frontmatter remains available to retrieve.
 
       // When: apply omits the base hash
       const noHash = await client.callTool({
-        name: "oms_link",
+        name: "link",
         arguments: { op: "apply", notePath: "notes/sage.md", candidateIds: [] },
       });
       // Then: the tool refuses before any write
@@ -1029,12 +1030,12 @@ Valid frontmatter remains available to retrieve.
     try {
       await client.connect(transport);
 
-      const status = textPayload(await client.callTool({ name: "oms_status", arguments: {} }));
-      expect(status.writeTools).toBe("oms_write-disabled-target-unverified");
+      const status = textPayload(await client.callTool({ name: "status", arguments: {} }));
+      expect(status.writeTools).toBe("write-disabled-target-unverified");
 
       const write = textPayload(
         await client.callTool({
-          name: "oms_write",
+          name: "write",
           arguments: {
             op: "note",
             mode: "create",
@@ -1057,7 +1058,7 @@ Valid frontmatter remains available to retrieve.
       expect(write.resolvedVault).toBe(tmpCwd);
       expect(write.resolutionSource).toBe("cwd");
 
-      const linkApply = textPayload(await client.callTool({ name: "oms_link", arguments: { op: "apply", notePath: "notes/misrouted.md", baseContentHash: "0".repeat(64), candidateIds: [] } }));
+      const linkApply = textPayload(await client.callTool({ name: "link", arguments: { op: "apply", notePath: "notes/misrouted.md", baseContentHash: "0".repeat(64), candidateIds: [] } }));
       expect(linkApply).toMatchObject({ applied: false, reason: "write-rejected", write: { rejection: { code: "target-unverified" } } });
       expect(await readdir(tmpCwd)).toEqual([]);
     } finally {
@@ -1085,7 +1086,7 @@ Valid frontmatter remains available to retrieve.
       await client.connect(transport);
 
       for (const op of ["build-graph", "cleanup", "sync-embeddings"]) {
-        const repair = textPayload(await client.callTool({ name: "oms_doctor", arguments: { op } }));
+        const repair = textPayload(await client.callTool({ name: "doctor", arguments: { op } }));
         expect(repair).toMatchObject({
           status: "rejected",
           rejection: {
@@ -1099,10 +1100,10 @@ Valid frontmatter remains available to retrieve.
         expect(repair.receipt).toBeUndefined();
       }
 
-      const audit = textPayload(await client.callTool({ name: "oms_doctor", arguments: { op: "audit" } }));
+      const audit = textPayload(await client.callTool({ name: "doctor", arguments: { op: "audit" } }));
       expect(audit).toMatchObject({ vault: tmpCwd, projectionSource: "vault-invalid", clean: false });
       const templateDiagnosis = textPayload(
-        await client.callTool({ name: "oms_doctor", arguments: { op: "validate" } }),
+        await client.callTool({ name: "doctor", arguments: { op: "validate" } }),
       );
       expect(templateDiagnosis.status).toBe("needs-repair");
       expect(await readdir(tmpCwd)).toEqual(["notes"]);
@@ -1130,7 +1131,7 @@ Valid frontmatter remains available to retrieve.
     try {
       await client.connect(transport);
       const repair = textPayload(
-        await client.callTool({ name: "oms_doctor", arguments: { op: "build-graph" } }),
+        await client.callTool({ name: "doctor", arguments: { op: "build-graph" } }),
       );
       const receipt = repair.receipt as Record<string, unknown>;
       const postcondition = receipt.postcondition as Record<string, unknown>;
@@ -1172,7 +1173,7 @@ Valid frontmatter remains available to retrieve.
 
     try {
       await client.connect(transport);
-      const result = textPayload(await client.callTool({ name: "oms_doctor", arguments: { op: "build-graph" } }));
+      const result = textPayload(await client.callTool({ name: "doctor", arguments: { op: "build-graph" } }));
       expect(result.edges).toBe(0);
       expect(result.warnings).toEqual([
         'Skipped type-affinity edges for template "literature": 65 notes exceeds the 64-note limit.',
@@ -1200,7 +1201,7 @@ Valid frontmatter remains available to retrieve.
     try {
       await client.connect(transport);
       const repair = textPayload(
-        await client.callTool({ name: "oms_doctor", arguments: { op: "sync-embeddings", embed: false } }),
+        await client.callTool({ name: "doctor", arguments: { op: "sync-embeddings", embed: false } }),
       );
       const receipt = repair.receipt as Record<string, unknown>;
       const postcondition = receipt.postcondition as Record<string, unknown>;
@@ -1247,11 +1248,11 @@ Valid frontmatter remains available to retrieve.
     try {
       await client.connect(transport);
       textPayload(
-        await client.callTool({ name: "oms_doctor", arguments: { op: "sync-embeddings", embed: false } }),
+        await client.callTool({ name: "doctor", arguments: { op: "sync-embeddings", embed: false } }),
       );
       await rm(path.join(tmpVault, "removed.md"));
       const repair = textPayload(
-        await client.callTool({ name: "oms_doctor", arguments: { op: "cleanup" } }),
+        await client.callTool({ name: "doctor", arguments: { op: "cleanup" } }),
       );
       const receipt = repair.receipt as Record<string, unknown>;
       const postcondition = receipt.postcondition as Record<string, unknown>;
@@ -1299,12 +1300,12 @@ Valid frontmatter remains available to retrieve.
     try {
       await client.connect(transport);
 
-      const status = textPayload(await client.callTool({ name: "oms_status", arguments: {} }));
-      expect(status.writeTools).toBe("oms_write-gated-by-verified-target-and-contract");
+      const status = textPayload(await client.callTool({ name: "status", arguments: {} }));
+      expect(status.writeTools).toBe("write-gated-by-verified-target-and-contract");
 
       const created = textPayload(
         await client.callTool({
-          name: "oms_write",
+          name: "write",
           arguments: {
             op: "note",
             mode: "create",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -56,7 +56,7 @@ import {
 const SERVER_VERSION = readBundledPackageVersion();
 
 export const BASE_SERVER_INSTRUCTIONS =
-  "Oh My Second Brain exposes write, search, link, status, and doctor tools. oms_write and doctor repair operations are gated by a verified vault target (a vault inferred from the current directory is refused); oms_write also enforces vault confinement and contract validation.";
+  "Oh My Second Brain exposes write, search, link, status, and doctor tools. write and doctor repair operations are gated by a verified vault target (a vault inferred from the current directory is refused); write also enforces vault confinement and contract validation.";
 
 function jsonText(value: unknown): CallToolResult {
   return {
@@ -150,14 +150,14 @@ const templateBinding = { type: "object", additionalProperties: false, propertie
 const source = { type: "object", additionalProperties: false, properties: { path: string, content: string, publication: { ...string, enum: ["write", "verify-existing"] } }, required: ["path", "content", "publication"] };
 const expected = { expectedInputDigest: digestSchema, expectedPolicySignature: digestSchema, expectedTaxonomySignature: digestSchema, expectedProjectionSignature: digestSchema, expectedSourceSignatures: { type: "array", items: { type: "object", additionalProperties: false, properties: { templateId: string, path: string, signature: digestSchema }, required: ["templateId", "path", "signature"] } } };
 const operations: Record<string, readonly Operation[]> = {
-  oms_write: [
+  write: [
     { op: "note", name: "write-note", properties: { mode: { ...string, enum: ["create", "append", "update"] }, templateId: string, notePath: string, frontmatter, body: string, dryRun: boolean } },
     { op: "template", name: "write-template", properties: { mode: { ...string, enum: ["create", "update", "reclassify", "relocate-folder"] }, templateId: string, binding: templateBinding, source, moveStrategy: { ...string, enum: ["oms-managed-rename", "register-already-moved"] }, toClass: { ...string, enum: ["managed-default", "registered-existing"] }, templateFolder: string, ...expected, dryRun: boolean, approvedDigest: digestSchema }, required: ["mode", "expectedInputDigest", "expectedPolicySignature", "expectedTaxonomySignature", "expectedProjectionSignature", "expectedSourceSignatures"] },
   ],
-  oms_search: [{ op: "context", name: "oms_retrieve_context", properties: contextProperties }, { op: "lazy-load", name: "oms_lazy_load_note", properties: { notePath: string }, required: ["notePath"] }, { op: "templates", name: "oms_list_templates" }, { op: "query", name: "oms_semantic_query", properties: searchProperties }, { op: "collections", name: "oms_semantic_collections", properties: { index: string } }, { op: "contexts", name: "oms_semantic_contexts", properties: { index: string } }, { op: "status", name: "oms_semantic_status", properties: { index: string } }, { op: "get-document", name: "oms_get_document", properties: searchProperties, required: ["target"] }, { op: "multi-get-documents", name: "oms_multi_get_documents", properties: searchProperties }],
-  oms_link: [{ op: "suggest", name: "oms_link_suggest", properties: { notePath: string, folder: string }, required: ["notePath"] }, { op: "apply", name: "oms_link_apply", properties: { notePath: string, folder: string, baseContentHash: string, candidateIds: stringArray }, required: ["notePath", "baseContentHash", "candidateIds"] }],
-  oms_status: [{ name: "oms_graph_status", direct: true }],
-  oms_doctor: [{ op: "audit", name: "oms_vault_audit", properties: { folder: string } }, { op: "validate", name: "oms_validate_templates" }, { op: "regenerate-types", name: "oms_regenerate_types", properties: { dryRun: boolean, approvedDigest: digestSchema } }, { op: "backfill-defaults", name: "oms_backfill_defaults", properties: { notePath: string, dryRun: boolean, approvedDigest: digestSchema }, required: ["notePath"] }, { op: "build-graph", name: "oms_graph_build" }, { op: "cleanup", name: "oms_semantic_cleanup", properties: { collection: string, index: string } }, { op: "sync-embeddings", name: "oms_sync_embeddings", properties: { collection: string, ensureCollection: boolean, update: boolean, embed: boolean, force: boolean, pull: boolean, index: string, chunkStrategy: string, maxDocsPerBatch: number, maxBatchMb: number } }],
+  search: [{ op: "context", name: "oms_retrieve_context", properties: contextProperties }, { op: "lazy-load", name: "oms_lazy_load_note", properties: { notePath: string }, required: ["notePath"] }, { op: "templates", name: "oms_list_templates" }, { op: "query", name: "oms_semantic_query", properties: searchProperties }, { op: "collections", name: "oms_semantic_collections", properties: { index: string } }, { op: "contexts", name: "oms_semantic_contexts", properties: { index: string } }, { op: "status", name: "oms_semantic_status", properties: { index: string } }, { op: "get-document", name: "oms_get_document", properties: searchProperties, required: ["target"] }, { op: "multi-get-documents", name: "oms_multi_get_documents", properties: searchProperties }],
+  link: [{ op: "suggest", name: "oms_link_suggest", properties: { notePath: string, folder: string }, required: ["notePath"] }, { op: "apply", name: "oms_link_apply", properties: { notePath: string, folder: string, baseContentHash: string, candidateIds: stringArray }, required: ["notePath", "baseContentHash", "candidateIds"] }],
+  status: [{ name: "oms_graph_status", direct: true }],
+  doctor: [{ op: "audit", name: "oms_vault_audit", properties: { folder: string } }, { op: "validate", name: "oms_validate_templates" }, { op: "regenerate-types", name: "oms_regenerate_types", properties: { dryRun: boolean, approvedDigest: digestSchema } }, { op: "backfill-defaults", name: "oms_backfill_defaults", properties: { notePath: string, dryRun: boolean, approvedDigest: digestSchema }, required: ["notePath"] }, { op: "build-graph", name: "oms_graph_build" }, { op: "cleanup", name: "oms_semantic_cleanup", properties: { collection: string, index: string } }, { op: "sync-embeddings", name: "oms_sync_embeddings", properties: { collection: string, ensureCollection: boolean, update: boolean, embed: boolean, force: boolean, pull: boolean, index: string, chunkStrategy: string, maxDocsPerBatch: number, maxBatchMb: number } }],
 };
 interface SchemaBranch {
   readonly additionalProperties: false;
@@ -258,38 +258,38 @@ function unknownOperationMessage(tool: string, op: string | undefined): string {
 
 export const omsMcpTools: Tool[] = [
   {
-    name: "oms_write",
+    name: "write",
     title: "Oh My Second Brain write",
     description: "Write template-resolved vault notes and guarded template changes.",
-    inputSchema: operationSchema("oms_write"),
+    inputSchema: operationSchema("write"),
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
   },
   {
-    name: "oms_search",
+    name: "search",
     title: "Oh My Second Brain search",
     description: "Retrieve vault context, template metadata, semantic search, and selected documents. `op` selects the operation.",
-    inputSchema: operationSchema("oms_search"),
+    inputSchema: operationSchema("search"),
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: false },
   },
   {
-    name: "oms_link",
+    name: "link",
     title: "Oh My Second Brain link",
     description: "Suggest or apply wikilinks; `op` selects the operation.",
-    inputSchema: operationSchema("oms_link"),
+    inputSchema: operationSchema("link"),
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
   },
   {
-    name: "oms_status",
+    name: "status",
     title: "Oh My Second Brain status",
     description: "Read-only health and statistics for the active vault.",
-    inputSchema: operationSchema("oms_status"),
+    inputSchema: operationSchema("status"),
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   },
   {
-    name: "oms_doctor",
+    name: "doctor",
     title: "Oh My Second Brain doctor",
     description: "Diagnose or repair the vault; `op` selects the operation.",
-    inputSchema: operationSchema("oms_doctor"),
+    inputSchema: operationSchema("doctor"),
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
   },
 ];
@@ -401,7 +401,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       ? getReadOnlySemanticEngine()?.adapter ?? engine.adapter
       : getReadOnlyCoreSemanticEngine()?.adapter ?? engine.adapter;
   const resolveDocumentAdapter = (publicName: string): McpEngineAdapter => {
-    if (publicName === "oms_search") return resolveReadOnlyDocumentAdapter();
+    if (publicName === "search") return resolveReadOnlyDocumentAdapter();
     return resolveCreatingDocumentAdapter();
   };
   const resolveReadOnlyIndexAdapter = (): McpEngineAdapter => {
@@ -482,7 +482,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
     const op = stringArg(args, "op");
     const name = resolveOperation(publicName, op);
     if (!name) return errorText(unknownOperationMessage(publicName, op));
-    if (publicName === "oms_search" && op === "query") {
+    if (publicName === "search" && op === "query") {
       const searches = args?.["searches"];
       if (typeof args?.["query"] === "string" && Array.isArray(searches)) {
         return errorText('Provide exactly one of "query" or "searches" for query.');
@@ -505,7 +505,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
           managedSourcePaths: convention.managedSourcePaths,
           derivedState: diagnosis,
           engineGraph,
-          writeTools: source === "cwd" ? "oms_write-disabled-target-unverified" : "oms_write-gated-by-verified-target-and-contract",
+          writeTools: source === "cwd" ? "write-disabled-target-unverified" : "write-gated-by-verified-target-and-contract",
           readTools: omsMcpTools.map(tool => tool.name),
         });
       } catch (error) {
@@ -515,10 +515,10 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
           sourceOfTruth: ["actual Obsidian templates", ".obsidian/types.json", ".oms/template-policy.json", ".oms/types.json"],
           error: error instanceof Error ? error.message : String(error),
           counts: null,
-          derivedState: { status: "invalid", remediation: "run oms_doctor validate, then regenerate-types with an approved digest" },
+          derivedState: { status: "invalid", remediation: "run doctor validate, then regenerate-types with an approved digest" },
           engineGraph,
-          writeTools: source === "cwd" ? "oms_write-disabled-target-unverified" : "oms_write-disabled-invalid-template-projection",
-          readTools: ["oms_status"],
+          writeTools: source === "cwd" ? "write-disabled-target-unverified" : "write-disabled-invalid-template-projection",
+          readTools: ["status"],
         });
       }
     }
@@ -539,7 +539,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       const resolveRepairAdapter = (): McpEngineAdapter =>
         operation === "build-graph"
           ? engine.adapter
-          : publicName === "oms_search"
+          : publicName === "search"
             ? resolveReadOnlyDocumentAdapter()
             : operation === "semantic-cleanup" || (operation === "sync-embeddings" && args?.["embed"] === false)
               ? resolveCreatingDocumentAdapter()
@@ -712,7 +712,7 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
       }
       const useEphemeralLexicalFallback =
         name === "oms_semantic_query" &&
-        publicName === "oms_search" &&
+        publicName === "search" &&
         !hasExplicitEmbeddingIntent(args) &&
         (hasEmbeddingModel()
           ? getReadOnlySemanticEngine() === null
@@ -725,12 +725,12 @@ export function createOMSMcpServer(opts: OMSMcpServerOptions): Server {
         name !== "oms_semantic_cleanup" &&
         !(name === "oms_sync_embeddings" && args?.["embed"] === false) &&
         !isModelOptionalSemanticQueryOp(name, args, vault)
-          ? publicName === "oms_search"
+          ? publicName === "search"
             ? resolveReadOnlyIndexAdapter()
             : getSemanticEngine().adapter
           : isEngineDocumentOp(name)
             ? resolveDocumentAdapter(publicName)
-            : publicName === "oms_search"
+            : publicName === "search"
               ? resolveReadOnlyIndexAdapter()
               : resolveDocumentAdapter(publicName);
       const semanticToolResult = await handleSemanticTool(

--- a/src/mcp/verified-target.test.ts
+++ b/src/mcp/verified-target.test.ts
@@ -83,7 +83,7 @@ describe("Issue #58: Verified-target write kernel", () => {
 
       const write = textPayload(
         await client.callTool({
-          name: "oms_write",
+          name: "write",
           arguments: {
             op: "note",
             mode: "create",
@@ -160,7 +160,7 @@ describe("Issue #58: Verified-target write kernel", () => {
       // Case A: Written response with receipt
       const written = textPayload(
         await client.callTool({
-          name: "oms_write",
+          name: "write",
           arguments: {
             op: "note",
             mode: "create",
@@ -184,7 +184,7 @@ describe("Issue #58: Verified-target write kernel", () => {
       // Case B: Rejected response (ask status - contract violation)
       const rejected = textPayload(
         await client.callTool({
-          name: "oms_write",
+          name: "write",
           arguments: {
             op: "note",
             mode: "create",

--- a/test/architecture/readme-parity.test.ts
+++ b/test/architecture/readme-parity.test.ts
@@ -67,9 +67,10 @@ function cliCommands(text: string): string[] {
   return matches(text, /^oms [a-z-]+/gmu);
 }
 
-/** `oms_*` tool identifiers. */
+/** Capability-only MCP tool identifiers listed in the MCP surface line. */
 function toolNames(text: string): string[] {
-  return matches(text, /oms_[a-z_]+/gu);
+  const surfaceLine = text.split("\n").find((line) => line.includes("·"));
+  return surfaceLine === undefined ? [] : matches(surfaceLine, /(?:write|search|link|status|doctor)/gu);
 }
 
 /** `OMS_*` environment variable identifiers. */
@@ -83,7 +84,7 @@ function advertisedTools(serverSource: string): string[] {
   if (start === -1) throw new Error(`${MCP_SERVER} no longer declares omsMcpTools; update readme-parity.test.ts`);
   const end = serverSource.indexOf("\n];", start);
   if (end === -1) throw new Error(`${MCP_SERVER} omsMcpTools array is unterminated`);
-  return matches(serverSource.slice(start, end), /name: "(oms_[a-z_]+)"/gu).map((entry) =>
+  return matches(serverSource.slice(start, end), /name: "([a-z_]+)"/gu).map((entry) =>
     entry.replace(/^name: "|"$/gu, ""),
   );
 }

--- a/test/architecture/surface-parity.test.ts
+++ b/test/architecture/surface-parity.test.ts
@@ -129,6 +129,15 @@ export function checkSurfaceSets(sets: SurfaceSets, expected: { skills: number; 
     violations.push({ rule: "mcp-tools-populated", detail: "MCP tool registry is empty" });
   }
 
+  for (const tool of sets.mcpTools) {
+    if (tool.startsWith("oms_")) {
+      violations.push({ rule: "mcp-tool-local-name", detail: `MCP tool ${tool} must not repeat the oms server namespace` });
+    }
+    if (`oms_${tool}`.startsWith("oms_oms_")) {
+      violations.push({ rule: "mcp-tool-qualified-name", detail: `Qualified MCP tool oms_${tool} has a doubled oms namespace` });
+    }
+  }
+
   if (sets.cliCommands.length === 0) {
     violations.push({ rule: "cli-allowlist-populated", detail: "CLI command allowlist is empty" });
   }
@@ -155,6 +164,7 @@ export function checkSurfaceSets(sets: SurfaceSets, expected: { skills: number; 
 }
 
 const TARGET = { skills: 7, tools: 5 } as const;
+const MCP_SERVER_ID = "oms";
 
 const CLEAN: SurfaceSets = {
   skills: ["write", "search", "link", "distill", "status", "doctor", "template"],
@@ -217,6 +227,15 @@ describe("surface-set parity gate (rules)", () => {
       TARGET,
     );
     expect(violations.map((v) => v.rule)).toContain("tools-subset-of-skills");
+  });
+
+  it("fails when a local tool repeats the server namespace", () => {
+    const violations = checkSurfaceSets(
+      { ...CLEAN, mcpTools: ["oms_write", "search", "link", "status", "doctor"] },
+      TARGET,
+    );
+    expect(violations.map((v) => v.rule)).toContain("mcp-tool-local-name");
+    expect(violations.map((v) => v.rule)).toContain("mcp-tool-qualified-name");
   });
 
   it("fails when the MCP server registers an extra tool absent from the registry", () => {
@@ -322,7 +341,7 @@ function liveSurfaceSets(skillRoot = path.join(repoRoot, "assets/skills")): Surf
   const mcpTools = harnessSurfaceRegistry.mcpTools.map((tool) => tool.name).sort();
   expect(mcpTools, "MCP tool registry must not be empty").not.toEqual([]);
   expect(mcpTools).toEqual(declaredMcpTools);
-  const searchTool = omsMcpTools.find((tool) => tool.name === "oms_search");
+  const searchTool = omsMcpTools.find((tool) => tool.name === "search");
   const searchOperations = (
     (searchTool?.inputSchema as {
       readonly oneOf?: readonly {
@@ -369,7 +388,7 @@ function liveSurfaceSets(skillRoot = path.join(repoRoot, "assets/skills")): Surf
     minScore: { type: "number", default: 0 },
     cursor: { type: "string" },
   });
-  const doctorTool = omsMcpTools.find((tool) => tool.name === "oms_doctor");
+  const doctorTool = omsMcpTools.find((tool) => tool.name === "doctor");
   const doctorOperations = [...new Set((
     (doctorTool?.inputSchema as {
       readonly oneOf?: readonly {
@@ -561,6 +580,13 @@ describe("current guidance CLI spellings", () => {
 describe("surface-set parity gate (live surface)", () => {
   it("reads the seven disk-authored skills, MCP registry, and CLI dispatcher", () => {
     expect(checkSurfaceSets(liveSurfaceSets(), TARGET)).toEqual([]);
+    expect(harnessSurfaceRegistry.hosts, "supported host registry must not be empty").not.toEqual([]);
+    for (const host of harnessSurfaceRegistry.hosts) {
+      const qualifiedNames = omsMcpTools.map((tool) => `${MCP_SERVER_ID}_${tool.name}`);
+      expect(qualifiedNames, `${host.runtime} must not render a doubled OMS namespace`).not.toEqual(
+        expect.arrayContaining([expect.stringMatching(/^oms_oms_/)]),
+      );
+    }
   });
 
   it("fails when a registry CLI command is renamed without updating the dispatcher", () => {


### PR DESCRIPTION
Closes #107

## What changed
The server is registered under id `oms` **and** its tools were named `oms_write`, `oms_search`, `oms_link`, `oms_status`, `oms_doctor`. Any host that qualifies a tool as `<server>_<tool>` therefore rendered `oms_oms_write` — live Hermes evidence in the issue, internally `mcp__oms__oms_write`.

**Decision:** keep server id `oms`, make MCP-local tool names capability-only.

| surface | before | after |
|---|---|---|
| raw `tools/list` | `oms_write` | `write` |
| Hermes / qualifying hosts | `oms_oms_write` | `oms_write` |
| Claude / Codex | `mcp__oms__oms_write` | `mcp__oms__write` |

Verified against the built server:

```
count: 5
write, search, link, status, doctor
```

## What deliberately did NOT change
The `oms_`-prefixed strings inside the `operations` table (`oms_semantic_query`, `oms_retrieve_context`, `oms_sync_embeddings`, `oms_vault_audit`, `oms_link_suggest`, …) are the **demoted internal operation names** routed behind `op`, not public tool names. They are untouched, so every existing `op` route and the missing/unknown-operation diagnostics from #65 behave identically.

No aliases, no dual registration, no sixth tool — the public surface stays at exactly five capabilities.

## Guard
`test/architecture/surface-parity.test.ts` now fails if any advertised tool name starts with `oms_`, if `<serverId>_<toolName>` would produce a doubled `oms_oms_` prefix on a supported host, or if the advertised count is not five.

## Migration
Raw MCP clients calling the old local names must switch `oms_write` → `write`, `oms_search` → `search`, `oms_link` → `link`, `oms_status` → `status`, `oms_doctor` → `doctor`. Documented in `CHANGELOG-mcp.md` and `CHANGELOG-vendors.md`.

## Verification
- `tsc --noEmit` clean, `tsc` build clean
- Full `vitest run`: 116 files passed, 1425 tests passed, 1 skipped
- `src/mcp/search-read-only.test.ts` still green — it snapshots the whole vault tree around every advertised search operation and demands byte-identical results, so the rename did not make a read path write