### PR TITLE
chore(kernel): drop the dead node:path import from asset health

### DIFF
--- a/src/kernel/install/asset-health.ts
+++ b/src/kernel/install/asset-health.ts
@@ -1,5 +1,4 @@
 import { lstat, readFile, realpath, stat } from "node:fs/promises";
-import path from "node:path";
 import { computeTreeDigest, parseProvenance } from "./provenance.js";
 
 export type InstalledAssetKind = "hook" | "binary" | "skill-tree" | "registration";


### PR DESCRIPTION
Follow-up to #116.

The final AI-slop cleaner lane returned `Gate Result: PASS` with zero blocking findings, but it did raise one **LOW advisory** that I failed to carry into the completion gate's evidence: the host-evidence refactor moved every asset path composition out of `src/kernel/install/asset-health.ts` into the CLI probe, leaving `import path from "node:path"` with no remaining use.

`tsc` does not flag unused imports under the current settings (`noUnusedLocals` is not enabled), so it passed every gate.

Verified: zero `path.` usages in the file; `npm run lint` clean; `asset-health`, `doctor-lint`, and `host-probe` suites green (26 tests).

No changelog entry — this is dead-code removal with no user-facing behavior change.