### PR TITLE
chore: enable noUnusedLocals and remove the dead code it surfaced

### DIFF
--- a/src/kernel/capture/safe.ts
+++ b/src/kernel/capture/safe.ts
@@ -1,4 +1,4 @@
-import { access, appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { stringify as yamlStringify } from "yaml";
 import { parseNote } from "../conventions/frontmatter.js";
@@ -162,7 +162,6 @@ function orderedTemplateFrontmatter(
 }
 
 function renderTemplateBody(template: ResolvedTemplate, content: string, title: string, resolvedAt: string): string {
-  const marker = "<!-- oms:content -->";
   const rendered = renderExpressions(template.body, template, "body", title, resolvedAt);
   if (typeof rendered !== "string") throw new Error("TEMPLATE_SOURCE_INVALID: template body must be a string");
   const standalone = /(^|\r?\n)<!-- oms:content -->(?=\r?\n|$)/g;

--- a/src/kernel/conventions/write-protocol.ts
+++ b/src/kernel/conventions/write-protocol.ts
@@ -14,7 +14,6 @@
  */
 
 import type { VaultSource } from "../link/link.js";
-import type { WriteMode } from "../capture/safe.js";
 
 export type WriteStage = "admission" | "acceptance";
 

--- a/src/kernel/engine/embed/model.ts
+++ b/src/kernel/engine/embed/model.ts
@@ -547,11 +547,6 @@ function isInside(child: string, parent: string): boolean {
   return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }
 
-function filenameFor(descriptor: EmbeddingModelDescriptor): string {
-  const name = descriptor.filename ?? descriptor.model;
-  return path.basename(name) || "model.gguf";
-}
-
 async function writeAtomic(filename: string, contents: Uint8Array | string): Promise<void> {
   const temporary = `${filename}.${process.pid}.${Date.now()}.tmp`;
   try { await writeFile(temporary, contents, { flag: "wx" }); await rename(temporary, filename); } finally { await rm(temporary, { force: true }); }

--- a/src/kernel/engine/graph/builder.ts
+++ b/src/kernel/engine/graph/builder.ts
@@ -183,7 +183,7 @@ export async function buildGraphWithWarnings(opts: { readonly vaultPath: string;
     }
   }
   const pairs = new Map<string, number>();
-  for (const [common, neighbors] of adjacency) {
+  for (const neighbors of adjacency.values()) {
     const score = adamicAdarContribution(neighbors.size);
     if (score === 0) continue;
     const sorted = [...neighbors].sort((left, right) => left.localeCompare(right));

--- a/src/kernel/engine/mcp/facade.ts
+++ b/src/kernel/engine/mcp/facade.ts
@@ -21,7 +21,7 @@
  */
 
 import path from "node:path";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { deriveTemplateRetrievalAxes } from "../../templates/axes.js";
 import { loadResolvedTemplates } from "../../templates/resolver.js";
 import { walkVaultMarkdown } from "../../conventions/vault-walk.js";

--- a/src/kernel/templates/policy.ts
+++ b/src/kernel/templates/policy.ts
@@ -1,8 +1,8 @@
 import type {
   BaseContract, ContractDefinition, DerivedProjection, DerivedTemplateProjection, DestinationClass,
-  Extensions, FieldDefault, FieldPolicy, GlobalAxes, GlobalAxis, JsonValue, ObsidianContractType,
-  RetrievalView, SourceDescriptor, TemplateBinding, TemplateFolderPath, TemplateId, TemplatePolicy,
-  TemplateSourcePath, WriterRegistry,
+  Extensions, FieldDefault, FieldPolicy, GlobalAxis, JsonValue, ObsidianContractType,
+  RetrievalView, SourceDescriptor, TemplateBinding, TemplateFolderPath, TemplatePolicy,
+  WriterRegistry,
 } from "./types.js";
 import {
   deriveManagedSourcePath,

--- a/src/mcp/engine-morning-backend.ts
+++ b/src/mcp/engine-morning-backend.ts
@@ -14,7 +14,7 @@
  */
 
 import type { McpEngineAdapter } from "../kernel/engine/mcp/facade.js";
-import type { MorningRetrieveOptions, MorningSemanticBackend } from "../kernel/search/morning.js";
+import type { MorningSemanticBackend } from "../kernel/search/morning.js";
 
 /**
  * Build a MorningSemanticBackend that routes the five semantic leaf operations

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Follow-up to #116 and #117.

The dead `node:path` import fixed in #117 passed `tsc`, the full suite, and every architecture gate — it was caught only because an AI-slop cleaner lane happened to read the file. That is a detection method that does not scale. `noUnusedLocals` makes it mechanical.

## What surfaced
Ten violations, every one a genuine leftover:

| File | Leftover |
|---|---|
| `src/kernel/capture/safe.ts:1` | unused `access` fs import |
| `src/kernel/capture/safe.ts:165` | unused `marker` local — its value is inlined into the regex below it |
| `src/kernel/conventions/write-protocol.ts:17` | unused `WriteMode` type import |
| `src/kernel/engine/embed/model.ts:550` | orphaned `filenameFor` helper |
| `src/kernel/engine/graph/builder.ts:186` | unused destructured map key → now `adjacency.values()` |
| `src/kernel/engine/mcp/facade.ts:24` | unused `existsSync` import |
| `src/kernel/templates/policy.ts:3-5` | three stale type imports left by the writer-registry work |
| `src/mcp/engine-morning-backend.ts:17` | unused `MorningRetrieveOptions` type import |

Three of them were introduced by this session's own work, which is the point.

## Scope note
`tsconfig.json` excludes `**/*.test.ts`, so this covers `src/` non-test files only. I did **not** enable `noUnusedParameters` — it flags intentionally-unused signature parameters and would need a separate pass with `_`-prefix conventions decided first.

## Verification
- `npx tsc --noEmit`: **0 errors** (was 10 with the flag on)
- `npm run build` clean
- `vitest`: **121 files / 1492 tests passed**, 1 skipped

No changelog entry — no user-facing behavior change.